### PR TITLE
Unify integral signatures

### DIFF
--- a/ffc/codegeneration/form_template.py
+++ b/ffc/codegeneration/form_template.py
@@ -62,7 +62,7 @@ void get_cell_integral_ids_{factory_name}(int *ids)
   {get_cell_integral_ids}
 }}
 
-ufc_exterior_facet_integral* create_exterior_facet_integral_{factory_name}(int subdomain_id)
+ufc_facet_integral* create_exterior_facet_integral_{factory_name}(int subdomain_id)
 {{
   {create_exterior_facet_integral}
 }}
@@ -72,7 +72,7 @@ void get_exterior_facet_integral_ids_{factory_name}(int *ids)
   {get_exterior_facet_integral_ids}
 }}
 
-ufc_interior_facet_integral* create_interior_facet_integral_{factory_name}(int subdomain_id)
+ufc_facet_integral* create_interior_facet_integral_{factory_name}(int subdomain_id)
 {{
 {create_interior_facet_integral}
 }}

--- a/ffc/codegeneration/form_template.py
+++ b/ffc/codegeneration/form_template.py
@@ -52,7 +52,7 @@ ufc_dofmap* create_dofmap_{factory_name}(int i)
 {create_dofmap}
 }}
 
-ufc_cell_integral* create_cell_integral_{factory_name}(int subdomain_id)
+ufc_integral* create_cell_integral_{factory_name}(int subdomain_id)
 {{
   {create_cell_integral}
 }}
@@ -62,7 +62,7 @@ void get_cell_integral_ids_{factory_name}(int *ids)
   {get_cell_integral_ids}
 }}
 
-ufc_facet_integral* create_exterior_facet_integral_{factory_name}(int subdomain_id)
+ufc_integral* create_exterior_facet_integral_{factory_name}(int subdomain_id)
 {{
   {create_exterior_facet_integral}
 }}
@@ -72,7 +72,7 @@ void get_exterior_facet_integral_ids_{factory_name}(int *ids)
   {get_exterior_facet_integral_ids}
 }}
 
-ufc_facet_integral* create_interior_facet_integral_{factory_name}(int subdomain_id)
+ufc_integral* create_interior_facet_integral_{factory_name}(int subdomain_id)
 {{
 {create_interior_facet_integral}
 }}
@@ -82,7 +82,7 @@ void get_interior_facet_integral_ids_{factory_name}(int *ids)
   {get_interior_facet_integral_ids}
 }}
 
-ufc_vertex_integral* create_vertex_integral_{factory_name}(int subdomain_id)
+ufc_integral* create_vertex_integral_{factory_name}(int subdomain_id)
 {{
 {create_vertex_integral}
 }}

--- a/ffc/codegeneration/integrals.py
+++ b/ffc/codegeneration/integrals.py
@@ -37,6 +37,7 @@ def generator(ir, parameters):
         factory_name=factory_name, tabulate_tensor=code["tabulate_tensor"])
 
     # Format implementation code
