### PR TITLE
Declare sub- elements and dofmaps

### DIFF
--- a/ffc/backends/ufc/dofmap.py
+++ b/ffc/backends/ufc/dofmap.py
@@ -207,6 +207,14 @@ def create_sub_dofmap(L, ir):
     return generate_return_new_switch(L, "i", classnames, factory=True)
 
 
+def sub_dofmap_declaration(L, ir):
+    classnames = set(ir["create_sub_dofmap"])
+    code = ""
+    for name in classnames:
+        code += "ufc_dofmap* create_{name}();\n".format(name=name)
+    return code
+
+
 def ufc_dofmap_generator(ir, parameters):
     """Generate UFC code for a dofmap"""
 
@@ -230,6 +238,7 @@ def ufc_dofmap_generator(ir, parameters):
     d["tabulate_facet_dofs"] = tabulate_facet_dofs(L, ir)
     d["tabulate_entity_dofs"] = tabulate_entity_dofs(L, ir)
     d["tabulate_entity_closure_dofs"] = tabulate_entity_closure_dofs(L, ir)
+    d["sub_dofmap_declaration"] = sub_dofmap_declaration(L, ir)
     d["create_sub_dofmap"] = create_sub_dofmap(L, ir)
 
     # Check that no keys are redundant or have been missed

--- a/ffc/backends/ufc/dofmap_template.py
+++ b/ffc/backends/ufc/dofmap_template.py
@@ -33,6 +33,7 @@ void tabulate_entity_closure_dofs_{factory_name}(int* restrict dofs, int d, int 
 {tabulate_entity_closure_dofs}
 }}
 
+{sub_dofmap_declaration}
 ufc_dofmap* create_sub_dofmap_{factory_name}(int i)
 {{
 {create_sub_dofmap}

--- a/ffc/backends/ufc/finite_element.py
+++ b/ffc/backends/ufc/finite_element.py
@@ -115,6 +115,14 @@ def num_sub_elements(L, num_sub_elements):
     return L.Return(num_sub_elements)
 
 
+def sub_element_declaration(L, ir):
+    classnames = set(ir["create_sub_element"])
+    code = ""
+    for name in classnames:
+        code += "ufc_finite_element* create_{name}();\n".format(name=name)
+    return code
+
+
 def create_sub_element(L, ir):
     classnames = ir["create_sub_element"]
     return generate_return_new_switch(L, "i", classnames, factory=True)
@@ -452,6 +460,7 @@ def generator(ir, parameters):
     d["tabulate_reference_dof_coordinates"] = L.StatementList(statements)
 
     statements = create_sub_element(L, ir)
+    d["sub_element_declaration"] = sub_element_declaration(L, ir)
     d["create_sub_element"] = statements
 
     # Check that no keys are redundant or have been missed

--- a/ffc/backends/ufc/finite_element_template.py
+++ b/ffc/backends/ufc/finite_element_template.py
@@ -60,6 +60,7 @@ void tabulate_reference_dof_coordinates_{factory_name}(double* restrict referenc
   {tabulate_reference_dof_coordinates}
 }}
 
+{sub_element_declaration}
 ufc_finite_element* create_sub_element_{factory_name}(int i)
 {{
   {create_sub_element}


### PR DESCRIPTION

Missing C declarations for sub_dofmaps and sub_elements cause some C99 compliant compilers to assume `int` return type instead of pointer. This usually causes a SEGV. 

This PR adds C declarations for sub_dofmaps and sub_elements.
 