### PR TITLE
Fix some ufc return types

### DIFF
--- a/ffc/codegeneration/evaluatedof.py
+++ b/ffc/codegeneration/evaluatedof.py
@@ -347,4 +347,5 @@ def generate_transform_values(L, ir):
         code += c
         code += [L.Assign(values[i], r)]
 
+    code += [L.Return(0)]
     return code

--- a/ffc/codegeneration/finite_element.py
+++ b/ffc/codegeneration/finite_element.py
@@ -376,8 +376,7 @@ def transform_reference_basis_derivatives(L, ir, parameters):
                                 index_type=index_type,
                                 body=[
                                     L.AssignAdd(values[ip, idof, r, physical_offset + i],
-                                                transform[r, s] * mapped_value)
-                                ])
+                                                transform[r, s] * mapped_value)])
                 ])
         ]
 
@@ -392,8 +391,8 @@ def transform_reference_basis_derivatives(L, ir, parameters):
     ]
 
     # Join code
-    code = (combinations_code + values_init_code + dof_attributes_code + point_loop_code +
-            [L.Comment(msg), L.Return(0)])
+    code = (combinations_code + values_init_code + dof_attributes_code + point_loop_code
+            + [L.Comment(msg), L.Return(0)])
     return code
 
 

--- a/ffc/codegeneration/finite_element.py
+++ b/ffc/codegeneration/finite_element.py
@@ -407,9 +407,9 @@ def generator(ir, parameters):
     d["cell_shape"] = ir["cell_shape"]
     d["space_dimension"] = ir["space_dimension"]
     d["value_rank"] = len(ir["value_shape"])
-    d["value_size"] = product(ir["value_shape"])
+    d["value_size"] = ufl.product(ir["value_shape"])
     d["reference_value_rank"] = len(ir["reference_value_shape"])
-    d["reference_value_size"] = product(ir["reference_value_shape"])
+    d["reference_value_size"] = ufl.product(ir["reference_value_shape"])
     d["degree"] = ir["degree"]
     d["family"] = "\"{}\"".format(ir["family"])
     d["num_sub_elements"] = ir["num_sub_elements"]

--- a/ffc/codegeneration/finite_element.py
+++ b/ffc/codegeneration/finite_element.py
@@ -12,13 +12,13 @@
 from collections import defaultdict
 
 import ffc.codegeneration.finite_element_template as ufc_finite_element
+import ufl
 from ffc.codegeneration.evalderivs import (_generate_combinations,
                                            generate_evaluate_reference_basis_derivatives)
 from ffc.codegeneration.evaluatebasis import generate_evaluate_reference_basis
 from ffc.codegeneration.evaluatedof import generate_transform_values
 from ffc.codegeneration.utils import (generate_return_int_switch,
                                       generate_return_new_switch)
-from ufl import product
 
 index_type = "int64_t"
 
@@ -87,7 +87,7 @@ def value_dimension(L, value_shape):
 
 
 def value_size(L, value_shape):
-    return L.Return(product(value_shape))
+    return L.Return(ufl.product(value_shape))
 
 
 def reference_value_rank(L, reference_value_shape):
@@ -99,7 +99,7 @@ def reference_value_dimension(L, reference_value_shape):
 
 
 def reference_value_size(L, reference_value_shape):
-    return L.Return(product(reference_value_shape))
+    return L.Return(ufl.product(reference_value_shape))
 
 
 def degree(L, degree):
@@ -140,7 +140,6 @@ def tabulate_reference_dof_coordinates(L, ir, parameters):
 
     # Raise error if tabulate_reference_dof_coordinates is ill-defined
     if not ir:
-        # Return error code
         return [L.Return(-1)]
 
     # Extract coordinates and cell dimension
@@ -155,9 +154,8 @@ def tabulate_reference_dof_coordinates(L, ir, parameters):
     dof_X_values = [X[jj] for X in points for jj in range(tdim)]
     decl = L.ArrayDecl("static const double", dof_X, (len(points) * tdim, ), values=dof_X_values)
     copy = L.MemCopy(dof_X, reference_dof_coordinates, tdim * len(points), "double")
-
-    code = [decl, copy]
-    return code
+    ret = L.Return(0)
+    return [decl, copy, ret]
 
 
 def evaluate_reference_basis(L, ir, parameters):
