### PR TITLE
Even less code duplictation for preintegrated blocks

### DIFF
--- a/ffc/uflacs/integralgenerator.py
+++ b/ffc/uflacs/integralgenerator.py
@@ -973,11 +973,6 @@ class IntegralGenerator(object):
             # Define rhs expression for A[blockmap[arg_indices]] += A_rhs
             # A_rhs = f * PI where PI = sum_q weight * u * v
             PI = L.Symbol(blockdata.name)
-            block_rank = len(blockmap)
-
-            # Indices used to index A
-            A_index_symbols = tuple(self.backend.symbols.argument_loop_index(i)
-                                    for i in range(block_rank))
 
             # Define indices into preintegrated block
             P_entity_indices = self.get_entities(blockdata)

--- a/ffc/uflacs/integralgenerator.py
+++ b/ffc/uflacs/integralgenerator.py
@@ -949,8 +949,6 @@ class IntegralGenerator(object):
 
         # List for unrolled assignments
         A_values = [0.0] * A_size
-        # List of statements when not unrolling
-        code_looped = []
 
         # Generate unrolled code and collect data about non-unrolled code
         for block_id, (blockmap, blockdata) in enumerate(blocks):
@@ -1027,15 +1025,9 @@ class IntegralGenerator(object):
 
         # Generate unrolled code zeroing whole tensor
         code_unroll = self.generate_tensor_value_initialization(A_values)
-
-        # Add comments
         code_unroll = L.commented_code_list(code_unroll, "UFLACS block mode: preintegrated unroll")
-        code_looped = L.commented_code_list(code_looped, "UFLACS block mode: preintegrated looped")
 
-        # NB: Unrolled code zeros whole tensor; must be first
-        code = code_unroll + code_looped
-
-        return code
+        return code_unroll
 
     def generate_tensor_value_initialization(self, A_values):
         parts = []
@@ -1131,11 +1123,6 @@ class IntegralGenerator(object):
         # Get symbol, dimensions, and loop index symbols for A
         A_shape = self.ir["tensor_shape"]
         A_rank = len(A_shape)
-
-        # TODO: there's something like shape2strides(A_shape) somewhere
-        A_strides = [1] * A_rank
-        for i in reversed(range(0, A_rank - 1)):
-            A_strides[i] = A_strides[i + 1] * A_shape[i + 1]
 
         Asym = self.backend.symbols.element_tensor()
         A = L.FlattenedArray(Asym, dims=A_shape)


### PR DESCRIPTION
Ok, I managed to remove even more newly added code and code duplication from `generate_preintegrated_dofblock_partition()`.

The function `generate_dofblock_partition()` loops through all blocks to generate block contributions that will be stored in the previously mentioned `finalization_blocks` dict (which is used to finally generate the assignment loops to `A`). Before this PR, `generate_dofblock_partition()` skipped all `preintegrated` blocks as it expected that all of them are unrolled and they don't have contributions to `finalization_blocks`. I changed it to only skip `unroll=True` blocks. Now it also calls `generate_block_parts()` with `preintegrated` blocks and previously dead code gets active which does exactly the same as the remaining code for `unroll=False` blocks in `generate_preintegrated_dofblock_partition()`. So, I removed this code duplication by deleting more of the added code in this last function. It goes back to its original purpose of only handling unrolled blocks.