+
     implementation = ufc_integrals.factory.format(
         type=integral_type,
         factory_name=factory_name,

--- a/ffc/codegeneration/integrals.py
+++ b/ffc/codegeneration/integrals.py
@@ -17,8 +17,10 @@ def generator(ir, parameters):
     integral_type = ir.integral_type
 
     # Format declaration
-    declaration = ufc_integrals.declaration.format(
-        type=integral_type, factory_name=factory_name)
+    if integral_type == "custom":
+        declaration = ufc_integrals.custom_declaration.format(factory_name=factory_name)
+    else:
+        declaration = ufc_integrals.declaration.format(factory_name=factory_name)
 
     if ir.representation == "uflacs":
         from ffc.codegeneration.uflacsgenerator import generate_integral_code
@@ -38,10 +40,15 @@ def generator(ir, parameters):
 
     # Format implementation code
 
-    implementation = ufc_integrals.factory.format(
-        type=integral_type,
-        factory_name=factory_name,
-        enabled_coefficients=code["enabled_coefficients"],
-        tabulate_tensor=tabulate_tensor_fn)
+    if integral_type == "custom":
+        implementation = ufc_integrals.custom_factory.format(
+            factory_name=factory_name,
+            enabled_coefficients=code["enabled_coefficients"],
+            tabulate_tensor=tabulate_tensor_fn)
+    else:
+        implementation = ufc_integrals.factory.format(
+            factory_name=factory_name,
+            enabled_coefficients=code["enabled_coefficients"],
+            tabulate_tensor=tabulate_tensor_fn)
 
     return declaration, implementation

--- a/ffc/codegeneration/integrals_template.py
+++ b/ffc/codegeneration/integrals_template.py
@@ -21,8 +21,8 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t
     "exterior_facet":
     """
 void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                                     const double* restrict coordinate_dofs,
-                                     int facet, int cell_orientation)
+                                    const double* restrict coordinate_dofs,
+                                    const int* facet, const int* cell_orientation)
 {{
 {tabulate_tensor}
 }}
@@ -30,10 +30,8 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t
     "interior_facet":
     """
 void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                                    const double* restrict coordinate_dofs_0,
-                                    const double* restrict coordinate_dofs_1, int facet_0,
-                                    int facet_1, int cell_orientation_0,
-                                    int cell_orientation_1)
+                                    const double* restrict coordinate_dofs,
+                                    const int* facet, const int* cell_orientation)
 {{
 {tabulate_tensor}
 }}

--- a/ffc/codegeneration/integrals_template.py
+++ b/ffc/codegeneration/integrals_template.py
@@ -13,7 +13,8 @@ tabulate_implementation = {
     """
 void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
                                     const double* restrict coordinate_dofs,
-                                    int cell_orientation)
+                                    const int* unused_local_index,
+                                    const int* cell_orientation)
 {{
 {tabulate_tensor}
 }}
@@ -22,7 +23,8 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t
     """
 void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
                                     const double* restrict coordinate_dofs,
-                                    const int* facet, const int* cell_orientation)
+                                    const int* facet,
+                                    const int* cell_orientation)
 {{
 {tabulate_tensor}
 }}
@@ -31,7 +33,8 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t
     """
 void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
                                     const double* restrict coordinate_dofs,
-                                    const int* facet, const int* cell_orientation)
+                                    const int* facet,
+                                    const int* cell_orientation)
 {{
 {tabulate_tensor}
 }}
@@ -39,8 +42,9 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t
     "vertex":
     """
 void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                                    const double* restrict coordinate_dofs, int vertex,
-                                    int cell_orientation)
+                                    const double* restrict coordinate_dofs,
+                                    const int* vertex,
+                                    const int* cell_orientation)
 {{
 {tabulate_tensor}
 }}

--- a/ffc/codegeneration/integrals_template.py
+++ b/ffc/codegeneration/integrals_template.py
@@ -5,7 +5,11 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2018
 
 declaration = """
-ufc_{type}_integral* create_{factory_name}(void);
+ufc_integral* create_{factory_name}(void);
+"""
+
+custom_declaration = """
+ufc_custom_integral* create_{factory_name}(void);
 """
 
 tabulate_implementation = {
@@ -65,19 +69,37 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A, const ufc_scalar_t
 }
 
 factory = """
-// Code for {type}_integral {factory_name}
+// Code for integral {factory_name}
 
 {tabulate_tensor}
 
-ufc_{type}_integral* create_{factory_name}(void)
+ufc_integral* create_{factory_name}(void)
 {{
   static const bool enabled{enabled_coefficients}
 
-  ufc_{type}_integral* integral = malloc(sizeof(*integral));
+  ufc_integral* integral = malloc(sizeof(*integral));
   integral->enabled_coefficients = enabled;
   integral->tabulate_tensor = tabulate_tensor_{factory_name};
   return integral;
 }};
 
-// End of code for {type}_integral {factory_name}
+// End of code for integral {factory_name}
+"""
+
+custom_factory = """
+// Code for custom integral {factory_name}
+
+{tabulate_tensor}
+
+ufc_custom_integral* create_{factory_name}(void)
+{{
+  static const bool enabled{enabled_coefficients}
+
+  ufc_custom_integral* integral = malloc(sizeof(*integral));
+  integral->enabled_coefficients = enabled;
+  integral->tabulate_tensor = tabulate_tensor_{factory_name};
+  return integral;
+}};
+
+// End of code for custom integral {factory_name}
 """

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -144,18 +144,16 @@ typedef struct ufc_exterior_facet_integral
 {
 const bool* enabled_coefficients;
 void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                        const double* restrict coordinate_dofs, int facet,
-                        int cell_orientation);
+                        const double* restrict coordinate_dofs, const int* facet,
+                        const int* cell_orientation);
 } ufc_exterior_facet_integral;
 
 typedef struct ufc_interior_facet_integral
 {
 const bool* enabled_coefficients;
 void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                        const double* restrict coordinate_dofs_0,
-                        const double* restrict coordinate_dofs_1,
-                        int facet_0, int facet_1, int cell_orientation_0,
-                        int cell_orientation_1);
+                        const double* restrict coordinate_dofs,
+                        const int* facet, const int* cell_orientation);
 } ufc_interior_facet_integral;
 
 typedef struct ufc_vertex_integral

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -140,21 +140,13 @@ void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
                         int cell_orientation);
 } ufc_cell_integral;
 
