### PR TITLE
Add #include<complex.h> to the include list

### DIFF
--- a/ffc/formatting.py
+++ b/ffc/formatting.py
@@ -184,10 +184,10 @@ def _generate_includes(includes, parameters):
     # s2 = external_includes - s
     includes_h = "\n".join(sorted(s_h)) + "\n" if s_h else ""
     includes_c = "\n".join(sorted(s_c)) + "\n" if s_c else ""
-    
+
     # This should really be set by the backend
     scalar_type = parameters.get("scalar_type")
     if scalar_type == "double complex":
-      includes_c += "#include <complex.h> \n"
-    
+        includes_c += "#include <complex.h> \n"
+
     return includes_h, includes_c

--- a/ffc/formatting.py
+++ b/ffc/formatting.py
@@ -82,8 +82,9 @@ def format_code(code, wrapper_code, prefix, parameters):
     code_c_pre += format_template["header_c"] % {"prefix": prefix}
 
     # Generate includes and add to preamble
-    includes_h = _generate_includes(includes, parameters)
+    includes_h, includes_c = _generate_includes(includes, parameters)
     code_h_pre += includes_h
+    code_c_pre += includes_c
 
     # Enclose header with 'extern "C"'
     code_h_pre += c_extern_pre
@@ -177,11 +178,12 @@ def _generate_includes(includes, parameters):
     s = set(default_h_includes) | includes
 
     # s2 = external_includes - s
-    includes = "\n".join(sorted(s)) + "\n" if s else ""
+    includes_h = "\n".join(sorted(s)) + "\n" if s else ""
 
+    includes_c = ""
     # This should really be set by the backend
     scalar_type = parameters.get("scalar_type")
     if scalar_type == "double complex":
-        includes += "#include<complex.h>" + "\n"
+        includes_c += "#include <complex.h> \n"
 
-    return includes
+    return includes_h, includes_c

--- a/ffc/formatting.py
+++ b/ffc/formatting.py
@@ -182,7 +182,6 @@ def _generate_includes(includes, parameters):
     # This should really be set by the backend
     scalar_type = parameters.get("scalar_type")
     if scalar_type == "double complex":
-        print(scalar_type)
         includes += "#include<complex.h>" + "\n"
 
     return includes

--- a/ffc/formatting.py
+++ b/ffc/formatting.py
@@ -82,9 +82,8 @@ def format_code(code, wrapper_code, prefix, parameters):
     code_c_pre += format_template["header_c"] % {"prefix": prefix}
 
     # Generate includes and add to preamble
-    includes_h, includes_c = _generate_includes(includes, parameters)
+    includes_h = _generate_includes(includes, parameters)
     code_h_pre += includes_h
-    code_c_pre += includes_c
 
     # Enclose header with 'extern "C"'
     code_h_pre += c_extern_pre
@@ -178,11 +177,12 @@ def _generate_includes(includes, parameters):
     s = set(default_h_includes) | includes
 
     # s2 = external_includes - s
-    includes_h = "\n".join(sorted(s)) + "\n" if s else ""
+    includes = "\n".join(sorted(s)) + "\n" if s else ""
 
     # This should really be set by the backend
-    if "scalar_type" in parameters.keys():
-        if parameters["scalar_type"] == "double complex":
-            includes_c = "#include<complex.h>" + "\n"
+    scalar_type = parameters.get("scalar_type")
+    if scalar_type == "double complex":
+        print(scalar_type)
+        includes += "#include<complex.h>" + "\n"
 
-    return includes_h, includes_c
+    return includes

--- a/ffc/formatting.py
+++ b/ffc/formatting.py
@@ -82,8 +82,9 @@ def format_code(code, wrapper_code, prefix, parameters):
     code_c_pre += format_template["header_c"] % {"prefix": prefix}
 
     # Generate includes and add to preamble
-    includes_h = _generate_includes(includes, parameters)
+    includes_h, includes_c = _generate_includes(includes, parameters)
     code_h_pre += includes_h
+    code_c_pre += includes_c
 
     # Enclose header with 'extern "C"'
     code_h_pre += c_extern_pre
@@ -177,6 +178,11 @@ def _generate_includes(includes, parameters):
     s = set(default_h_includes) | includes
 
     # s2 = external_includes - s
+    includes_h = "\n".join(sorted(s)) + "\n" if s else ""
 
-    includes = "\n".join(sorted(s)) + "\n" if s else ""
-    return includes
+    # This should really be set by the backend
+    if "scalar_type" in parameters.keys():
+        if parameters["scalar_type"] == "double complex":
+            includes_c = "#include<complex.h>" + "\n"
+
+    return includes_h, includes_c


### PR DESCRIPTION
Insert `#include<complex.h>` when the scalar type is defined as `double complex`.
This allows dolfinx to use the generated c code (without throwing an error), even though it it does not use complex scalars yet.

Alternatively, this could be done by the backend (more changes needed). 


