### PR TITLE
Merge dolfin_form functions into ufc_form

### DIFF
--- a/ffc/codegeneration/codegeneration.py
+++ b/ffc/codegeneration/codegeneration.py
@@ -15,18 +15,16 @@ UFC function from an intermediate representation (IR).
 import itertools
 import logging
 
-from ffc.codegeneration.coordinate_mapping import \
-    ufc_coordinate_mapping_generator
+from ffc.codegeneration.coordinate_mapping import ufc_coordinate_mapping_generator
 from ffc.codegeneration.dofmap import ufc_dofmap_generator
-from ffc.codegeneration.finite_element import \
-    generator as ufc_finite_element_generator
+from ffc.codegeneration.finite_element import generator as ufc_finite_element_generator
 from ffc.codegeneration.form import ufc_form_generator
 from ffc.codegeneration.integrals import ufc_integral_generator
 
 logger = logging.getLogger(__name__)
 
 
-def generate_code(ir, parameters, jit):
+def generate_code(analysis, object_names, ir, parameters, jit):
     """Generate code from intermediate representation."""
 
     logger.debug("Compiler stage 4: Generating code")
@@ -37,6 +35,9 @@ def generate_code(ir, parameters, jit):
     # Set code generation parameters
     # set_float_formatting(parameters["precision"])
     # set_exception_handling(parameters["convert_exceptions_to_warnings"])
+
+    # Extract data from analysis
+    form_data, elements, element_map, domains = analysis
 
     # Extract representations
     ir_finite_elements, ir_dofmaps, ir_coordinate_mappings, ir_integrals, ir_forms = ir
@@ -63,7 +64,18 @@ def generate_code(ir, parameters, jit):
 
     # Generate code for forms
     logger.debug("Generating code for forms")
-    code_forms = [ufc_form_generator(ir, parameters) for ir in ir_forms]
+    # FIXME: add coefficient names it IR
+    coefficient_names = []
+    # print(form_data)
+    # print(ir_forms[0])
+    for form in form_data:
+        names = [
+            object_names.get(id(obj), "w%d" % j) for j, obj in enumerate(form.reduced_coefficients)
+        ]
+        coefficient_names.append(names)
+    # print(forms_coefficient_names)
+    code_forms = [ufc_form_generator(ir, cnames, parameters) for ir, cnames in zip(ir_forms, coefficient_names)]
+    # code_forms = [ufc_form_generator(ir, parameters) for ir in ir_forms]
 
     # Extract additional includes
     includes = _extract_includes(full_ir, code_integrals, jit)

--- a/ffc/codegeneration/codegeneration.py
+++ b/ffc/codegeneration/codegeneration.py
@@ -66,16 +66,12 @@ def generate_code(analysis, object_names, ir, parameters, jit):
     logger.debug("Generating code for forms")
     # FIXME: add coefficient names it IR
     coefficient_names = []
-    # print(form_data)
-    # print(ir_forms[0])
     for form in form_data:
         names = [
             object_names.get(id(obj), "w%d" % j) for j, obj in enumerate(form.reduced_coefficients)
         ]
         coefficient_names.append(names)
-    # print(forms_coefficient_names)
     code_forms = [ufc_form_generator(ir, cnames, parameters) for ir, cnames in zip(ir_forms, coefficient_names)]
-    # code_forms = [ufc_form_generator(ir, parameters) for ir in ir_forms]
 
     # Extract additional includes
     includes = _extract_includes(full_ir, code_integrals, jit)

--- a/ffc/codegeneration/dolfin.py
+++ b/ffc/codegeneration/dolfin.py
@@ -31,7 +31,7 @@ def generate_wrappers(prefix, forms, common_function_space=False):
     code_h += """
 // Typedefs for convenience pointers to functions (factories)
 typedef ufc_function_space* (*ufc_function_space_factory_ptr)(void);
-typedef dolfin_form* (*dolfin_form_factory_ptr)(void);
+typedef ufc_form* (*ufc_form_factory_ptr)(void);
 
 """
 
@@ -105,7 +105,7 @@ def generate_namespace_typedefs(forms, prefix, common_function_space):
 
     # Combine data to typedef code
     typedefs = "\n".join(
-        "static const dolfin_form_factory_ptr {0}{1} = {0}{2};".format(prefix, fro, to)
+        "static const ufc_form_factory_ptr {0}{1} = {0}{2};".format(prefix, fro, to)
         for (to, fro) in pairs)
 
     # Keepin' it simple: Add typedef for function space factory if term applies
@@ -163,10 +163,10 @@ def generate_form(form, prefix, classname):
     blocks_h += [""]
 
     # Generate Form factory
-    code_h, code_c = generate_form_class(form, prefix, classname)
+    code_h = generate_form_class(form, prefix, classname)
 
     # Return code
-    return "\n".join(blocks_h) + code_h, "\n".join(blocks_c) + code_c
+    return "\n".join(blocks_h) + code_h, "\n".join(blocks_c)
 
 
 def generate_form_class(form, prefix, classname):
