### PR TITLE
Remove "kind" argument where possible

### DIFF
--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -229,7 +229,7 @@ def compile_elements(elements, module_name=None, parameters=None):
         names.append(name)
         decl += dofmap_template.format(name=name)
 
-    _, code_body = ffc.compiler.compile_element(elements, prefix=("Element", True), parameters=p)
+    _, code_body = ffc.compiler.compile_ufl_objects(elements, prefix=("Element", True), parameters=p)
 
     objects, module = _compile_objects(decl, code_body, names, module_name, p)
     # Pair up elements with dofmaps
@@ -255,7 +255,7 @@ def compile_forms(forms, module_name=None, parameters=None):
     for name in form_names:
         decl += form_template.format(name=name)
 
-    _, code_body = ffc.compiler.compile_form(forms, prefix=("Form", True), parameters=p)
+    _, code_body = ffc.compiler.compile_ufl_objects(forms, prefix=("Form", True), parameters=p)
 
     return _compile_objects(decl, code_body, form_names, module_name, p)
 
@@ -270,7 +270,7 @@ def compile_coordinate_maps(cmaps, module_name=None, parameters=None):
     for name in cmap_names:
         decl += cmap_template.format(name=name)
 
-    _, code_body = ffc.compiler.compile_coordinate_mapping(cmaps, prefix=("Mesh", True), parameters=p)
+    _, code_body = ffc.compiler.compile_ufl_objects(cmaps, prefix=("Mesh", True), parameters=p)
 
     return _compile_objects(decl, code_body, cmap_names, module_name, p)
 

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -260,17 +260,18 @@ def compile_forms(forms, module_name=None, parameters=None):
     return _compile_objects(decl, code_body, form_names, module_name, p)
 
 
-def compile_coordinate_maps(cmaps, module_name=None, parameters=None):
+def compile_coordinate_maps(meshes, module_name=None, parameters=None):
     """Compile a list of UFL coordinate mappings into UFC Python objects"""
     p = ffc.parameters.validate_parameters(parameters)
 
     decl = UFC_HEADER_DECL.format("") + UFC_COORDINATEMAPPING_DECL
     cmap_template = "ufc_coordinate_mapping * create_{name}(void);\n"
-    cmap_names = [ffc.ir.representation.make_coordinate_mapping_jit_classname(cmap, "Mesh", p) for cmap in cmaps]
+    cmap_names = [ffc.ir.representation.make_coordinate_mapping_jit_classname(
+        mesh.ufl_coordinate_element(), "Mesh", p) for mesh in meshes]
     for name in cmap_names:
         decl += cmap_template.format(name=name)
 
