### PR TITLE
Add scalar_type to command line options

### DIFF
--- a/ffc/main.py
+++ b/ffc/main.py
@@ -63,7 +63,7 @@ parser.add_argument(
     action='store',
     choices=('double', 'double complex'),
     default="double",
-    help="Scalar type (default: double)")
+    help="scalar type to use (default: double)")
 parser.add_argument(
     '-f',
     action="append",

--- a/ffc/main.py
+++ b/ffc/main.py
@@ -57,6 +57,14 @@ parser.add_argument(
     default="uflacs",
     help="backend to use for compiling forms (default: uflacs)")
 parser.add_argument(
+    "-s",
+    "--scalar_type",
+    type=str,
+    action='store',
+    choices=('double', 'double complex'),
+    default="double",
+    help="Scalar type (default: double)")
+parser.add_argument(
     '-f',
     action="append",
     default=[],
@@ -91,6 +99,7 @@ def main(args=None):
     parameters["representation"] = xargs.representation
     parameters["quadrature_rule"] = xargs.quadrature_rule
     parameters["quadrature_degree"] = xargs.quadrature_degree
+    parameters["scalar_type"] = xargs.scalar_type
     if xargs.output_directory:
         parameters["output_dir"] = xargs.output_directory
     for p in xargs.f:


### PR DESCRIPTION
The command 
`python3 -m ffc -l dolfin -fscalar_type='double complex' xxxx.ufl`
now throws an AssertionError (`assert key in parameters`).

With the addition of `scalar_type` to command line options, the following comannd
`python3 -m ffc -l dolfin -s 'double_complex' -r 'tsfc' xxxx.ufl`
works.