### PR TITLE
Revise JIT module import

### DIFF
--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -57,7 +57,7 @@ def get_cached_module(module_name, object_names, parameters):
     """Look for an existing C file and wait for compilation, or if it does not exist, create it."""
     cache_dir = ffc.config.get_cache_path(parameters)
     timeout = int(parameters.get("timeout", 10))
-    c_filename = cache_dir.joinpath(module_name + ".c")
+    c_filename = cache_dir.joinpath(module_name).with_suffix(".c")
     ready_name = c_filename.with_suffix(".c.cached")
 
     # Ensure cache dir exists

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -5,14 +5,14 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import tempfile
-from pathlib import Path
 import importlib
 import logging
 import os
-import sys
-import time
 import re
+import sys
+import tempfile
+import time
+from pathlib import Path
 
 import cffi
 
@@ -195,23 +195,22 @@ def _compile_objects(decl, ufl_objects, object_names, module_name, parameters):
     ffibuilder = cffi.FFI()
     ffibuilder.set_source(module_name, code_body, include_dirs=[ffc.codegeneration.get_include_path()],
                           extra_compile_args=['-g0'])  # turn off -g
-
     ffibuilder.cdef(decl)
 
     c_filename = compile_dir.joinpath(module_name + ".c")
     ready_name = c_filename.with_suffix(".c.cached")
 
-    print("Sys dir:", cache_dir)
-    print("Sys dir:", str(cache_dir))
+    print("Sys dir:", compile_dir)
+    print("Sys dir:", str(compile_dir))
 
     # Ensure path is set for module and ensure cache dir exists
     sys.path.insert(0, str(compile_dir))
     compile_dir.mkdir(exist_ok=True)
 
     # Compile
-    print("Tmp dir:", cache_dir)
+    print("Tmp dir:", compile_dir)
     ffibuilder.compile(tmpdir=compile_dir, verbose=False)
-    print("Boo:", os.listdir(str(cache_dir)))
+    print("Boo:", os.listdir(str(compile_dir)))
 
     # Create a "status ready" file. If this fails, it is an error,
     # because it should not exist yet.

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -331,13 +331,13 @@ def _compile_objects(decl, ufl_objects, object_names, module_name, parameters):
     # Ensure path is set for module and ensure cache dir exists
     print("Sys dir:", cache_dir)
     print("Sys dir:", str(cache_dir))
-    print("Boo:", os.listdir(str(cache_dir)))
     sys.path.insert(0, str(cache_dir))
     cache_dir.mkdir(exist_ok=True)
 
     # Compile
     print("Tmp dir:", cache_dir)
     ffibuilder.compile(tmpdir=cache_dir, verbose=False)
+    print("Boo:", os.listdir(str(cache_dir)))
 
     # Create a "status ready" file. If this fails, it is an error,
     # because it should not exist yet.

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -329,10 +329,14 @@ def _compile_objects(decl, ufl_objects, object_names, module_name, parameters):
     ready_name = c_filename.with_suffix(".c.cached")
 
     # Ensure path is set for module and ensure cache dir exists
+    print("Sys dir:", cache_dir)
+    print("Sys dir:", str(cache_dir))
+    print("Boo:", os.listdir(str(cache_dir)))
     sys.path.insert(0, str(cache_dir))
     cache_dir.mkdir(exist_ok=True)
 
     # Compile
+    print("Tmp dir:", cache_dir)
     ffibuilder.compile(tmpdir=cache_dir, verbose=False)
 
     # Create a "status ready" file. If this fails, it is an error,

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -220,7 +220,7 @@ def _compile_objects(decl, ufl_objects, object_names, module_name, parameters):
     if spec is None:
         raise ModuleNotFoundError("Unable to find JIT module.")
 
-    # Import module
+    # Load module
     compiled_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(compiled_module)
 

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -200,17 +200,17 @@ def _compile_objects(decl, ufl_objects, object_names, module_name, parameters):
     c_filename = compile_dir.joinpath(module_name + ".c")
     ready_name = c_filename.with_suffix(".c.cached")
 
-    print("Sys dir:", compile_dir)
-    print("Sys dir:", str(compile_dir))
+    # print("Sys dir:", compile_dir)
+    # print("Sys dir:", str(compile_dir))
 
     # Ensure path is set for module and ensure cache dir exists
     sys.path.insert(0, str(compile_dir))
     compile_dir.mkdir(exist_ok=True)
 
     # Compile
-    print("Tmp dir:", compile_dir)
+    # print("Tmp dir:", compile_dir)
     ffibuilder.compile(tmpdir=compile_dir, verbose=False)
-    print("Boo:", os.listdir(str(compile_dir)))
+    # print("Boo:", os.listdir(str(compile_dir)))
 
     # Create a "status ready" file. If this fails, it is an error,
     # because it should not exist yet.
@@ -218,7 +218,18 @@ def _compile_objects(decl, ufl_objects, object_names, module_name, parameters):
     fd.close()
 
     # Build list of compiled objects
-    compiled_module = importlib.import_module(module_name)
+    import importlib.util
+    spec = importlib.util.find_spec(module_name)
+    if spec is None:
+        print("can't find the compiled module module")
+    else:
+        # If you chose to perform the actual import ...
+        compiled_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(compiled_module)
+        # Adding the module to sys.modules is optional.
+        #sys.modules[name] = module
+
+    # compiled_module = importlib.import_module(module_name)
     sys.path.remove(str(compile_dir))
     compiled_objects = [getattr(compiled_module.lib, "create_" + name)() for name in object_names]
 

--- a/ffc/config.py
+++ b/ffc/config.py
@@ -14,8 +14,6 @@ logger = logging.getLogger(__name__)
 def get_cache_path(parameters):
     """Get the path for the JIT cache"""
 
-    print("Test path:", Path.cwd())
-
     # Get cache path from parameters, with fallback to current working
     # directory
     cache_dir = parameters.get("cache_dir", Path.cwd() / "compile-cache")

--- a/ffc/config.py
+++ b/ffc/config.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 def get_cache_path(parameters):
     """Get the path for the JIT cache"""
 
+    print("Test path:", Path.cwd())
+
     # Get cache path from parameters, with fallback to current working
     # directory
     cache_dir = parameters.get("cache_dir", Path.cwd() / "compile-cache")


### PR DESCRIPTION
This addresses an issue with Python module import caching which can lead to JIT-created modules being overlooked due to Python not re-checking module search paths.