### PR TITLE
Remove crosslinking 

### DIFF
--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -6,16 +6,15 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import importlib
-import sys
-import os
 import logging
-import time
-import cffi
+import os
 import pathlib
+import sys
+import time
 
-import ufl
+import cffi
+
 import ffc
-from ffc.analysis import analyze_ufl_objects
 
 logger = logging.getLogger(__name__)
 
@@ -218,42 +217,6 @@ ufc_custom_integral* (*create_custom_integral)(int subdomain_id);
 """
 
 
-def get_ufl_dependencies(ufl_objects, parameters):
-
-    _, unique_elements, _, unique_coordinate_elements = analyze_ufl_objects(ufl_objects, parameters)
-
-    mesh_id = None
-    if isinstance(ufl_objects[0], ufl.Form):
-        mesh_id = ufl_objects[0].ufl_domain().ufl_id()
-    elif isinstance(ufl_objects[0], ufl.Mesh):
-        mesh_id = ufl_objects[0].ufl_id()
-    unique_meshes = []
-    if mesh_id is not None:
-        unique_meshes = [ufl.Mesh(element, ufl_id=mesh_id)
-                         for element in unique_coordinate_elements]
-
-    # Avoid returning self as dependency for infinite recursion
-    unique_elements = tuple(element for element in unique_elements
-                            if element not in ufl_objects)
-
-    unique_meshes = tuple(mesh for mesh in unique_meshes if mesh not in ufl_objects)
-
-    logger.info('Dependencies = ' + str(unique_elements) + str(unique_meshes))
-
-    depfiles = []
-    for el in unique_elements:
-        objects, module = compile_elements([el], parameters=parameters)
-        libname = pathlib.Path(module.__file__).stem
-        depfiles.append(libname[3:])
-
-    for cm in unique_meshes:
-        objects, module = compile_coordinate_maps([cm], parameters=parameters)
-        libname = pathlib.Path(module.__file__).stem
-        depfiles.append(libname[3:])
-
-    return depfiles
-
-
 def get_cached_module(module_name, object_names, parameters):
     cache_dir = pathlib.Path(parameters.get("cache_dir",
                                             "compile_cache"))
@@ -301,10 +264,6 @@ def compile_elements(elements, module_name=None, parameters=None):
     """Compile a list of UFL elements and dofmaps into UFC Python objects"""
     p = ffc.parameters.validate_parameters(parameters)
 
-    depfiles = []
-    if p['crosslink']:
-        depfiles = get_ufl_dependencies(elements, p)
-
     logger.info('Compiling elements: ' + str(elements))
 
     # Get a signature for these elements
@@ -332,7 +291,7 @@ def compile_elements(elements, module_name=None, parameters=None):
         decl += element_template.format(name=names[i * 2])
         decl += dofmap_template.format(name=names[i * 2 + 1])
 
-    objects, module = _compile_objects(decl, elements, names, module_name, p, depfiles)
+    objects, module = _compile_objects(decl, elements, names, module_name, p)
     # Pair up elements with dofmaps
     objects = list(zip(objects[::2], objects[1::2]))
     return objects, module
@@ -341,10 +300,6 @@ def compile_elements(elements, module_name=None, parameters=None):
 def compile_forms(forms, module_name=None, parameters=None):
     """Compile a list of UFL forms into UFC Python objects"""
     p = ffc.parameters.validate_parameters(parameters)
-
-    depfiles = []
-    if p['crosslink']:
-        depfiles = get_ufl_dependencies(forms, p)
 
     logger.info('Compiling forms: ' + str(forms))
 
@@ -367,16 +322,12 @@ def compile_forms(forms, module_name=None, parameters=None):
     for name in form_names:
         decl += form_template.format(name=name)
 
-    return _compile_objects(decl, forms, form_names, module_name, p, depfiles)
+    return _compile_objects(decl, forms, form_names, module_name, p)
 
 
 def compile_coordinate_maps(meshes, module_name=None, parameters=None):
     """Compile a list of UFL coordinate mappings into UFC Python objects"""
     p = ffc.parameters.validate_parameters(parameters)
-
-    depfiles = []
-    if (p['crosslink']):
-        depfiles = get_ufl_dependencies(meshes, p)
 
     logger.info('Compiling cmaps: ' + str(meshes))
 
@@ -397,28 +348,22 @@ def compile_coordinate_maps(meshes, module_name=None, parameters=None):
     for name in cmap_names:
         decl += cmap_template.format(name=name)
 
-    return _compile_objects(decl, meshes, cmap_names, module_name, p, depfiles)
+    return _compile_objects(decl, meshes, cmap_names, module_name, p)
 
 
-def _compile_objects(decl, ufl_objects, object_names, module_name, parameters, link=[]):
+def _compile_objects(decl, ufl_objects, object_names, module_name, parameters):
 
     cache_dir = pathlib.Path(parameters.get("cache_dir",
                                             "compile_cache"))
     cache_dir = cache_dir.expanduser()
 
-    # Cancel crosslinking on MacOS, not needed
-    if sys.platform == 'darwin':
-        link = []
-
-    _, code_body = ffc.compiler.compile_ufl_objects(ufl_objects, prefix="JIT", parameters=parameters,
-                                                    jit=parameters['crosslink'])
+    _, code_body = ffc.compiler.compile_ufl_objects(ufl_objects, prefix="JIT", parameters=parameters)
 
     ffibuilder = cffi.FFI()
     ffibuilder.set_source(
         module_name, code_body, include_dirs=[ffc.codegeneration.get_include_path()],
         library_dirs=[str(cache_dir.absolute())],
-        runtime_library_dirs=[str(cache_dir.absolute())], libraries=link,
-        extra_compile_args=['-g0'])  # turn off -g
+        runtime_library_dirs=[str(cache_dir.absolute())], extra_compile_args=['-g0'])  # turn off -g
 
     ffibuilder.cdef(decl)
 

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -86,8 +86,7 @@ def _print_timing(stage, timing):
 def compile_ufl_objects(ufl_objects: Union[List, Tuple],
                         object_names: Dict = {},
                         prefix: str = None,
-                        parameters: Dict = None,
-                        jit: bool = False):
+                        parameters: Dict = None):
     """Generate UFC code for a given UFL objects.
 
     Parameters