-    _, code_body = ffc.compiler.compile_ufl_objects(cmaps, prefix=("Mesh", True), parameters=p)
+    _, code_body = ffc.compiler.compile_ufl_objects(meshes, prefix=("Mesh", True), parameters=p)
 
     return _compile_objects(decl, code_body, cmap_names, module_name, p)
 

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -112,8 +112,13 @@ def compile_ufl_objects(ufl_objects: Union[List, Tuple],
         ufl_objects = (ufl_objects, )
     if not ufl_objects:
         return "", ""
+
     if prefix[0] != os.path.basename(prefix[0]):
         raise RuntimeError("Invalid prefix, looks like a full path? prefix='{}'.".format(prefix[0]))
+
+    # Check that all UFL objects passed here are of the same class/type
+    obj_type = type(ufl_objects[0])
+    assert (obj_type == type(x) for x in ufl_objects)
 
     # Stage 1: analysis
     cpu_time = time()

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -85,6 +85,7 @@ def _print_timing(stage, timing):
 
 
 def compile_ufl_objects(ufl_objects: Union[List, Tuple],
+                        object_names: Dict = {},
                         prefix: Tuple = None,
                         parameters: Dict = None,
                         jit: bool = False):
@@ -141,7 +142,7 @@ def compile_ufl_objects(ufl_objects: Union[List, Tuple],
         for ir_comp, e_name in zip(ir, comp):
             for e in ir_comp:
                 classnames[e_name].append(e["classname"])
-        wrapper_code = generate_wrapper_code(analysis, prefix[0], {}, classnames, parameters)
+        wrapper_code = generate_wrapper_code(analysis, prefix[0], object_names, classnames, parameters)
     else:
         wrapper_code = None
 

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -60,18 +60,13 @@ Compiler stages:
    to the UFC format, generating as output one or more .h/.c files
    conforming to the UFC format.
 
-The main interface is defined by the following two functions::
-
-    compile_form compile_element
-
 """
-
-__all__ = ["compile_form", "compile_element"]
 
 import logging
 import os
 from collections import defaultdict
 from time import time
+from typing import Dict, List, Tuple, Union
 
 import ufl
 from ffc.analysis import analyze_ufl_objects
@@ -89,30 +84,19 @@ def _print_timing(stage, timing):
         stage=stage, time=timing))
 
 
-def compile_form(forms, object_names=None, prefix="Form", parameters=None, jit=False):
-    """Generate UFC code for a given UFL form or list of UFL forms."""
-    return compile_ufl_objects(forms, "form", object_names, prefix, parameters, jit)
+def compile_ufl_objects(ufl_objects: Union[List, Tuple],
+                        prefix: Tuple=None,
+                        parameters: Dict=None,
+                        jit: bool=False):
+    """Generate UFC code for a given UFL objects.
 
-
-def compile_element(elements, object_names=None, prefix="Element", parameters=None, jit=False):
-    """Generate UFC code for a given UFL element or list of UFL elements."""
-    return compile_ufl_objects(elements, "element", object_names, prefix, parameters, jit)
-
-
-def compile_coordinate_mapping(meshes, object_names=None, prefix="Mesh", parameters=None,
-                               jit=False):
-    """Generates UFC code for a given UFL mesh or list of UFL meshes."""
-    return compile_ufl_objects(meshes, "coordinate_mapping", object_names, prefix, parameters, jit)
-
-
-def compile_ufl_objects(ufl_objects,
-                        kind,
-                        object_names=None,
-                        prefix=None,
-                        parameters=None,
-                        jit=False):
-    """Generate UFC code for a given UFL form or list of UFL forms."""
-    logger.info("Compiling {} {}\n".format(kind, prefix))
+    Parameters
+    ----------
+    ufl_objects
+        Objects to be compiled. Accepts elements, forms, integrals or coordinate mappings.
+    
+    """
+    logger.info("Compiling {}\n".format(prefix))
 
     # Reset timing
     cpu_time_0 = time()
@@ -129,12 +113,10 @@ def compile_ufl_objects(ufl_objects,
         return "", ""
     if prefix[0] != os.path.basename(prefix[0]):
         raise RuntimeError("Invalid prefix, looks like a full path? prefix='{}'.".format(prefix[0]))
-    if object_names is None:
-        object_names = {}
 
     # Stage 1: analysis
     cpu_time = time()
-    analysis = analyze_ufl_objects(ufl_objects, kind, parameters)
+    analysis = analyze_ufl_objects(ufl_objects, parameters)
     _print_timing(1, time() - cpu_time)
 
     # Stage 2: intermediate representation
@@ -159,7 +141,7 @@ def compile_ufl_objects(ufl_objects,
         for ir_comp, e_name in zip(ir, comp):
             for e in ir_comp:
                 classnames[e_name].append(e["classname"])
-        wrapper_code = generate_wrapper_code(analysis, prefix[0], object_names, classnames, parameters)
+        wrapper_code = generate_wrapper_code(analysis, prefix[0], {}, classnames, parameters)
     else:
         wrapper_code = None
 

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -85,16 +85,16 @@ def _print_timing(stage, timing):
 
 
 def compile_ufl_objects(ufl_objects: Union[List, Tuple],
-                        prefix: Tuple=None,
-                        parameters: Dict=None,
-                        jit: bool=False):
+                        prefix: Tuple = None,
+                        parameters: Dict = None,
+                        jit: bool = False):
     """Generate UFC code for a given UFL objects.
 
     Parameters
     ----------
     ufl_objects
         Objects to be compiled. Accepts elements, forms, integrals or coordinate mappings.
-    
+
     """
     logger.info("Compiling {}\n".format(prefix))
 

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -38,23 +38,29 @@ ufc_integral_types = ("cell", "exterior_facet", "interior_facet", "vertex", "cus
 
 def make_finite_element_jit_classname(ufl_element, tag, parameters):
     from ffc import jitcompiler  # FIXME circular file dependency
+    assert isinstance(ufl_element, ufl.FiniteElementBase)
     kind, prefix = jitcompiler.compute_prefix(ufl_element, tag, parameters)
+
     return classname.make_name(prefix, "finite_element", "main")
 
 
 def make_dofmap_jit_classname(ufl_element, tag, parameters):
     from ffc import jitcompiler  # FIXME circular file dependency
+    assert isinstance(ufl_element, ufl.FiniteElementBase)
     kind, prefix = jitcompiler.compute_prefix(ufl_element, tag, parameters)
+
     return classname.make_name(prefix, "dofmap", "main")
 
 
-def make_coordinate_mapping_jit_classname(ufl_mesh, tag, parameters):
+def make_coordinate_mapping_jit_classname(ufl_element, tag, parameters):
     from ffc import jitcompiler  # FIXME circular file dependency
-    kind, prefix = jitcompiler.compute_prefix(ufl_mesh, tag, parameters)
+    assert isinstance(ufl_element, ufl.FiniteElementBase)
+    kind, prefix = jitcompiler.compute_prefix(ufl_element, tag, parameters)
+
     return classname.make_name(prefix, "coordinate_mapping", "main")
 
 
-def make_all_element_classnames(prefix, elements, coordinate_elements, element_numbers, parameters):
+def make_all_element_classnames(prefix, elements, coordinate_elements, parameters):
     # Make unique classnames to match separately jit-compiled
     # module
 
@@ -91,8 +97,7 @@ def compute_ir(analysis, prefix, parameters, jit=False):
     assert isinstance(prefix, tuple)
 
     # Construct classnames for all element objects and coordinate mappings
-    classnames = make_all_element_classnames(prefix, elements, coordinate_elements, element_numbers,
-                                             parameters)
+    classnames = make_all_element_classnames(prefix, elements, coordinate_elements, parameters)
 
     # Skip processing elements if jitting forms
     # NB! it's important that this happens _after_ the element numbers and classnames

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -50,7 +50,7 @@ def make_dofmap_jit_classname(ufl_element, tag, parameters):
 
 def make_coordinate_mapping_jit_classname(ufl_mesh, tag, parameters):
     from ffc import jitcompiler  # FIXME circular file dependency
-    kind, prefix = jitcompiler.compute_prefix(ufl_mesh, tag, parameters, kind="coordinate_mapping")
+    kind, prefix = jitcompiler.compute_prefix(ufl_mesh, tag, parameters)
     return classname.make_name(prefix, "coordinate_mapping", "main")
 
 

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -55,7 +55,7 @@ def make_dofmap_jit_classname(ufl_element, tag, parameters):
 def make_coordinate_mapping_jit_classname(ufl_element, tag, parameters):
     from ffc import jitcompiler  # FIXME circular file dependency
     assert isinstance(ufl_element, ufl.FiniteElementBase)
-    kind, prefix = jitcompiler.compute_prefix(ufl_element, tag, parameters)
+    kind, prefix = jitcompiler.compute_prefix(ufl_element, tag, parameters, coordinate_mapping=True)
 
     return classname.make_name(prefix, "coordinate_mapping", "main")
 

--- a/ffc/jitcompiler.py
+++ b/ffc/jitcompiler.py
@@ -28,17 +28,9 @@ def generate(ufl_object, module_name, signature, parameters):
     """Callback function passed to dijitso.jit: generate code and return as strings."""
     logger.info("Calling FFC just-in-time (JIT) compiler.")
 
-    # Pick the generator for actual code for this object
-    if isinstance(ufl_object, ufl.Form):
-        compile_object = compiler.compile_form
-    elif isinstance(ufl_object, ufl.FiniteElementBase):
-        compile_object = compiler.compile_element
-    elif isinstance(ufl_object, ufl.Mesh):
-        compile_object = compiler.compile_coordinate_mapping
-
     # Return C code for requested ufl_object, and return any UFL objects
     # that ufl_objects needs, e.g. a form will require some elements.
-    code_h, code_c, dependent_ufl_objects = compile_object(
+    code_h, code_c, dependent_ufl_objects = compiler.compile_ufl_objects(
         ufl_object, prefix=(module_name, False), parameters=parameters, jit=True)
 
     # Jit compile dependent objects separately, but pass indirect=True

--- a/ffc/jitcompiler.py
+++ b/ffc/jitcompiler.py
@@ -110,7 +110,14 @@ def build(ufl_object, module_name, parameters):
 
 
 def compute_prefix(ufl_object, tag, parameters, coordinate_mapping=False):
-    """Compute the prefix (module name) for jit modules."""
+    """Compute the prefix (module name) for jit modules.
+
+    Note
+    ----
+    The parameter `coordinate_mapping` is used to force compilation of finite element
+    as a coordinate mapping element. There is no way to find this information
+    just by looking at type of `ufl_object` passed.
+    """
 
     # Get signature from ufl object
     if isinstance(ufl_object, ufl.Form):

--- a/ffc/jitcompiler.py
+++ b/ffc/jitcompiler.py
@@ -109,7 +109,7 @@ def build(ufl_object, module_name, parameters):
     return module
 
 
-def compute_prefix(ufl_object, tag, parameters):
+def compute_prefix(ufl_object, tag, parameters, coordinate_mapping=False):
     """Compute the prefix (module name) for jit modules."""
 
     # Get signature from ufl object
@@ -121,6 +121,9 @@ def compute_prefix(ufl_object, tag, parameters):
         # its coordinate element
         kind = "coordinate_mapping"
         object_signature = repr(ufl_object.ufl_coordinate_element())
+    elif coordinate_mapping and isinstance(ufl_object, ufl.FiniteElementBase):
+        object_signature = repr(ufl_object)
+        kind = "coordinate_mapping"
     elif isinstance(ufl_object, ufl.FiniteElementBase):
         kind = "element"
         object_signature = repr(ufl_object)

--- a/ffc/jitcompiler.py
+++ b/ffc/jitcompiler.py
@@ -109,7 +109,7 @@ def build(ufl_object, module_name, parameters):
     return module
 
 
-def compute_prefix(ufl_object, tag, parameters, kind=None):
+def compute_prefix(ufl_object, tag, parameters):
     """Compute the prefix (module name) for jit modules."""
 
     # Get signature from ufl object
@@ -120,11 +120,7 @@ def compute_prefix(ufl_object, tag, parameters, kind=None):
         # When coordinate mapping is represented by a Mesh, just getting
         # its coordinate element
         kind = "coordinate_mapping"
-        object_signature = repr(ufl_object.ufl_coordinate_element())  # ** must match below
-    elif kind == "coordinate_mapping" and isinstance(ufl_object, ufl.FiniteElementBase):
-        # When coordinate mapping is represented by its coordinate
-        # element
-        object_signature = repr(ufl_object)  # ** must match above
+        object_signature = repr(ufl_object.ufl_coordinate_element())
     elif isinstance(ufl_object, ufl.FiniteElementBase):
         kind = "element"
         object_signature = repr(ufl_object)

--- a/ffc/main.py
+++ b/ffc/main.py
@@ -78,16 +78,6 @@ parser.add_argument(
 parser.add_argument("ufl_file", nargs='+', help="UFL file(s) to be compiled")
 
 
-def compile_ufl_data(ufd, prefix, parameters):
-    if len(ufd.forms) > 0:
-        code_h, code_c = compiler.compile_form(
-            ufd.forms, ufd.object_names, prefix=(prefix, True), parameters=parameters)
-    else:
-        code_h, code_c = compiler.compile_element(
-            ufd.elements, ufd.object_names, prefix=(prefix, True), parameters=parameters)
-    return code_h, code_c
-
-
 def main(args=None):
     """Commandline tool for FFC."""
 
@@ -148,11 +138,13 @@ def _compile_files(args, parameters, enable_profile):
         # Load UFL file
         ufd = ufl.algorithms.load_ufl_file(filename)
 
-        # Previously wrapped in try-except, disabled to actually get information we need
-        # try:
-
         # Generate code
-        code_h, code_c = compile_ufl_data(ufd, prefix, parameters)
+        if len(ufd.forms) > 0:
+            code_h, code_c = compiler.compile_ufl_objects(
+                ufd.forms, prefix=(prefix, True), parameters=parameters)
+        else:
+            code_h, code_c = compiler.compile_ufl_objects(
+                ufd.elements, prefix=(prefix, True), parameters=parameters)
 
         # Write to file
         formatting.write_code(code_h, code_c, prefix, parameters)

--- a/ffc/main.py
+++ b/ffc/main.py
@@ -141,10 +141,10 @@ def _compile_files(args, parameters, enable_profile):
         # Generate code
         if len(ufd.forms) > 0:
             code_h, code_c = compiler.compile_ufl_objects(
-                ufd.forms, prefix=(prefix, True), parameters=parameters)
+                ufd.forms, ufd.object_names, prefix=(prefix, True), parameters=parameters)
         else:
             code_h, code_c = compiler.compile_ufl_objects(
-                ufd.elements, prefix=(prefix, True), parameters=parameters)
+                ufd.elements, ufd.object_names, prefix=(prefix, True), parameters=parameters)
 
         # Write to file
         formatting.write_code(code_h, code_c, prefix, parameters)


### PR DESCRIPTION
General method dispatched to specialised which dispatched to general again... I tried to remove this pattern in `compile_foo_...`

Also removed passing "kind" as argument where not needed (and could be found from type of ufl objects).

Dolfin cross-tested here https://github.com/FEniCS/dolfinx/commits/michal/ffc-compiler-clean