### PR TITLE
Fix integral code with conditionals (complex mode)

### DIFF
--- a/ffc/codegeneration/uflacsgenerator.py
+++ b/ffc/codegeneration/uflacsgenerator.py
@@ -524,25 +524,25 @@ class IntegralGenerator(object):
                 # Get previously visited operands
                 vops = [self.get_var(num_points, op) for op in v.ufl_operands]
 
-                # get parent
-                parent_id = F.in_edges[i]
-                parent_exp = None
-                if parent_id:
-                    parent_exp = F.nodes.get(parent_id[0])['expression']
+                # get parent operand
+                pid = F.in_edges[i][0] if F.in_edges[i] else -1
+                if pid and pid > i:
+                    parent_exp = F.nodes.get(pid)['expression']
+                else:
+                    parent_exp = None
 
                 # Mapping UFL operator to target language
                 self._ufl_names.add(v._ufl_handler_name_)
                 vexpr = self.backend.ufl_to_language.get(v, *vops)
 
-                # Create a new intermediate for
-                # each subexpression except boolean conditions
-                if isinstance(parent_exp, ufl.classes.Conditional):
-                    vaccess = vexpr
-                elif isinstance(parent_exp, ufl.classes.Condition):
+                # Create a new intermediate for each subexpression
+                # except boolean conditions and its childs
+                if isinstance(parent_exp, ufl.classes.Condition):
+                    # Skip intermediates for 'x' and 'y' in x<y
+                    # Avoid the creation of complex valued intermediates
                     vaccess = vexpr
                 elif isinstance(v, ufl.classes.Condition):
                     # Inline the conditions x < y, condition values
-                    # 'x' and 'y' may still be stored in intermediates.
                     # This removes the need to handle boolean intermediate variables.
                     # With tensor-valued conditionals it may not be optimal but we
                     # let the compiler take responsibility for optimizing those cases.

--- a/ffc/codegeneration/uflacsgenerator.py
+++ b/ffc/codegeneration/uflacsgenerator.py
@@ -264,7 +264,7 @@ class IntegralGenerator(object):
                 wsym = self.backend.symbols.weights_table(num_points)
                 parts += [
                     L.ArrayDecl(
-                        "static const double", wsym, num_points, weights, alignas=alignas)
+                        "static const ufc_scalar_t", wsym, num_points, weights, alignas=alignas)
                 ]
 
             # Generate quadrature points array
@@ -316,7 +316,7 @@ class IntegralGenerator(object):
                 continue
 
             decl = L.ArrayDecl(
-                "static const double", name, table.shape, table, alignas=alignas, padlen=p)
+                "static const ufc_scalar_t", name, table.shape, table, alignas=alignas, padlen=p)
             parts += [decl]
 
         # Add leading comment if there are any tables

--- a/ffc/codegeneration/uflacsgenerator.py
+++ b/ffc/codegeneration/uflacsgenerator.py
@@ -529,8 +529,6 @@ class IntegralGenerator(object):
                 parent_exp = None
                 if parent_id:
                     parent_exp = F.nodes.get(parent_id[0])['expression']
-                    print(type(v))
-                    print(type(parent_exp))
 
                 # Mapping UFL operator to target language
                 self._ufl_names.add(v._ufl_handler_name_)
@@ -548,7 +546,6 @@ class IntegralGenerator(object):
                     # This removes the need to handle boolean intermediate variables.
                     # With tensor-valued conditionals it may not be optimal but we
                     # let the compiler take responsibility for optimizing those cases.
-                    # Conditionals should be stored to
                     vaccess = vexpr
                 elif any(op._ufl_is_literal_ for op in v.ufl_operands):
                     # Skip intermediates for e.g. -2.0*x,

--- a/ffc/ir/uflacs/analysis/factorization.py
+++ b/ffc/ir/uflacs/analysis/factorization.py
@@ -13,7 +13,6 @@ from ffc.ir.uflacs.analysis.graph import ExpressionGraph
 from ffc.ir.uflacs.analysis.modified_terminals import (analyse_modified_terminal,
                                                        strip_modified_terminal)
 from ufl import as_ufl, conditional
-import ufl
 from ufl.classes import (Argument, Conditional, Conj, Division, Product, Sum,
                          Zero)
 

