### PR TITLE
No developer pip install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             pip install git+https://bitbucket.org/fenics-project/dijitso.git --user
       - run:
           name: Install FFC
-          command: pip install -e . --user
+          command: pip install . --user -v
       - run:
           name: Run flake8 tests
           command: python -m flake8 ffc/ test/


### PR DESCRIPTION
Developer install keeps files in place, ignoring some options in `setup.py`, is therefore not appropriate for test suite.