### PR TITLE
More C declarations

### DIFF
--- a/ffc/backends/ufc/coordinate_mapping.py
+++ b/ffc/backends/ufc/coordinate_mapping.py
@@ -168,9 +168,21 @@ def create_coordinate_finite_element(L, ir):
     return generate_return_new(L, classname, factory=True)
 
 
+def coordinate_finite_element_declaration(L, ir):
+    classname = ir["create_coordinate_finite_element"]
+    code = "ufc_finite_element* create_{name}();\n".format(name=classname)
+    return code
+
+
 def create_coordinate_dofmap(L, ir):
     classname = ir["create_coordinate_dofmap"]
     return generate_return_new(L, classname, factory=True)
+
+
+def coordinate_dofmap_declaration(L, ir):
+    classname = ir["create_coordinate_dofmap"]
+    code = "ufc_dofmap* create_{name}();\n".format(name=classname)
+    return code
 
 
 def compute_physical_coordinates(L, ir):
@@ -836,7 +848,9 @@ def ufc_coordinate_mapping_generator(ir, parameters):
 
     # Functions
     d["create_coordinate_finite_element"] = create_coordinate_finite_element(L, ir)
+    d["coordinate_finite_element_declaration"] = coordinate_finite_element_declaration(L, ir)
     d["create_coordinate_dofmap"] = create_coordinate_dofmap(L, ir)
+    d["coordinate_dofmap_declaration"] = coordinate_dofmap_declaration(L, ir)
 
     statements = compute_physical_coordinates(L, ir)
     assert isinstance(statements, list)

--- a/ffc/backends/ufc/coordinate_mapping.py
+++ b/ffc/backends/ufc/coordinate_mapping.py
@@ -185,6 +185,15 @@ def coordinate_dofmap_declaration(L, ir):
     return code
 
 
+def evaluate_reference_basis_declaration(L, ir):
+    scalar_coordinate_element_classname = ir["scalar_coordinate_finite_element_classname"]
+    code = """
+int evaluate_reference_basis_{}(double* restrict reference_values,
+    int num_points, const double* restrict X);
+""".format(scalar_coordinate_element_classname)
+    return code
+
+
 def compute_physical_coordinates(L, ir):
     num_dofs = ir["num_scalar_coordinate_element_dofs"]
     scalar_coordinate_element_classname = ir["scalar_coordinate_finite_element_classname"]
@@ -597,6 +606,15 @@ def _compute_reference_coordinates_newton(L, ir, output_all=False):
     return code
 
 
+def evaluate_reference_basis_derivatives_declaration(L, ir):
+    scalar_coordinate_element_classname = ir["scalar_coordinate_finite_element_classname"]
+    code = """
+int evaluate_reference_basis_derivatives_{}(double* restrict reference_values,
+    int order, int num_points, const double* restrict X);
+""".format(scalar_coordinate_element_classname)
+    return code
+
+
 def compute_jacobians(L, ir):
     num_dofs = ir["num_scalar_coordinate_element_dofs"]
     scalar_coordinate_element_classname = ir["scalar_coordinate_finite_element_classname"]
@@ -855,6 +873,7 @@ def ufc_coordinate_mapping_generator(ir, parameters):
     statements = compute_physical_coordinates(L, ir)
     assert isinstance(statements, list)
     d["compute_physical_coordinates"] = L.StatementList(statements)
+    d["evaluate_reference_basis_declaration"] = evaluate_reference_basis_declaration(L, ir)
 
     statements = compute_reference_coordinates(L, ir)
     assert isinstance(statements, list)
@@ -863,6 +882,7 @@ def ufc_coordinate_mapping_generator(ir, parameters):
     statements = compute_reference_geometry(L, ir)
     assert isinstance(statements, list)
     d["compute_reference_geometry"] = L.StatementList(statements)
+    d["evaluate_reference_basis_derivatives_declaration"] = evaluate_reference_basis_derivatives_declaration(L, ir)
 
     statements = compute_jacobians(L, ir)
     assert isinstance(statements, list)