@@ -271,19 +269,17 @@ def transform_reference_basis_derivatives(L, ir, parameters):
     transform_matrix_code = [
         # Initialize transform matrix to all 1.0
         L.ArrayDecl("double", transform, (max_g_d, max_t_d)),
-        L.ForRanges(
-            (r, 0, num_derivatives_g), (s, 0, num_derivatives_t),
-            index_type=index_type,
-            body=L.Assign(transform[r, s], 1.0)),
+        L.ForRanges((r, 0, num_derivatives_g), (s, 0, num_derivatives_t),
+                    index_type=index_type,
+                    body=L.Assign(transform[r, s], 1.0)),
     ]
     if max_degree > 0:
         transform_matrix_code += [
             # Compute transform matrix entries, each a product of K entries
-            L.ForRanges(
-                (r, 0, num_derivatives_g), (s, 0, num_derivatives_t), (k, 0, order),
-                index_type=index_type,
-                body=L.AssignMul(transform[r, s],
-                                 K[ip, combinations_t[s, k], combinations_g[r, k]])),
+            L.ForRanges((r, 0, num_derivatives_g), (s, 0, num_derivatives_t), (k, 0, order),
+                        index_type=index_type,
+                        body=L.AssignMul(transform[r, s],
+                                         K[ip, combinations_t[s, k], combinations_g[r, k]])),
         ]
 
     # Initialize values to 0, will be added to inside loops
@@ -376,13 +372,12 @@ def transform_reference_basis_derivatives(L, ir, parameters):
                     # Apply derivative transformation, for order=0 this reduces to
                     # values[ip,idof,0,physical_offset+i] = transform[0,0]*mapped_value
                     L.Comment("Mapping derivatives back to the physical element"),
-                    L.ForRanges(
-                        (r, 0, num_derivatives_g),
-                        index_type=index_type,
-                        body=[
-                            L.AssignAdd(values[ip, idof, r, physical_offset + i],
-                                        transform[r, s] * mapped_value)
-                        ])
+                    L.ForRanges((r, 0, num_derivatives_g),
+                                index_type=index_type,
+                                body=[
+                                    L.AssignAdd(values[ip, idof, r, physical_offset + i],
+                                                transform[r, s] * mapped_value)
+                                ])
                 ])
         ]
 
@@ -397,9 +392,8 @@ def transform_reference_basis_derivatives(L, ir, parameters):
     ]
 
     # Join code
-    code = (combinations_code + values_init_code
-            + dof_attributes_code + point_loop_code
-            + [L.Comment(msg), L.Return(0)])
+    code = (combinations_code + values_init_code + dof_attributes_code + point_loop_code +
+            [L.Comment(msg), L.Return(0)])
     return code
 
 

--- a/ffc/codegeneration/finite_element_template.py
+++ b/ffc/codegeneration/finite_element_template.py
@@ -45,7 +45,7 @@ int transform_reference_basis_derivatives_{factory_name}(
   {transform_reference_basis_derivatives}
 }}
 
-void transform_values_{factory_name}(
+int transform_values_{factory_name}(
      ufc_scalar_t* restrict reference_values,
      const ufc_scalar_t* restrict physical_values,
      const double* restrict coordinate_dofs,

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -61,7 +61,7 @@ void (*transform_values)(
     const ufc_scalar_t* restrict physical_values,
     const double* restrict coordinate_dofs,
     int cell_orientation, const ufc_coordinate_mapping* cm);
-void (*tabulate_reference_dof_coordinates)(
+int (*tabulate_reference_dof_coordinates)(
     double* restrict reference_dof_coordinates);
 int num_sub_elements;
 ufc_finite_element* (*create_sub_element)(int i);

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -56,7 +56,7 @@ int (*transform_reference_basis_derivatives)(
     const double* restrict reference_values, const double* restrict X,
     const double* restrict J, const double* restrict detJ,
     const double* restrict K, int cell_orientation);
-void (*transform_values)(
+int (*transform_values)(
     ufc_scalar_t* restrict reference_values,
     const ufc_scalar_t* restrict physical_values,
     const double* restrict coordinate_dofs,

--- a/ffc/codegeneration/ufc.h
+++ b/ffc/codegeneration/ufc.h
@@ -108,8 +108,9 @@ extern "C"
         const double* restrict K, int cell_orientation);
 
     /// Map values of field from physical to reference space which has
-    /// been evaluated at points given by tabulate_reference_dof_coordinates.
-    void (*transform_values)(ufc_scalar_t* restrict reference_values,
+    /// been evaluated at points given by
+    /// tabulate_reference_dof_coordinates.
+    int (*transform_values)(ufc_scalar_t* restrict reference_values,
                              const ufc_scalar_t* restrict physical_values,
                              const double* restrict coordinate_dofs,
                              int cell_orientation,
@@ -123,7 +124,8 @@ extern "C"
     /// Return the number of sub elements (for a mixed element)
     int num_sub_elements;
 
-    /// Create a new finite element for sub element i (for a mixed element)
+    /// Create a new finite element for sub element i (for a mixed
+    /// element)
     ufc_finite_element* (*create_sub_element)(int i);
 
     /// Create a new class instance


### PR DESCRIPTION
Changes some `void` -> `int`, and add return to `int` functions that were missing a return statement.