-typedef struct ufc_exterior_facet_integral
-{
-const bool* enabled_coefficients;
-void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                        const double* restrict coordinate_dofs, const int* facet,
-                        const int* cell_orientation);
-} ufc_exterior_facet_integral;
-
-typedef struct ufc_interior_facet_integral
+typedef struct ufc_facet_integral
 {
 const bool* enabled_coefficients;
 void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
                         const double* restrict coordinate_dofs,
                         const int* facet, const int* cell_orientation);
-} ufc_interior_facet_integral;
+} ufc_facet_integral;
 
 typedef struct ufc_vertex_integral
 {
@@ -201,9 +193,9 @@ int num_interior_facet_integrals;
 int num_vertex_integrals;
 int num_custom_integrals;
 ufc_cell_integral* (*create_cell_integral)(int subdomain_id);
-ufc_exterior_facet_integral* (*create_exterior_facet_integral)(
+ufc_facet_integral* (*create_exterior_facet_integral)(
     int subdomain_id);
-ufc_interior_facet_integral* (*create_interior_facet_integral)(
+ufc_facet_integral* (*create_interior_facet_integral)(
     int subdomain_id);
 ufc_vertex_integral* (*create_vertex_integral)(int subdomain_id);
 ufc_custom_integral* (*create_custom_integral)(int subdomain_id);

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -132,29 +132,14 @@ void (*compute_midpoint_geometry)(double* restrict x, double* restrict J,
 """
 
 UFC_INTEGRAL_DECL = """
-typedef struct ufc_cell_integral
+typedef struct ufc_integral
 {
 const bool* enabled_coefficients;
 void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
                         const double* restrict coordinate_dofs,
-                        int cell_orientation);
-} ufc_cell_integral;
-
-typedef struct ufc_facet_integral
-{
-const bool* enabled_coefficients;
-void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                        const double* restrict coordinate_dofs,
-                        const int* facet, const int* cell_orientation);
-} ufc_facet_integral;
-
-typedef struct ufc_vertex_integral
-{
-const bool* enabled_coefficients;
-void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                        const double* restrict coordinate_dofs, int vertex,
-                        int cell_orientation);
-} ufc_vertex_integral;
+                        const int* entity_local_index,
+                        const int* cell_orientation);
+} ufc_integral;
 
 typedef struct ufc_custom_integral
 {
@@ -192,12 +177,12 @@ int num_exterior_facet_integrals;
 int num_interior_facet_integrals;
 int num_vertex_integrals;
 int num_custom_integrals;
-ufc_cell_integral* (*create_cell_integral)(int subdomain_id);
-ufc_facet_integral* (*create_exterior_facet_integral)(
+ufc_integral* (*create_cell_integral)(int subdomain_id);
+ufc_integral* (*create_exterior_facet_integral)(
     int subdomain_id);
-ufc_facet_integral* (*create_interior_facet_integral)(
+ufc_integral* (*create_interior_facet_integral)(
     int subdomain_id);
-ufc_vertex_integral* (*create_vertex_integral)(int subdomain_id);
+ufc_integral* (*create_vertex_integral)(int subdomain_id);
 ufc_custom_integral* (*create_custom_integral)(int subdomain_id);
 } ufc_form;
 """

--- a/ffc/codegeneration/symbols.py
+++ b/ffc/codegeneration/symbols.py
@@ -81,7 +81,7 @@ class FFCBackendSymbols(object):
                 postfix = "[1]"
             return self.S("facet" + postfix)
         elif entitytype == "vertex":
-            return self.S("vertex")
+            return self.S("vertex[0]")
         else:
             logging.exception("Unknown entitytype {}".format(entitytype))
 

--- a/ffc/codegeneration/symbols.py
+++ b/ffc/codegeneration/symbols.py
@@ -76,7 +76,10 @@ class FFCBackendSymbols(object):
             # Always 0 for cells (even with restriction)
             return self.L.LiteralInt(0)
         elif entitytype == "facet":
-            return self.S("facet" + ufc_restriction_postfix(restriction))
+            postfix = "[0]"
+            if restriction == "-":
+                postfix = "[1]"
+            return self.S("facet" + postfix)
         elif entitytype == "vertex":
             return self.S("vertex")
         else:
@@ -143,11 +146,14 @@ class FFCBackendSymbols(object):
 
     def domain_dof_access(self, dof, component, gdim, num_scalar_dofs, restriction):
         # FIXME: Add domain number or offset!
-        vc = self.S("coordinate_dofs" + ufc_restriction_postfix(restriction))
+        offset = 0
+        if restriction == "-":
+            offset = num_scalar_dofs * gdim
+        vc = self.S("coordinate_dofs")
         if self.interleaved_components:
-            return vc[gdim * dof + component]
+            return vc[gdim * dof + component + offset]
         else:
-            return vc[num_scalar_dofs * component + dof]
+            return vc[num_scalar_dofs * component + dof + offset]
 
     def domain_dofs_access(self, gdim, num_scalar_dofs, restriction):
         # FIXME: Add domain number or offset!

--- a/ffc/codegeneration/symbols.py
+++ b/ffc/codegeneration/symbols.py
@@ -87,7 +87,10 @@ class FFCBackendSymbols(object):
 
     def cell_orientation_argument(self, restriction):
         """Cell orientation argument in ufc. Not same as cell orientation in generated code."""
-        return self.S("cell_orientation" + ufc_restriction_postfix(restriction))
+        postfix = "[0]"
+        if restriction == "-":
+            postfix = "[1]"
+        return self.S("cell_orientation" + postfix)
 
     def cell_orientation_internal(self, restriction):
         """Internal value for cell orientation in generated code."""

--- a/ffc/codegeneration/ufc.h
+++ b/ffc/codegeneration/ufc.h
@@ -15,9 +15,11 @@
 #define UFC_VERSION_RELEASE 0
 
 #if UFC_VERSION_RELEASE
-#define UFC_VERSION UFC_VERSION_MAJOR "." UFC_VERSION_MINOR "." UFC_VERSION_MAINTENANCE
+#define UFC_VERSION                                                            \
+  UFC_VERSION_MAJOR "." UFC_VERSION_MINOR "." UFC_VERSION_MAINTENANCE
 #else
-#define UFC_VERSION UFC_VERSION_MAJOR "." UFC_VERSION_MINOR "." UFC_VERSION_MAINTENANCE ".dev0"
+#define UFC_VERSION                                                            \
+  UFC_VERSION_MAJOR "." UFC_VERSION_MINOR "." UFC_VERSION_MAINTENANCE ".dev0"
 #endif
 
 #include <stdbool.h>
@@ -34,8 +36,8 @@ extern "C"
 #define restrict __restrict__
 #else
 #define restrict
-#endif  // restrict
-#endif  // __cplusplus
+#endif // restrict
+#endif // __cplusplus
 
   typedef enum
   {
@@ -111,10 +113,10 @@ extern "C"
     /// been evaluated at points given by
     /// tabulate_reference_dof_coordinates.
     int (*transform_values)(ufc_scalar_t* restrict reference_values,
-                             const ufc_scalar_t* restrict physical_values,
-                             const double* restrict coordinate_dofs,
-                             int cell_orientation,
-                             const ufc_coordinate_mapping* cm);
+                            const ufc_scalar_t* restrict physical_values,
+                            const double* restrict coordinate_dofs,
+                            int cell_orientation,
+                            const ufc_coordinate_mapping* cm);
 
     // FIXME: change to 'const double* reference_dof_coordinates()'
     /// Tabulate the coordinates of all dofs on a reference cell
@@ -374,39 +376,20 @@ extern "C"
 
   } ufc_coordinate_mapping;
 
-  // FIXME: Is this required for integrals?
-  // Number of coefficients
-  // int num_coefficients() const = 0;
-
-  // FIXME: Consider a common signature for tabulate_tensor
-
-  typedef struct ufc_cell_integral
+  typedef struct ufc_integral
   {
     const bool* enabled_coefficients;
     void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
                             const double* restrict coordinate_dofs,
-                            int cell_orientation);
-  } ufc_cell_integral;
-
-  typedef struct ufc_facet_integral
-  {
-    const bool* enabled_coefficients;
-    void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                            const double* restrict coordinate_dofs, const int* facet,
+                            const int* entity_local_index,
                             const int* cell_orientation);
-  } ufc_facet_integral;
+  } ufc_integral;
 
   // Backwards compatible typedefs
-  typedef ufc_facet_integral ufc_exterior_facet_integral;
-  typedef ufc_facet_integral ufc_interior_facet_integral;
-
-  typedef struct ufc_vertex_integral
-  {
-    const bool* enabled_coefficients;
-    void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                            const double* restrict coordinate_dofs, int vertex,
-                            int cell_orientation);
-  } ufc_vertex_integral;
+  typedef ufc_integral ufc_cell_integral;
+  typedef ufc_integral ufc_exterior_facet_integral;
+  typedef ufc_integral ufc_interior_facet_integral;
+  typedef ufc_integral ufc_vertex_integral;
 
   typedef struct ufc_custom_integral
   {
@@ -483,19 +466,19 @@ extern "C"
     ufc_dofmap* (*create_dofmap)(int i);
 
     /// All ids for cell integrals
-    void (*get_cell_integral_ids)(int *ids);
+    void (*get_cell_integral_ids)(int* ids);
 
     /// All ids for exterior facet integrals
-    void (*get_exterior_facet_integral_ids)(int *ids);
+    void (*get_exterior_facet_integral_ids)(int* ids);
 
     /// All ids for interior facet integrals
-    void (*get_interior_facet_integral_ids)(int *ids);
+    void (*get_interior_facet_integral_ids)(int* ids);
 
     /// All ids for vertex integrals
-    void (*get_vertex_integral_ids)(int *ids);
+    void (*get_vertex_integral_ids)(int* ids);
 
     /// All ids for custom integrals
-    void (*get_custom_integral_ids)(int *ids);
+    void (*get_custom_integral_ids)(int* ids);
 
     /// Number of cell integrals
     int num_cell_integrals;
@@ -513,24 +496,21 @@ extern "C"
     int num_custom_integrals;
 
     /// Create a new cell integral on sub domain subdomain_id
-    ufc_cell_integral* (*create_cell_integral)(int subdomain_id);
+    ufc_integral* (*create_cell_integral)(int subdomain_id);
 
     /// Create a new exterior facet integral on sub domain subdomain_id
-    ufc_facet_integral* (*create_exterior_facet_integral)(
-        int subdomain_id);
+    ufc_integral* (*create_exterior_facet_integral)(int subdomain_id);
 
     /// Create a new interior facet integral on sub domain subdomain_id
-    ufc_facet_integral* (*create_interior_facet_integral)(
-        int subdomain_id);
+    ufc_integral* (*create_interior_facet_integral)(int subdomain_id);
 
     /// Create a new vertex integral on sub domain subdomain_id
-    ufc_vertex_integral* (*create_vertex_integral)(int subdomain_id);
+    ufc_integral* (*create_vertex_integral)(int subdomain_id);
 
     /// Create a new custom integral on sub domain subdomain_id
     ufc_custom_integral* (*create_custom_integral)(int subdomain_id);
 
   } ufc_form;
-
 
   // FIXME: Formalise a UFC 'function space'.
   typedef struct ufc_function_space

--- a/ffc/codegeneration/ufc.h
+++ b/ffc/codegeneration/ufc.h
@@ -388,21 +388,17 @@ extern "C"
                             int cell_orientation);
   } ufc_cell_integral;
 
-  typedef struct ufc_exterior_facet_integral
+  typedef struct ufc_facet_integral
   {
     const bool* enabled_coefficients;
     void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
                             const double* restrict coordinate_dofs, const int* facet,
                             const int* cell_orientation);
-  } ufc_exterior_facet_integral;
+  } ufc_facet_integral;
 
-  typedef struct ufc_interior_facet_integral
-  {
-    const bool* enabled_coefficients;
-    void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                            const double* restrict coordinate_dofs,
-                            const int* facet, const int* cell_orientation);
-  } ufc_interior_facet_integral;
+  // Backwards compatible typedefs
+  typedef ufc_facet_integral ufc_exterior_facet_integral;
+  typedef ufc_facet_integral ufc_interior_facet_integral;
 
   typedef struct ufc_vertex_integral
   {
@@ -520,11 +516,11 @@ extern "C"
     ufc_cell_integral* (*create_cell_integral)(int subdomain_id);
 
     /// Create a new exterior facet integral on sub domain subdomain_id
-    ufc_exterior_facet_integral* (*create_exterior_facet_integral)(
+    ufc_facet_integral* (*create_exterior_facet_integral)(
         int subdomain_id);
 
     /// Create a new interior facet integral on sub domain subdomain_id
-    ufc_interior_facet_integral* (*create_interior_facet_integral)(
+    ufc_facet_integral* (*create_interior_facet_integral)(
         int subdomain_id);
 
     /// Create a new vertex integral on sub domain subdomain_id

--- a/ffc/codegeneration/ufc.h
+++ b/ffc/codegeneration/ufc.h
@@ -385,12 +385,6 @@ extern "C"
                             const int* cell_orientation);
   } ufc_integral;
 
-  // Backwards compatible typedefs
-  typedef ufc_integral ufc_cell_integral;
-  typedef ufc_integral ufc_exterior_facet_integral;
-  typedef ufc_integral ufc_interior_facet_integral;
-  typedef ufc_integral ufc_vertex_integral;
-
   typedef struct ufc_custom_integral
   {
     const bool* enabled_coefficients;

--- a/ffc/codegeneration/ufc.h
+++ b/ffc/codegeneration/ufc.h
@@ -392,18 +392,16 @@ extern "C"
   {
     const bool* enabled_coefficients;
     void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                            const double* restrict coordinate_dofs, int facet,
-                            int cell_orientation);
+                            const double* restrict coordinate_dofs, const int* facet,
+                            const int* cell_orientation);
   } ufc_exterior_facet_integral;
 
   typedef struct ufc_interior_facet_integral
   {
     const bool* enabled_coefficients;
     void (*tabulate_tensor)(ufc_scalar_t* restrict A, const ufc_scalar_t* w,
-                            const double* restrict coordinate_dofs_0,
-                            const double* restrict coordinate_dofs_1,
-                            int facet_0, int facet_1, int cell_orientation_0,
-                            int cell_orientation_1);
+                            const double* restrict coordinate_dofs,
+                            const int* facet, const int* cell_orientation);
   } ufc_interior_facet_integral;
 
   typedef struct ufc_vertex_integral

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -334,7 +334,7 @@ def test_interior_facet_integral(mode):
     cell = ufl.triangle
     element = ufl.FiniteElement("Lagrange", cell, 1)
     u, v = ufl.TrialFunction(element), ufl.TestFunction(element)
-    a0 = ufl.inner(ufl.jump(u), ufl.jump(v)) * ufl.dS
+    a0 = ufl.inner(ufl.jump(ufl.grad(u)), ufl.jump(ufl.grad(v))) * ufl.dS
     forms = [a0]
     compiled_forms, module = ffc.codegeneration.jit.compile_forms(
         forms, parameters={'scalar_type': mode})
@@ -358,8 +358,8 @@ def test_interior_facet_integral(mode):
     facets = np.array([0, 2], dtype=np.int32)
     orients = np.array([1, 1], dtype=np.int32)
 
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0,
-                       1.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+    coords = np.array([[0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
+                       [1.0, 0.0, 0.0, 1.0, 1.0, 1.0]], dtype=np.float64)
 
     integral0.tabulate_tensor(
         ffi.cast('{}  *'.format(c_type), A.ctypes.data),

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -333,7 +333,7 @@ def test_interior_facet_integral():
     cell = ufl.triangle
     element = ufl.FiniteElement("Lagrange", cell, 1)
     u, v = ufl.TrialFunction(element), ufl.TestFunction(element)
-    a0 = ufl.avg(u) * ufl.avg(v) * ufl.dS
+    a0 = ufl.inner(ufl.jump(u), ufl.jump(v)) * ufl.dS
     forms = [a0]
     compiled_forms, module = ffc.codegeneration.jit.compile_forms(
         forms, parameters={'scalar_type': 'double'})
@@ -347,6 +347,22 @@ def test_interior_facet_integral():
     ids = np.zeros(form0.num_interior_facet_integrals, dtype=np.int32)
     form0.get_interior_facet_integral_ids(ffi.cast('int *', ids.ctypes.data))
     assert ids[0] == -1
+
+    integral0 = form0.create_interior_facet_integral(-1)
+    A = np.zeros((6, 6), dtype=np.float64)
+    w = np.array([], dtype=np.float64)
+    facets = np.array([0, 2], dtype=np.int32)
+    orients = np.array([1, 1], dtype=np.int32)
+    ffi = cffi.FFI()
+    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0,
+                       1.0, 0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float64)
+
+    integral0.tabulate_tensor(
+        ffi.cast('double  *', A.ctypes.data), ffi.cast('double  *', w.ctypes.data),
+        ffi.cast('double  *', coords.ctypes.data), ffi.cast('int *', facets.ctypes.data),
+        ffi.cast('int *', orients.ctypes.data))
+
+    print(A)
 
 
 @pytest.mark.parametrize("mode", ["double", "double complex"])

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -152,7 +152,7 @@ def test_laplace_bilinear_form_2d(mode, expected_result):
     default_integral.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), 0)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     assert np.allclose(A, expected_result)
 
@@ -208,13 +208,13 @@ def test_mass_bilinear_form_2d(mode, expected_result):
     form0.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), 0)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     b = np.zeros(3, dtype=np_type)
     form1.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), b.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), 0)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     assert np.allclose(A, expected_result)
     assert np.allclose(b, 1.0 / 6.0)
@@ -256,7 +256,7 @@ def test_helmholtz_form_2d(mode, expected_result):
     form0.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), 0)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     assert np.allclose(A, expected_result)
 
@@ -280,7 +280,7 @@ def test_form_coefficient():
     coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
     form0.tabulate_tensor(
         ffi.cast('double  *', A.ctypes.data), ffi.cast('double  *', w.ctypes.data),
-        ffi.cast('double  *', coords.ctypes.data), 0)
+        ffi.cast('double  *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     A_analytic = np.array([[2, 1, 1], [1, 2, 1], [1, 1, 2]], dtype=np.float64) / 24.0
     A_diff = (A - A_analytic)
@@ -403,7 +403,7 @@ def test_conditional(mode):
     form0.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A1.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w1.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), 0)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     expected_result = np.array([[2, -1, -1], [-1, 1, 0], [-1, 0, 1]], dtype=np_type)
     assert np.allclose(A1, expected_result)
@@ -415,7 +415,7 @@ def test_conditional(mode):
     form1.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A2.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w2.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), 0)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     expected_result = np.ones(3, dtype=np_type)
     assert np.allclose(A2, expected_result)

--- a/test/ufc/test_cffi_3d.py
+++ b/test/ufc/test_cffi_3d.py
@@ -111,6 +111,6 @@ def test_laplace_bilinear_form_3d(mode, expected_result):
     form0.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), 0)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     assert np.allclose(A, expected_result)


### PR DESCRIPTION
Makes all tabulate signatures the same, and replaces with `ufc_integral` instead of `ufc_foo_integral`.
The exception is `ufc_custom_integral`, but this will probably also be changed in a later PR.