--- a/ffc/ir/uflacs/analysis/factorization.py
+++ b/ffc/ir/uflacs/analysis/factorization.py
@@ -13,6 +13,7 @@ from ffc.ir.uflacs.analysis.graph import ExpressionGraph
 from ffc.ir.uflacs.analysis.modified_terminals import (analyse_modified_terminal,
                                                        strip_modified_terminal)
 from ufl import as_ufl, conditional
+import ufl
 from ufl.classes import (Argument, Conditional, Conj, Division, Product, Sum,
                          Zero)
 

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -335,7 +335,8 @@ def test_conditional(mode):
     element = ufl.FiniteElement("Lagrange", cell, 1)
     u, v = ufl.TrialFunction(element), ufl.TestFunction(element)
     x = ufl.SpatialCoordinate(cell)
-    condition = ufl.Or(ufl.ge(ufl.real(x[0]), 0.1), ufl.ge(ufl.real(x[1]), 0.1))
+    condition = ufl.Or(ufl.ge(ufl.real(x[0] + x[1]), 0.1),
+                       ufl.ge(ufl.real(x[1] + x[1]**2), 0.1))
     c = ufl.conditional(condition, 2.0, 1.0)
     a = c * ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
     forms = [a]

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -337,27 +337,44 @@ def test_conditional(mode):
     x = ufl.SpatialCoordinate(cell)
     condition = ufl.Or(ufl.ge(ufl.real(x[0] + x[1]), 0.1),
                        ufl.ge(ufl.real(x[1] + x[1]**2), 0.1))
-    c = ufl.conditional(condition, 2.0, 1.0)
-    a = c * ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
-    forms = [a]
+    c1 = ufl.conditional(condition, 2.0, 1.0)
+    a = c1 * ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
+
+    x1x2 = ufl.real(x[0] + ufl.as_ufl(2) * x[1])
+    c2 = ufl.conditional(ufl.ge(x1x2, 0), 6.0, 0.0)
+    b = c2 * ufl.conj(v) * ufl.dx
+
+    forms = [a, b]
 
     compiled_forms, module = ffc.codegeneration.jit.compile_forms(
         forms, parameters={'scalar_type': mode})
 
     form0 = compiled_forms[0][0].create_cell_integral(-1)
-
-    c_type, np_type = float_to_type(mode)
-
-    A = np.zeros((3, 3), dtype=np_type)
-    w = np.array([1.0, 1.0, 1.0], dtype=np_type)
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    form1 = compiled_forms[1][0].create_cell_integral(-1)
 
     ffi = cffi.FFI()
+    c_type, np_type = float_to_type(mode)
+
+    A1 = np.zeros((3, 3), dtype=np_type)
+    w1 = np.array([1.0, 1.0, 1.0], dtype=np_type)
+    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
 
     form0.tabulate_tensor(
-        ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
-        ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
+        ffi.cast('{type} *'.format(type=c_type), A1.ctypes.data),
+        ffi.cast('{type} *'.format(type=c_type), w1.ctypes.data),
         ffi.cast('double *', coords.ctypes.data), 0)
 
-    expected_A = np.array([[2, -1, -1], [-1, 1, 0], [-1, 0, 1]], dtype=np_type)
-    assert np.allclose(A, expected_A)
+    expected_result = np.array([[2, -1, -1], [-1, 1, 0], [-1, 0, 1]], dtype=np_type)
+    assert np.allclose(A1, expected_result)
+
+    A2 = np.zeros(3, dtype=np_type)
+    w2 = np.array([1.0, 1.0, 1.0], dtype=np_type)
+    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
+
+    form1.tabulate_tensor(
+        ffi.cast('{type} *'.format(type=c_type), A2.ctypes.data),
+        ffi.cast('{type} *'.format(type=c_type), w2.ctypes.data),
+        ffi.cast('double *', coords.ctypes.data), 0)
+
+    expected_result = np.ones(3, dtype=np_type)
+    assert np.allclose(A2, expected_result)


### PR DESCRIPTION
- try to fix issue [124](https://github.com/FEniCS/ffcx/issues/124): Avoid creating intermediate variable for operands within conditionals.

- make spatial coordinates real quantities

- add test -  
this test fails in complex mode without the fix. eg:
```
$ error: invalid operands to binary >= (have 'ufc_scalar_t {aka _Complex double}' and 'double')
$ sp[33] = sp[23] * (sp[29] >= 0.1 || sp[32] >= 0.1 ? 2.0 : 1.0);
```