### PR TITLE
Add scalar_type to ffc default parameters

### DIFF
--- a/ffc/parameters.py
+++ b/ffc/parameters.py
@@ -36,7 +36,8 @@ _FFC_GENERATE_PARAMETERS = {
     # set to True to add timing inside tabulate_tensor
     "generate_dummy_tabulate_tensor": False,
     "add_tabulate_tensor_timing": False,
-    # Scalar type to be used ("double" or "double complex")
+    # Scalar type to be used in generated code (real or complex
+    # C double precision floating-point types)
     "scalar_type": "double",
     # ':' separated list of include filenames to add to generated code
     "external_includes": "",

--- a/ffc/parameters.py
+++ b/ffc/parameters.py
@@ -36,6 +36,8 @@ _FFC_GENERATE_PARAMETERS = {
     # set to True to add timing inside tabulate_tensor
     "generate_dummy_tabulate_tensor": False,
     "add_tabulate_tensor_timing": False,
+    # Scalar type to be used ("double" or "double complex")
+    "scalar_type": "double",
     # ':' separated list of include filenames to add to generated code
     "external_includes": "",
 }


### PR DESCRIPTION
Currently, any of the options `p["scalar_type"] = "double"` or `p.update("scalar_type": "double")` throws the error "Parameter not found in Parameters object" (`p = Parameters("form_compiler")`).