@@ -184,15 +184,12 @@ def generate_form_class(form, prefix, classname):
         "prefix": prefix,
         "classname": classname,
         "ufc_form": form.ufc_form_classname,
-        "coefficient_number": number,
-        "coefficient_name": name,
         "typedefs": typedefs
     }
 
     code_h = FORM_CLASS_TEMPLATE_DECL.format_map(args)
-    code_c = FORM_CLASS_TEMPLATE_IMPL.format_map(args)
 
-    return code_h, code_c
+    return code_h
 
 
 def generate_coefficient_map_data(form):
@@ -274,32 +271,9 @@ def generate_function_space_typedefs(form, prefix, classname):
 
 
 FORM_CLASS_TEMPLATE_DECL = """\
-dolfin_form* {prefix}{classname}(void);
+static const ufc_form_factory_ptr {prefix}{classname} = create_{ufc_form};
 
 {typedefs}
-"""
-
-FORM_CLASS_TEMPLATE_IMPL = """\
-// Return the number of the coefficient with this name. Returns -1 if name does not exist.
-static int {prefix}{classname}_coefficient_number(const char* name)
-{{
-{coefficient_number}
-}}
-
-// Return the name of the coefficient with this number. Returns NULL if index is out-of-range.
-static const char* {prefix}{classname}_coefficient_name(int i)
-{{
-{coefficient_name}
-}}
-
-dolfin_form* {prefix}{classname}()
-{{
-  dolfin_form* form = (dolfin_form*) malloc(sizeof(*form));
-  form->form = create_{ufc_form};
-  form->coefficient_name_map = {prefix}{classname}_coefficient_name;
-  form->coefficient_number_map = {prefix}{classname}_coefficient_number;
-  return form;
-}}
 """
 
 FUNCTION_SPACE_TEMPLATE_DECL = """\

--- a/ffc/codegeneration/dolfin.py
+++ b/ffc/codegeneration/dolfin.py
@@ -172,9 +172,6 @@ def generate_form(form, prefix, classname):
 def generate_form_class(form, prefix, classname):
     """Generate dolfin wrapper code for a single Form class."""
 
-    # Generate data for coefficient assignments
-    (number, name) = generate_coefficient_map_data(form)
-
     # Generate typedefs for FunctionSpace subclasses for Coefficients
     typedefs = "// Typedefs (function spaces for {})\n".format(
         classname) + generate_function_space_typedefs(form, prefix, classname)
@@ -190,31 +187,6 @@ def generate_form_class(form, prefix, classname):
     code_h = FORM_CLASS_TEMPLATE_DECL.format_map(args)
 
     return code_h
-
-
-def generate_coefficient_map_data(form):
-    """Generate data for code for the functions Form::coefficient_number
-    and Form::coefficient_name."""
-
-    # Handle case of no coefficients
-    if form.num_coefficients == 0:
-        num = "  return -1;"
-        name = "  return NULL;"
-        return (num, name)
-
-    # Otherwise create switch
-    ifstr = "if "
-    num = ""
-    name = '  switch (i)\n  {\n'
-    for i, coeff in enumerate(form.coefficient_names):
-        num += '  %s(strcmp(name, "%s") == 0)\n    return %d;\n' % (ifstr, coeff, i)
-        name += '  case %d:\n    return "%s";\n' % (i, coeff)
-        ifstr = 'else if '
-
-    num += "\n  return -1;"
-    name += "  }\n  return NULL;"
-
-    return (num, name)
 
 
 def extract_coefficient_spaces(forms):

--- a/ffc/codegeneration/form.py
+++ b/ffc/codegeneration/form.py
@@ -110,11 +110,9 @@ class UFCForm:
         if ir["num_coefficients"] == 0:
             name = "  return NULL;"
         else:
-            ifstr = "if "
             name = '  switch (i)\n  {\n'
             for i, coeff in enumerate(cnames):
                 name += '  case %d:\n    return "%s";\n' % (i, coeff)
-                ifstr = 'else if '
             name += "  }\n  return NULL;"
         return name
 

--- a/ffc/codegeneration/form.py
+++ b/ffc/codegeneration/form.py
@@ -88,6 +88,36 @@ class UFCForm:
             code = [L.Comment(msg), L.Return(-1)]
         return code
 
+    def generate_coefficient_name_to_position_map(self, L, ir, cnames):
+        """Generate code that maps name to number."""
+        assert ir["num_coefficients"] == len(cnames)
+        if ir["num_coefficients"] == 0:
+            num = "  return -1;"
+        else:
+            ifstr = "if "
+            num = ""
+            for i, coeff in enumerate(cnames):
+                num += '  %s(strcmp(name, "%s") == 0)\n    return %d;\n' % (ifstr, coeff, i)
+                ifstr = 'else if '
+            num += "\n  return -1;"
+        return num
+
+    def generate_coefficient_position_to_name_map(self, L, ir, cnames):
+        """Generate code that maps int to name string."""
+        assert ir["num_coefficients"] == len(cnames)
+
+        # Handle case of no coefficients
+        if ir["num_coefficients"] == 0:
+            name = "  return NULL;"
+        else:
+            ifstr = "if "
+            name = '  switch (i)\n  {\n'
+            for i, coeff in enumerate(cnames):
+                name += '  case %d:\n    return "%s";\n' % (i, coeff)
+                ifstr = 'else if '
+            name += "  }\n  return NULL;"
+        return name
+
     def create_coordinate_finite_element(self, L, ir):
         classnames = ir["create_coordinate_finite_element"]
         assert len(classnames) == 1
@@ -163,7 +193,7 @@ class UFCForm:
         return generate_return_new_switch(L, subdomain_id, classnames, subdomain_ids)
 
 
-def ufc_form_generator(ir, parameters):
+def ufc_form_generator(ir, cnames, parameters):
     """Generate UFC code for a form"""
 
     factory_name = ir["classname"]
@@ -186,6 +216,9 @@ def ufc_form_generator(ir, parameters):
     statements = generator.original_coefficient_position(L, ir)
     assert isinstance(statements, list)
     d["original_coefficient_position"] = L.StatementList(statements)
+
+    d["coefficient_number_map"] = generator.generate_coefficient_name_to_position_map(L, ir, cnames)
+    d["coefficient_name_map"] = generator.generate_coefficient_position_to_name_map(L, ir, cnames)
 
     d["create_coordinate_finite_element"] = generator.create_coordinate_finite_element(L, ir)
     d["coordinate_finite_element_declaration"] = generator.coordinate_finite_element_declaration(L, ir)

--- a/ffc/codegeneration/form_template.py
+++ b/ffc/codegeneration/form_template.py
@@ -16,6 +16,18 @@ int original_coefficient_position_{factory_name}(int i)
 {original_coefficient_position}
 }}
 
+// Return the number of the coefficient with this name. Returns -1 if name does not exist.
+int coefficient_number_{factory_name}(const char* name)
+{{
+{coefficient_number_map}
+}}
+
+// Return the name of the coefficient with this number. Returns NULL if index is out-of-range.
+const char* coefficient_name_{factory_name}(int i)
+{{
+{coefficient_name_map}
+}}
+
 {coordinate_finite_element_declaration}
 ufc_finite_element* create_coordinate_finite_element_{factory_name}(void)
 {{
@@ -104,6 +116,10 @@ ufc_form* create_{factory_name}(void)
   form->rank = {rank};
   form->num_coefficients = {num_coefficients};
   form->original_coefficient_position = original_coefficient_position_{factory_name};
+
+  form->coefficient_name_map = coefficient_name_{factory_name};
+  form->coefficient_number_map = coefficient_number_{factory_name};
+
   form->create_coordinate_finite_element = create_coordinate_finite_element_{factory_name};
   form->create_coordinate_dofmap = create_coordinate_dofmap_{factory_name};
   form->create_coordinate_mapping = create_coordinate_mapping_{factory_name};

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -190,6 +190,8 @@ const char* signature;
 int rank;
 int num_coefficients;
 int (*original_coefficient_position)(int i);
+const char* (*coefficient_name_map)(int i);
+int (*coefficient_number_map)(const char* name);
 ufc_finite_element* (*create_coordinate_finite_element)(void);
 ufc_dofmap* (*create_coordinate_dofmap)(void);
 ufc_coordinate_mapping* (*create_coordinate_mapping)(void);

--- a/ffc/codegeneration/ufc.h
+++ b/ffc/codegeneration/ufc.h
@@ -567,18 +567,6 @@ extern "C"
     ufc_coordinate_mapping* (*coordinate_mapping)(void);
   } ufc_function_space;
 
-  typedef struct dolfin_form
-  {
-    // Pointer to factory function that returns a new ufc_form
-    ufc_form* (*form)(void);
-
-    // Pointer to function that returns name of coefficient i
-    const char* (*coefficient_name_map)(int i);
-
-    // Pointer to function that returns index of coefficient
-    int (*coefficient_number_map)(const char* name);
-  } dolfin_form;
-
 #ifdef __cplusplus
 #undef restrict
 }

--- a/ffc/codegeneration/ufc.h
+++ b/ffc/codegeneration/ufc.h
@@ -471,6 +471,12 @@ extern "C"
     ///
     int (*original_coefficient_position)(int i);
 
+    // Return name of coefficient i
+    const char* (*coefficient_name_map)(int i);
+
+    // Return index of named coefficient
+    int (*coefficient_number_map)(const char* name);
+
     // FIXME: Remove and just use 'create_coordinate_mapping'
     /// Create a new finite element for parameterization of coordinates
     ufc_finite_element* (*create_coordinate_finite_element)(void);

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -131,7 +131,7 @@ def compile_ufl_objects(ufl_objects: Union[List, Tuple],
 
     # Stage 4: code generation
     cpu_time = time()
-    code = generate_code(ir, parameters, jit)
+    code = generate_code(analysis, object_names, ir, parameters, jit)
     _print_timing(4, time() - cpu_time)
 
     # Stage 4.1: generate convenience wrappers, e.g. for DOLFIN


### PR DESCRIPTION
`dolfin_form` was basically `ufc_form` with two extra methods for handling coefficients. These have now been added to `ufc_form`.