--- a/ffc/backends/ufc/coordinate_mapping_template.py
+++ b/ffc/backends/ufc/coordinate_mapping_template.py
@@ -11,11 +11,13 @@ ufc_coordinate_mapping* create_{factory_name}(void);
 factory = """
 // Code for coordinate mapping {factory_name}
 
+{coordinate_finite_element_declaration}
 ufc_finite_element* create_coordinate_finite_element_{factory_name}(void)
 {{
 {create_coordinate_finite_element}
 }}
 
+{coordinate_dofmap_declaration}
 ufc_dofmap* create_coordinate_dofmap_{factory_name}(void)
 {{
 {create_coordinate_dofmap}

--- a/ffc/backends/ufc/coordinate_mapping_template.py
+++ b/ffc/backends/ufc/coordinate_mapping_template.py
@@ -89,7 +89,7 @@ void compute_reference_geometry_{factory_name}(double* restrict X, double* restr
 ufc_coordinate_mapping* create_{factory_name}(void)
 {{
   ufc_coordinate_mapping* cmap = malloc(sizeof(*cmap));
-  const char* signature = {signature};
+  cmap->signature = {signature};
   cmap->create = create_{factory_name};
   cmap->geometric_dimension = {geometric_dimension};
   cmap->topological_dimension = {topological_dimension};

--- a/ffc/backends/ufc/coordinate_mapping_template.py
+++ b/ffc/backends/ufc/coordinate_mapping_template.py
@@ -23,6 +23,7 @@ ufc_dofmap* create_coordinate_dofmap_{factory_name}(void)
 {create_coordinate_dofmap}
 }}
 
+{evaluate_reference_basis_derivatives_declaration}
 void compute_jacobians_{factory_name}(double* restrict J, int num_points,
                                       const double* restrict X,
                                       const double* restrict coordinate_dofs)
@@ -42,6 +43,7 @@ void compute_jacobian_inverses_{factory_name}(double* restrict K, int num_points
 {compute_jacobian_inverses}
 }}
 
+{evaluate_reference_basis_declaration}
 void compute_physical_coordinates_{factory_name}(double* restrict x, int num_points,
                                                  const double* restrict X,
                                                  const double* restrict coordinate_dofs)

--- a/ffc/backends/ufc/evalderivs.py
+++ b/ffc/backends/ufc/evalderivs.py
@@ -96,7 +96,7 @@ def generate_evaluate_reference_basis_derivatives(L, data, classname, parameters
 
     # If max_degree is zero, we don't need to generate any more code
     if max_degree == 0:
-        return setup_code
+        return setup_code + [ret]
 
     # Tabulate dmats tables for all dofs and all derivative directions
     dmats_names, dmats_code = generate_tabulate_dmats(L, data["dofs_data"])

--- a/ffc/backends/ufc/form.py
+++ b/ffc/backends/ufc/form.py
@@ -147,7 +147,6 @@ class UFCForm:
             code += "ufc_dofmap* create_{name}();\n".format(name=name)
         return code
 
-
     # This group of functions are repeated for each
     # foo_integral by add_ufc_form_integral_methods:
 
@@ -184,8 +183,6 @@ def ufc_form_generator(ir, parameters):
     """Generate UFC code for a form"""
 
     factory_name = ir["classname"]
-
-
 
     d = {}
     d["factory_name"] = factory_name
@@ -240,7 +237,6 @@ def ufc_form_generator(ir, parameters):
         L, ir, parameters)
     d["create_default_custom_integral"] = generator.create_default_custom_integral(
         L, ir, parameters)
-
 
     # Check that no keys are redundant or have been missed
     from string import Formatter

--- a/ffc/backends/ufc/form.py
+++ b/ffc/backends/ufc/form.py
@@ -91,13 +91,11 @@ class UFCForm:
         return code
 
     def create_coordinate_finite_element(self, L, ir):
-        print('create coord')
         classnames = ir["create_coordinate_finite_element"]
         assert len(classnames) == 1
         return generate_return_new(L, classnames[0], factory=True)
 
     def coordinate_finite_element_declaration(self, L, ir):
-        print('create coord decl')
         classname = ir["create_coordinate_finite_element"]
         code = "ufc_finite_element* create_{name}();\n".format(name=classname[0])
         return code

--- a/ffc/backends/ufc/form.py
+++ b/ffc/backends/ufc/form.py
@@ -91,14 +91,26 @@ class UFCForm:
         return code
 
     def create_coordinate_finite_element(self, L, ir):
+        print('create coord')
         classnames = ir["create_coordinate_finite_element"]
         assert len(classnames) == 1
         return generate_return_new(L, classnames[0], factory=True)
+
+    def coordinate_finite_element_declaration(self, L, ir):
+        print('create coord decl')
+        classname = ir["create_coordinate_finite_element"]
+        code = "ufc_finite_element* create_{name}();\n".format(name=classname[0])
+        return code
 
     def create_coordinate_dofmap(self, L, ir):
         classnames = ir["create_coordinate_dofmap"]
         assert len(classnames) == 1
         return generate_return_new(L, classnames[0], factory=True)
+
+    def coordinate_dofmap_declaration(self, L, ir):
+        classname = ir["create_coordinate_dofmap"]
+        code = "ufc_dofmap* create_{name}();\n".format(name=classname[0])
+        return code
 
     def create_coordinate_mapping(self, L, ir):
         classnames = ir["create_coordinate_mapping"]
@@ -106,15 +118,35 @@ class UFCForm:
         assert len(classnames) == 1
         return generate_return_new(L, classnames[0], factory=True)
 
+    def coordinate_mapping_declaration(self, L, ir):
+        classname = ir["create_coordinate_mapping"]
+        code = "ufc_coordinate_mapping* create_{name}();\n".format(name=classname[0])
+        return code
+
     def create_finite_element(self, L, ir):
         i = L.Symbol("i")
         classnames = ir["create_finite_element"]
         return generate_return_new_switch(L, i, classnames, factory=True)
 
+    def finite_element_declaration(self, L, ir):
+        classnames = set(ir["create_finite_element"])
+        code = ""
+        for name in classnames:
+            code += "ufc_finite_element* create_{name}();\n".format(name=name)
+        return code
+
     def create_dofmap(self, L, ir):
         i = L.Symbol("i")
         classnames = ir["create_dofmap"]
         return generate_return_new_switch(L, i, classnames, factory=True)
+
+    def dofmap_declaration(self, L, ir):
+        classnames = set(ir["create_dofmap"])
+        code = ""
+        for name in classnames:
+            code += "ufc_dofmap* create_{name}();\n".format(name=name)
+        return code
+
 
     # This group of functions are repeated for each
     # foo_integral by add_ufc_form_integral_methods:
@@ -153,6 +185,8 @@ def ufc_form_generator(ir, parameters):
 
     factory_name = ir["classname"]
 
+
+
     d = {}
     d["factory_name"] = factory_name
     d["signature"] = "\"{}\"".format(ir["signature"])
@@ -179,10 +213,15 @@ def ufc_form_generator(ir, parameters):
     d["original_coefficient_position"] = L.StatementList(statements)
 
     d["create_coordinate_finite_element"] = generator.create_coordinate_finite_element(L, ir)
+    d["coordinate_finite_element_declaration"] = generator.coordinate_finite_element_declaration(L, ir)
     d["create_coordinate_dofmap"] = generator.create_coordinate_dofmap(L, ir)
+    d["coordinate_dofmap_declaration"] = generator.coordinate_dofmap_declaration(L, ir)
     d["create_coordinate_mapping"] = generator.create_coordinate_mapping(L, ir)
+    d["coordinate_mapping_declaration"] = generator.coordinate_mapping_declaration(L, ir)
     d["create_finite_element"] = generator.create_finite_element(L, ir)
+    d["finite_element_declaration"] = generator.finite_element_declaration(L, ir)
     d["create_dofmap"] = generator.create_dofmap(L, ir)
+    d["dofmap_declaration"] = generator.dofmap_declaration(L, ir)
 
     d["create_cell_integral"] = generator.create_cell_integral(L, ir, parameters)
     d["create_interior_facet_integral"] = generator.create_interior_facet_integral(
@@ -201,6 +240,7 @@ def ufc_form_generator(ir, parameters):
         L, ir, parameters)
     d["create_default_custom_integral"] = generator.create_default_custom_integral(
         L, ir, parameters)
+
 
     # Check that no keys are redundant or have been missed
     from string import Formatter

--- a/ffc/backends/ufc/form_template.py
+++ b/ffc/backends/ufc/form_template.py
@@ -16,26 +16,31 @@ int original_coefficient_position_{factory_name}(int i)
 {original_coefficient_position}
 }}
 
+{coordinate_finite_element_declaration}
 ufc_finite_element* create_coordinate_finite_element_{factory_name}()
 {{
 {create_coordinate_finite_element}
 }}
 
+{coordinate_dofmap_declaration}
 ufc_dofmap* create_coordinate_dofmap_{factory_name}()
 {{
 {create_coordinate_dofmap}
 }}
 
+{coordinate_mapping_declaration}
 ufc_coordinate_mapping* create_coordinate_mapping_{factory_name}()
 {{
 {create_coordinate_mapping}
 }}
 
+{finite_element_declaration}
 ufc_finite_element* create_finite_element_{factory_name}(int i)
 {{
 {create_finite_element}
 }}
 
+{dofmap_declaration}
 ufc_dofmap* create_dofmap_{factory_name}(int i)
 {{
 {create_dofmap}

--- a/ffc/uflacs/language/cnodes.py
+++ b/ffc/uflacs/language/cnodes.py
@@ -1493,7 +1493,7 @@ class ArrayDecl(CStatement):
             # Zero initial values
             # (NB! C style zero initialization, not sure about other target languages)
             nb = len(sizes)
-            return decl + " = {lbr} 0 {rbr};".format(lbr="{"*nb, rbr="}"*nb)
+            return decl + " = {lbr} 0 {rbr};".format(lbr="{" * nb, rbr="}" * nb)
         else:
             # Construct initializer lists for arbitrary multidimensional array values
             if self.values.dtype.kind == "f":

--- a/ffc/uflacs/language/cnodes.py
+++ b/ffc/uflacs/language/cnodes.py
@@ -1492,7 +1492,8 @@ class ArrayDecl(CStatement):
         elif _is_zero_valued(self.values):
             # Zero initial values
             # (NB! C style zero initialization, not sure about other target languages)
-            return decl + " = { 0 };"
+            nb = len(sizes)
+            return decl + " = {lbr} 0 {rbr};".format(lbr="{"*nb, rbr="}"*nb)
         else:
             # Construct initializer lists for arbitrary multidimensional array values
             if self.values.dtype.kind == "f":


### PR DESCRIPTION
Fixes a few issues in generated code (especially needed with clang):
* declarations for all functions called in a module (those returning pointers get cast to int by clang, if not declared).
* add extra braces for multidimensional array initialisation
* fix signature of coordinate_mapping