@@ -103,8 +102,7 @@ def compile_ufl_objects(ufl_objects: Union[List, Tuple],
 
     # Note that jit will always pass validated parameters so
     # this is only for commandline and direct call from python
-    if not jit:
-        parameters = validate_parameters(parameters)
+    parameters = validate_parameters(parameters)
 
     # Check input arguments
     if not isinstance(ufl_objects, (list, tuple)):
@@ -126,12 +124,12 @@ def compile_ufl_objects(ufl_objects: Union[List, Tuple],
 
     # Stage 2: intermediate representation
     cpu_time = time()
-    ir = compute_ir(analysis, prefix, parameters, jit)
+    ir = compute_ir(analysis, prefix, parameters)
     _print_timing(2, time() - cpu_time)
 
     # Stage 3: code generation
     cpu_time = time()
-    code = generate_code(analysis, object_names, ir, parameters, jit)
+    code = generate_code(analysis, object_names, ir, parameters)
     _print_timing(4, time() - cpu_time)
 
     # Stage 3.1: generate convenience wrappers, e.g. for DOLFIN

--- a/ffc/formatting.py
+++ b/ffc/formatting.py
@@ -80,7 +80,7 @@ def format_code(code: namedtuple, wrapper_code, prefix, parameters):
     code_c_pre += scalar_type
 
     # Generate includes and add to preamble
-    includes_h, includes_c = _generate_includes(code.includes, parameters)
+    includes_h, includes_c = _generate_includes(parameters)
     code_h_pre += includes_h
     code_c_pre += includes_c
 
@@ -161,7 +161,7 @@ def _generate_comment(parameters):
     return comment
 
 
-def _generate_includes(includes, parameters):
+def _generate_includes(parameters):
 
     default_h_includes = [
         "#include <ufc.h>",
@@ -179,7 +179,7 @@ def _generate_includes(includes, parameters):
     # external_includes = set(
     #     "#include <%s>" % inc for inc in parameters.get("external_includes", ()))
 
-    s_h = set(default_h_includes) | includes
+    s_h = set(default_h_includes)
     s_c = set(default_c_includes)
 
     # s2 = external_includes - s

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -73,7 +73,7 @@ def make_all_element_classnames(prefix, elements, coordinate_elements, parameter
     return classnames
 
 
-def compute_ir(analysis: namedtuple, prefix, parameters, jit=False):
+def compute_ir(analysis: namedtuple, prefix, parameters):
     """Compute intermediate representation."""
     logger.info("Compiler stage 2: Computing intermediate representation")
 
@@ -83,21 +83,6 @@ def compute_ir(analysis: namedtuple, prefix, parameters, jit=False):
 
     coordinate_elements = analysis.unique_coordinate_elements
     elements = analysis.unique_elements
-
-    # Skip processing elements if jitting forms
-    # NB! it's important that this happens _after_ the element numbers and classnames
-    # above have been created.
-    if jit and analysis.form_data:
-        # Drop some processing
-        elements = []
-        coordinate_elements = []
-    elif jit and coordinate_elements:
-        # While we may get multiple coordinate elements during command
-        # line action, or during form jit, not so during coordinate
-        # mapping jit
-        assert len(coordinate_elements) == 1, "Expecting only one coordinate map data instance during jit."
-        # Drop some processing
-        elements = []
 
     # Compute representation of elements
     logger.info("Computing representation of {} elements".format(len(elements)))

--- a/ffc/parameters.py
+++ b/ffc/parameters.py
@@ -35,8 +35,6 @@ _FFC_GENERATE_PARAMETERS = {
     "timeout": 10,
     # ':' separated list of include filenames to add to generated code
     "external_includes": "",
-    # Whether to crosslink JIT libraries or build standalone
-    "crosslink": True,
 }
 _FFC_BUILD_PARAMETERS = {
     "cpp_optimize": True,  # optimization for the C++ compiler

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -129,7 +129,7 @@ def test_laplace_bilinear_form_2d(mode, expected_result):
     a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
     forms = [a]
     compiled_forms, module = ffc.codegeneration.jit.compile_forms(
-        forms, parameters={'scalar_type': mode, 'cache_dir': './compile_cache', 'crosslink': True})
+        forms, parameters={'scalar_type': mode, 'cache_dir': './compile_cache'})
 
     for f, compiled_f in zip(forms, compiled_forms):
         assert compiled_f.rank == len(f.arguments())


### PR DESCRIPTION
Removes linking between libraries.

Complicated matter for only small gain. Can be added later (and make simpler) if needed.