### PR TITLE
Support setting new and existing FFC parameter options.

### DIFF
--- a/ffc/main.py
+++ b/ffc/main.py
@@ -45,7 +45,7 @@ parser.add_argument(
     "--quadrature-rule",
     type=str,
     default="auto",
-    help="quadrature rule to apply (default: auto)")
+    help="quadrature rule to apply (default: %(default)s)")
 parser.add_argument(
     "--quadrature-degree",
     type=int,
@@ -94,8 +94,6 @@ def main(args=None):
     xargs = parser.parse_args(args)
     parameters = default_parameters()
     ffc_logger = logging.getLogger("ffc")
-
-    print(xargs)
 
     if xargs.debug:
         ffc_logger.setLevel(logging.DEBUG)

--- a/ffc/main.py
+++ b/ffc/main.py
@@ -33,13 +33,13 @@ parser.add_argument(
     action='store',
     choices=["ufc", "dolfin"],
     default="ufc",
-    help="target language/wrappers (default: ufc)")
+    help="target language/wrappers (default: %(default)s)")
 parser.add_argument(
     "--version", action='version', version="%(prog)s " + ("(version {})".format(FFC_VERSION)))
-parser.add_argument("-d", "--debug", action='store_true', default=False, help="enable debug output")
-parser.add_argument("-v", "--verbose", action='store_true', default=False, help="verbose output")
+parser.add_argument("-d", "--debug", action='store_true', help="enable debug output")
+parser.add_argument("-v", "--verbose", action='store_true', help="verbose output")
 parser.add_argument("-o", "--output-directory", type=str, help="output directory")
-parser.add_argument("-p", "--profile", action='store_true', default=False, help="enable profiling")
+parser.add_argument("-p", "--profile", action='store_true',  help="enable profiling")
 parser.add_argument(
     "-q",
     "--quadrature-rule",
@@ -47,7 +47,7 @@ parser.add_argument(
     default="auto",
     help="quadrature rule to apply (default: auto)")
 parser.add_argument(
-    "--quadrature-degree", type=int, default=-1, help="quadrature degree to apply (auto: -1)")
+    "--quadrature-degree", type=int, default=-1, help="quadrature degree to apply, auto: -1 (default: %(default)s)")
 parser.add_argument(
     "-r",
     "--representation",
@@ -55,7 +55,7 @@ parser.add_argument(
     action='store',
     choices=('uflacs', 'tsfc'),
     default="uflacs",
-    help="backend to use for compiling forms (default: uflacs)")
+    help="backend to use for compiling forms (default: %(default)s)")
 parser.add_argument(
     '-f',
     action="append",
@@ -113,7 +113,7 @@ def main(args=None):
     for p in xargs.u:
         assert len(p) == 2
         if p[0] in parameters:
-            raise RuntimeError("Command parameter set with -u alreadt exists in parameters system. Use -f.")
+            raise RuntimeError("Command parameter set with -u already exists in parameters system. Use -f.")
         parameters[p[0]] = p[1]
 
     # FIXME: This is terrible!

--- a/ffc/main.py
+++ b/ffc/main.py
@@ -39,7 +39,7 @@ parser.add_argument(
 parser.add_argument("-d", "--debug", action='store_true', help="enable debug output")
 parser.add_argument("-v", "--verbose", action='store_true', help="verbose output")
 parser.add_argument("-o", "--output-directory", type=str, help="output directory")
-parser.add_argument("-p", "--profile", action='store_true',  help="enable profiling")
+parser.add_argument("-p", "--profile", action='store_true', help="enable profiling")
 parser.add_argument(
     "-q",
     "--quadrature-rule",
@@ -47,7 +47,10 @@ parser.add_argument(
     default="auto",
     help="quadrature rule to apply (default: auto)")
 parser.add_argument(
-    "--quadrature-degree", type=int, default=-1, help="quadrature degree to apply, auto: -1 (default: %(default)s)")
+    "--quadrature-degree",
+    type=int,
+    default=-1,
+    help="quadrature degree to apply, auto: -1 (default: %(default)s)")
 parser.add_argument(
     "-r",
     "--representation",
@@ -63,8 +66,7 @@ parser.add_argument(
     nargs=2,
     dest="f",
     metavar=("name", "value"),
-    help=
-    "set existing parameter value in the parameter system, where 'name' is the FFC parameter name")
+    help="set existing parameter value in the parameter system, where 'name' is the FFC parameter name")
 parser.add_argument(
     '-u',
     action="append",
@@ -113,7 +115,8 @@ def main(args=None):
     for p in xargs.u:
         assert len(p) == 2
         if p[0] in parameters:
-            raise RuntimeError("Command parameter set with -u already exists in parameters system. Use -f.")
+            raise RuntimeError(
+                "Command parameter set with -u already exists in parameters system. Use -f.")
         parameters[p[0]] = p[1]
 
     # FIXME: This is terrible!

--- a/ffc/main.py
+++ b/ffc/main.py
@@ -60,9 +60,19 @@ parser.add_argument(
     '-f',
     action="append",
     default=[],
+    nargs=2,
     dest="f",
-    metavar="parameter=value",
-    help="option passed through to parameter system, where 'parameter' is the FFC parameter name")
+    metavar=("name", "value"),
+    help=
+    "set existing parameter value in the parameter system, where 'name' is the FFC parameter name")
+parser.add_argument(
+    '-u',
+    action="append",
+    default=[],
+    nargs=2,
+    dest="u",
+    metavar=("name", "value"),
+    help="add new parameter to the parameter system")
 parser.add_argument("ufl_file", nargs='+', help="UFL file(s) to be compiled")
 
 
@@ -83,6 +93,8 @@ def main(args=None):
     parameters = default_parameters()
     ffc_logger = logging.getLogger("ffc")
 
+    print(xargs)
+
     if xargs.debug:
         ffc_logger.setLevel(logging.DEBUG)
     if xargs.verbose:
@@ -94,10 +106,15 @@ def main(args=None):
     if xargs.output_directory:
         parameters["output_dir"] = xargs.output_directory
     for p in xargs.f:
-        assert len(p.split("=")) == 2
-        key, value = p.split("=")
-        assert key in parameters
-        parameters[key] = value
+        assert len(p) == 2
+        if p[0] not in parameters:
+            raise RuntimeError("Command parameter set with -f does not exist in parameters system.")
+        parameters[p[0]] = p[1]
+    for p in xargs.u:
+        assert len(p) == 2
+        if p[0] in parameters:
+            raise RuntimeError("Command parameter set with -u alreadt exists in parameters system. Use -f.")
+        parameters[p[0]] = p[1]
 
     # FIXME: This is terrible!
     # Set UFL precision


### PR DESCRIPTION
Allow setting of existing parameters:
```
ffc -f pname value foo.ufl
```
and adding new parameters:
```
ffc -u new_pname value foo.ufl
```
The type will always be `str`, so any casting needs to be handled internally.

