### PR TITLE
Use namedtuple to improve code readability

### DIFF
--- a/ffc/analysis.py
+++ b/ffc/analysis.py
@@ -89,7 +89,9 @@ def analyze_ufl_objects(ufl_objects: Union[List[ufl.form.Form], List[ufl.FiniteE
 
     analyze_ufl_data = namedtuple(
         'analyze_ufl_data', ['form_data', 'unique_elements', 'element_numbers', 'unique_coordinate_elements'])
-    return analyze_ufl_data(form_datas, unique_elements, element_numbers, unique_coordinate_elements)
+    return analyze_ufl_data(form_data=form_datas, unique_elements=unique_elements,
+                            element_numbers=element_numbers,
+                            unique_coordinate_elements=unique_coordinate_elements)
 
 
 def _analyze_form(form: ufl.form.Form, parameters: Dict) -> ufl.algorithms.formdata.FormData:

--- a/ffc/analysis.py
+++ b/ffc/analysis.py
@@ -14,8 +14,9 @@ form representation type.
 
 import logging
 import os
-from typing import Dict, List, Tuple, Union
 import warnings
+from collections import namedtuple
+from typing import Dict, List, Tuple, Union
 
 import numpy
 
@@ -63,13 +64,11 @@ def analyze_ufl_objects(ufl_objects: Union[List[ufl.form.Form], List[ufl.FiniteE
         # Extract coordinate elements across all forms
         for form_data in form_datas:
             unique_coordinate_elements.update(form_data.coordinate_elements)
-
     elif isinstance(ufl_objects[0], ufl.FiniteElementBase):
         elements = ufl_objects
 
         # Extract unique (sub)elements
         unique_elements.update(ufl.algorithms.analysis.extract_sub_elements(elements))
-
     elif isinstance(ufl_objects[0], ufl.Mesh):
         meshes = ufl_objects
 
@@ -88,7 +87,9 @@ def analyze_ufl_objects(ufl_objects: Union[List[ufl.form.Form], List[ufl.FiniteE
     # Compute element numbers
     element_numbers = {element: i for i, element in enumerate(unique_elements)}
 
-    return form_datas, unique_elements, element_numbers, unique_coordinate_elements
+    analyze_ufl_data = namedtuple(
+        'analyze_ufl_data', ['form_data', 'unique_elements', 'element_numbers', 'unique_coordinate_elements'])
+    return analyze_ufl_data(form_datas, unique_elements, element_numbers, unique_coordinate_elements)
 
 
 def _analyze_form(form: ufl.form.Form, parameters: Dict) -> ufl.algorithms.formdata.FormData:

--- a/ffc/codegeneration/codegeneration.py
+++ b/ffc/codegeneration/codegeneration.py
@@ -39,28 +39,25 @@ def generate_code(analysis, object_names, ir, parameters, jit):
     # Extract data from analysis
     form_data, elements, element_map, domains = analysis
 
-    # Extract representations
-    ir_finite_elements, ir_dofmaps, ir_coordinate_mappings, ir_integrals, ir_forms = ir
-
     # Generate code for finite_elements
-    logger.debug("Generating code for {} finite_element(s)".format(len(ir_finite_elements)))
+    logger.debug("Generating code for {} finite_element(s)".format(len(ir.elements)))
     code_finite_elements = [
-        ufc_finite_element_generator(ir, parameters) for ir in ir_finite_elements
+        ufc_finite_element_generator(ir, parameters) for ir in ir.elements
     ]
 
     # Generate code for dofmaps
-    logger.debug("Generating code for {} dofmap(s)".format(len(ir_dofmaps)))
-    code_dofmaps = [ufc_dofmap_generator(ir, parameters) for ir in ir_dofmaps]
+    logger.debug("Generating code for {} dofmap(s)".format(len(ir.dofmaps)))
+    code_dofmaps = [ufc_dofmap_generator(ir, parameters) for ir in ir.dofmaps]
 
     # Generate code for coordinate_mappings
-    logger.debug("Generating code for {} coordinate_mapping(s)".format(len(ir_coordinate_mappings)))
+    logger.debug("Generating code for {} coordinate_mapping(s)".format(len(ir.coordinate_mappings)))
     code_coordinate_mappings = [
-        ufc_coordinate_mapping_generator(ir, parameters) for ir in ir_coordinate_mappings
+        ufc_coordinate_mapping_generator(ir, parameters) for ir in ir.coordinate_mappings
     ]
 
     # Generate code for integrals
     logger.debug("Generating code for integrals")
-    code_integrals = [ufc_integral_generator(ir, parameters) for ir in ir_integrals]
+    code_integrals = [ufc_integral_generator(ir, parameters) for ir in ir.integrals]
 
     # Generate code for forms
     logger.debug("Generating code for forms")
@@ -71,7 +68,7 @@ def generate_code(analysis, object_names, ir, parameters, jit):
             object_names.get(id(obj), "w%d" % j) for j, obj in enumerate(form.reduced_coefficients)
         ]
         coefficient_names.append(names)
-    code_forms = [ufc_form_generator(ir, cnames, parameters) for ir, cnames in zip(ir_forms, coefficient_names)]
+    code_forms = [ufc_form_generator(ir, cnames, parameters) for ir, cnames in zip(ir.forms, coefficient_names)]
 
     # Extract additional includes
     includes = _extract_includes(full_ir, code_integrals, jit)

--- a/ffc/codegeneration/codegeneration.py
+++ b/ffc/codegeneration/codegeneration.py
@@ -14,10 +14,13 @@ UFC function from an intermediate representation (IR).
 
 import itertools
 import logging
+from collections import namedtuple
 
-from ffc.codegeneration.coordinate_mapping import ufc_coordinate_mapping_generator
+from ffc.codegeneration.coordinate_mapping import \
+    ufc_coordinate_mapping_generator
 from ffc.codegeneration.dofmap import ufc_dofmap_generator
-from ffc.codegeneration.finite_element import generator as ufc_finite_element_generator
+from ffc.codegeneration.finite_element import \
+    generator as ufc_finite_element_generator
 from ffc.codegeneration.form import ufc_form_generator
 from ffc.codegeneration.integrals import ufc_integral_generator
 
@@ -29,15 +32,10 @@ def generate_code(analysis, object_names, ir, parameters, jit):
 
     logger.debug("Compiler stage 4: Generating code")
 
-    full_ir = ir
-
     # FIXME: This has global side effects
     # Set code generation parameters
     # set_float_formatting(parameters["precision"])
     # set_exception_handling(parameters["convert_exceptions_to_warnings"])
-
-    # Extract data from analysis
-    form_data, elements, element_map, domains = analysis
 
     # Generate code for finite_elements
     logger.debug("Generating code for {} finite_element(s)".format(len(ir.elements)))
@@ -63,7 +61,7 @@ def generate_code(analysis, object_names, ir, parameters, jit):
     logger.debug("Generating code for forms")
     # FIXME: add coefficient names it IR
     coefficient_names = []
-    for form in form_data:
+    for form in analysis.form_data:
         names = [
             object_names.get(id(obj), "w%d" % j) for j, obj in enumerate(form.reduced_coefficients)
         ]
@@ -71,14 +69,17 @@ def generate_code(analysis, object_names, ir, parameters, jit):
     code_forms = [ufc_form_generator(ir, cnames, parameters) for ir, cnames in zip(ir.forms, coefficient_names)]
 
     # Extract additional includes
-    includes = _extract_includes(full_ir, code_integrals, jit)
+    includes = _extract_includes(ir, code_integrals, jit)
 
-    return (code_finite_elements, code_dofmaps, code_coordinate_mappings, code_integrals,
-            code_forms, includes)
+    code_blocks = namedtuple('code_blocks', ['elements', 'dofmaps',
+                                             'coordinate_mappings', 'integrals', 'forms', 'includes'])
+    return code_blocks(elements=code_finite_elements, dofmaps=code_dofmaps,
+                       coordinate_mappings=code_coordinate_mappings, integrals=code_integrals,
+                       forms=code_forms, includes=includes)
 
 
 def _extract_includes(full_ir, code_integrals, jit):
-    ir_finite_elements, ir_dofmaps, ir_coordinate_mappings, ir_integrals, ir_forms = full_ir
+    # ir_finite_elements, ir_dofmaps, ir_coordinate_mappings, ir_integrals, ir_forms = full_ir
 
     # Includes added by representations
     includes = set()
@@ -88,15 +89,15 @@ def _extract_includes(full_ir, code_integrals, jit):
     # Includes for dependencies in jit mode
     if jit:
         dep_includes = set()
-        for ir in ir_finite_elements:
+        for ir in full_ir.elements:
             dep_includes.update(_finite_element_jit_includes(ir))
-        for ir in ir_dofmaps:
+        for ir in full_ir.dofmaps:
             dep_includes.update(_dofmap_jit_includes(ir))
-        for ir in ir_coordinate_mappings:
+        for ir in full_ir.coordinate_mappings:
             dep_includes.update(_coordinate_mapping_jit_includes(ir))
-        # for ir in ir_integrals:
+        # for ir in full_ir.integrals:
         #    dep_includes.update(_integral_jit_includes(ir))
-        for ir in ir_forms:
+        for ir in full_ir.forms:
             dep_includes.update(_form_jit_includes(ir))
         includes.update(['#include "{}"'.format(inc) for inc in dep_includes])
 

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -4,13 +4,13 @@
 # This file is part of FFC (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-"""Main interface for compilation
-of forms and breaking the compilation into several sequential stages.
-The output of each stage is the input of the next stage.
+"""Main interface for compilation of forms and breaking the compilation into
+several sequential stages. The output of each stage is the input of the next
+stage.
 
 Compiler stages:
 
-#. Language, parsing
+0. Language, parsing
 
    - Input:  Python code or .ufl file
    - Output: UFL form
@@ -18,7 +18,7 @@ Compiler stages:
    This stage consists of parsing and expressing a form in the UFL form
    language. This stage is handled by UFL.
 
-#. Analysis
+1. Analysis
 
    - Input:  UFL form
    - Output: Preprocessed UFL form and FormData (metadata)
@@ -26,7 +26,7 @@ Compiler stages:
    This stage preprocesses the UFL form and extracts form metadata. It
    may also perform simplifications on the form.
 
-#. Code representation
+2. Code representation
 
    - Input:  Preprocessed UFL form and FormData (metadata)
    - Output: Intermediate Representation (IR)
@@ -40,7 +40,7 @@ Compiler stages:
    The IR is stored as a dictionary, mapping names of UFC functions to
    data needed for generation of the corresponding code.
 
-#. Code generation
+3. Code generation
 
    - Input:  Intermediate Representation (IR)
    - Output: C code
@@ -51,7 +51,7 @@ Compiler stages:
    The code is stored as a dictionary, mapping names of UFC functions to
    strings containing the C code of the body of each function.
 
-#. Code formatting
+4. Code formatting
 
    - Input:  C code
    - Output: C code files
@@ -129,12 +129,12 @@ def compile_ufl_objects(ufl_objects: Union[List, Tuple],
     ir = compute_ir(analysis, prefix, parameters, jit)
     _print_timing(2, time() - cpu_time)
 
-    # Stage 4: code generation
+    # Stage 3: code generation
     cpu_time = time()
     code = generate_code(analysis, object_names, ir, parameters, jit)
     _print_timing(4, time() - cpu_time)
 
-    # Stage 4.1: generate convenience wrappers, e.g. for DOLFIN
+    # Stage 3.1: generate convenience wrappers, e.g. for DOLFIN
     cpu_time = time()
 
     # Extract class names from the IR and add to a dict
@@ -151,7 +151,7 @@ def compile_ufl_objects(ufl_objects: Union[List, Tuple],
 
     _print_timing(4.1, time() - cpu_time)
 
-    # Stage 5: format code
+    # Stage 4: format code
     cpu_time = time()
     code_h, code_c = format_code(code, wrapper_code, prefix, parameters)
     _print_timing(5, time() - cpu_time)

--- a/ffc/formatting.py
+++ b/ffc/formatting.py
@@ -18,6 +18,7 @@ import logging
 import os
 import pprint
 import textwrap
+from collections import namedtuple
 
 from ffc import __version__ as FFC_VERSION
 from ffc.codegeneration import __version__ as UFC_VERSION
@@ -60,14 +61,10 @@ c_extern_post = """
 """
 
 
-def format_code(code, wrapper_code, prefix, parameters):
+def format_code(code: namedtuple, wrapper_code, prefix, parameters):
     """Format given code in UFC format. Returns two strings with header and source file contents."""
 
     logger.debug("Compiler stage 5: Formatting code")
-
-    # Extract code
-    (code_finite_elements, code_dofmaps, code_coordinate_mappings, code_integrals, code_forms,
-     includes) = code
 
     # Generate code for comment at top of file
     code_h_pre = _generate_comment(parameters) + "\n"
@@ -83,7 +80,7 @@ def format_code(code, wrapper_code, prefix, parameters):
     code_c_pre += scalar_type
 
     # Generate includes and add to preamble
-    includes_h, includes_c = _generate_includes(includes, parameters)
+    includes_h, includes_c = _generate_includes(code.includes, parameters)
     code_h_pre += includes_h
     code_c_pre += includes_c
 
@@ -92,24 +89,24 @@ def format_code(code, wrapper_code, prefix, parameters):
     code_h_post = c_extern_post
 
     # Add code for new finite_elements
-    code_h = "".join([e[0] for e in code_finite_elements])
-    code_c = "".join([e[1] for e in code_finite_elements])
+    code_h = "".join([e[0] for e in code.elements])
+    code_c = "".join([e[1] for e in code.elements])
 
     # Add code for dofmaps
-    code_h += "".join([e[0] for e in code_dofmaps])
-    code_c += "".join([e[1] for e in code_dofmaps])
+    code_h += "".join([e[0] for e in code.dofmaps])
+    code_c += "".join([e[1] for e in code.dofmaps])
 
     # Add code for code_coordinate mappings
-    code_h += "".join([c[0] for c in code_coordinate_mappings])
-    code_c += "".join([c[1] for c in code_coordinate_mappings])
+    code_h += "".join([c[0] for c in code.coordinate_mappings])
+    code_c += "".join([c[1] for c in code.coordinate_mappings])
 
     # Add code for integrals
-    code_h += "".join([integral[0] for integral in code_integrals])
-    code_c += "".join([integral[1] for integral in code_integrals])
+    code_h += "".join([integral[0] for integral in code.integrals])
+    code_c += "".join([integral[1] for integral in code.integrals])
 
     # Add code for form
-    code_h += "".join([form[0] for form in code_forms])
-    code_c += "".join([form[1] for form in code_forms])
+    code_h += "".join([form[0] for form in code.forms])
+    code_c += "".join([form[1] for form in code.forms])
 
     # Add wrappers
     if wrapper_code:

--- a/ffc/wrappers.py
+++ b/ffc/wrappers.py
@@ -6,24 +6,21 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import logging
+from collections import namedtuple
 
 from ffc.codegeneration import dolfin
 
 logger = logging.getLogger(__name__)
 
 
-def generate_wrapper_code(analysis, prefix, object_names, classnames, parameters):
-
+def generate_wrapper_code(analysis: namedtuple, prefix, object_names, classnames, parameters):
     logger.info("Compiler stage 4.1: Generating additional wrapper code for {}".format(object_names))
-
-    # Extract data from analysis
-    form_data, elements, element_map, domains = analysis
-
-    if not form_data:
-        capsules = _encapsulate_elements(elements, object_names, classnames)
+    if not analysis.form_data:
+        capsules = _encapsulate_elements(analysis.unique_elements, object_names, classnames)
         common_space = False
     else:
-        capsules, common_space = _encapsule_forms(prefix, object_names, classnames, form_data, element_map)
+        capsules, common_space = _encapsule_forms(
+            prefix, object_names, classnames, analysis.form_data, analysis.element_numbers)
 
     # Generate code
     code_h, code_c = dolfin.generate_wrappers(prefix, capsules, common_space)


### PR DESCRIPTION
`namedtuple` tidies up cases where a function returns a long tuple. 