### PR TITLE
Add more scalar types to cffi tests

### DIFF
--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -13,7 +13,7 @@ import cffi
 import ffc
 
 UFC_HEADER_DECL = """
-typedef double {} ufc_scalar_t;  /* Hack to deal with scalar type */
+typedef {} ufc_scalar_t;  /* Hack to deal with scalar type */
 
 typedef struct ufc_coordinate_mapping ufc_coordinate_mapping;
 typedef struct ufc_finite_element ufc_finite_element;
@@ -217,7 +217,8 @@ ufc_custom_integral* (*create_default_custom_integral)(void);
 def compile_elements(elements, module_name=None, parameters=None):
     """Compile a list of UFL elements and dofmaps into UFC Python objects"""
     p = ffc.parameters.validate_parameters(parameters)
-    decl = UFC_HEADER_DECL.format("") + UFC_ELEMENT_DECL + UFC_DOFMAP_DECL
+    scalar_type = p["scalar_type"].replace("complex", "_Complex")
+    decl = UFC_HEADER_DECL.format(scalar_type) + UFC_ELEMENT_DECL + UFC_DOFMAP_DECL
     element_template = "ufc_finite_element * create_{name}(void);\n"
     dofmap_template = "ufc_dofmap * create_{name}(void);\n"
     names = []
@@ -241,11 +242,8 @@ def compile_forms(forms, module_name=None, parameters=None):
     """Compile a list of UFL forms into UFC Python objects"""
     p = ffc.parameters.validate_parameters(parameters)
 
-    if p and "complex" in p["scalar_type"]:
-        complex_mode = "_Complex"
-    else:
-        complex_mode = ""
-    decl = UFC_HEADER_DECL.format(complex_mode) + UFC_ELEMENT_DECL \
+    scalar_type = p["scalar_type"].replace("complex", "_Complex")
+    decl = UFC_HEADER_DECL.format(scalar_type) + UFC_ELEMENT_DECL \
         + UFC_DOFMAP_DECL + UFC_COORDINATEMAPPING_DECL \
         + UFC_INTEGRAL_DECL + UFC_FORM_DECL
 
@@ -263,8 +261,8 @@ def compile_forms(forms, module_name=None, parameters=None):
 def compile_coordinate_maps(cmaps, module_name=None, parameters=None):
     """Compile a list of UFL coordinate mappings into UFC Python objects"""
     p = ffc.parameters.validate_parameters(parameters)
-
-    decl = UFC_HEADER_DECL.format("") + UFC_COORDINATEMAPPING_DECL
+    scalar_type = p["scalar_type"].replace("complex", "_Complex")
+    decl = UFC_HEADER_DECL.format(scalar_type) + UFC_COORDINATEMAPPING_DECL
     cmap_template = "ufc_coordinate_mapping * create_{name}(void);\n"
     cmap_names = [ffc.ir.representation.make_coordinate_mapping_jit_classname(cmap, "Mesh", p) for cmap in cmaps]
     for name in cmap_names:

--- a/ffc/formatting.py
+++ b/ffc/formatting.py
@@ -199,18 +199,19 @@ def _define_scalar(parameters):
     # Define the ufc_scalar type before including  the ufc header
     # By default use double scalars
     scalar_type = parameters.get("scalar_type")
-    if scalar_type == "double complex":
-        scalar = "\n".join([
-            "#if defined(__cplusplus)",
-            "#include <complex>",
-            "typedef std::complex<double> ufc_scalar_t;",
-            "#else",
-            "#include <complex.h>",
-            "typedef double _Complex ufc_scalar_t;",
-            "#endif",
-            "\n",
-        ])
+    if "complex" in scalar_type:
+        base_type = scalar_type.replace("complex", "")
+        scalar = """
+#if defined(__cplusplus)
+ #include <complex>
+ typedef std::complex<{0}> ufc_scalar_t;
+#else
+ #include <complex.h>
+ typedef {0} _Complex ufc_scalar_t;
+#endif
+
+""".format(base_type)
     else:
-        scalar = "typedef double ufc_scalar_t;" + "\n"
+        scalar = "typedef " + scalar_type + " ufc_scalar_t;" + "\n"
 
     return scalar

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -19,6 +19,12 @@ def float_to_type(name):
         return "double", np.float64
     elif name == "double complex":
         return "double _Complex", np.complex128
+    elif name == "float":
+        return "float", np.float32
+    elif name == "float complex":
+        return "float _Complex", np.complex64
+    elif name == "long double":
+        return "long double", np.longdouble
     else:
         raise RuntimeError("Unknown C type for: {}".format(name))
 
@@ -144,6 +150,16 @@ def test_laplace_bilinear_form_2d(mode, expected_result):
 
 
 @pytest.mark.parametrize("mode,expected_result", [
+    ("float",
+     np.array(
+         [[1.0 / 12.0, 1.0 / 24.0, 1.0 / 24.0], [1.0 / 24.0, 1.0 / 12.0, 1.0 / 24.0],
+          [1.0 / 24.0, 1.0 / 24.0, 1.0 / 12.0]],
+         dtype=np.float32)),
+    ("long double",
+     np.array(
+         [[1.0 / 12.0, 1.0 / 24.0, 1.0 / 24.0], [1.0 / 24.0, 1.0 / 12.0, 1.0 / 24.0],
+          [1.0 / 24.0, 1.0 / 24.0, 1.0 / 12.0]],
+         dtype=np.longdouble)),
     ("double",
      np.array(
          [[1.0 / 12.0, 1.0 / 24.0, 1.0 / 24.0], [1.0 / 24.0, 1.0 / 12.0, 1.0 / 24.0],
@@ -154,6 +170,11 @@ def test_laplace_bilinear_form_2d(mode, expected_result):
          [[1.0 / 12.0, 1.0 / 24.0, 1.0 / 24.0], [1.0 / 24.0, 1.0 / 12.0, 1.0 / 24.0],
           [1.0 / 24.0, 1.0 / 24.0, 1.0 / 12.0]],
          dtype=np.complex128)),
+    ("float complex",
+     np.array(
+         [[1.0 / 12.0, 1.0 / 24.0, 1.0 / 24.0], [1.0 / 24.0, 1.0 / 12.0, 1.0 / 24.0],
+          [1.0 / 24.0, 1.0 / 24.0, 1.0 / 12.0]],
+         dtype=np.complex64)),
 ])
 def test_mass_bilinear_form_2d(mode, expected_result):
     cell = ufl.triangle


### PR DESCRIPTION
Allow users to select `float` `complex float` and `long double` for scalar type.