### PR TITLE
Handle complex max/min

### DIFF
--- a/ffc/codegeneration/C/ufl_to_cnodes.py
+++ b/ffc/codegeneration/C/ufl_to_cnodes.py
@@ -99,7 +99,9 @@ math_table = {'double': {'sqrt': 'sqrt',
                                  'ln': 'clog',
                                  'real': 'creal',
                                  'imag': 'cimag',
-                                 'conj': 'conj'},
+                                 'conj': 'conj',
+                                 'max_value': 'fmax',
+                                 'min_value': 'fmin'},
 
               'float complex': {'sqrt': 'csqrtf',
                                 'abs': 'cabsf',
@@ -120,7 +122,9 @@ math_table = {'double': {'sqrt': 'sqrt',
                                 'ln': 'clogf',
                                 'real': 'crealf',
                                 'imag': 'cimagf',
-                                'conj': 'conjf'}}
+                                'conj': 'conjf',
+                                'max_value': 'fmaxf',
+                                'min_value': 'fminf'}}
 
 
 class UFL2CNodesTranslatorCpp(object):
@@ -156,8 +160,8 @@ class UFL2CNodesTranslatorCpp(object):
                             ufl.classes.OrCondition: self.or_condition,
                             ufl.classes.NotCondition: self.not_condition,
                             ufl.classes.Conditional: self.conditional,
-                            ufl.classes.MinValue: self._cmath,
-                            ufl.classes.MaxValue: self._cmath,
+                            ufl.classes.MinValue: self.min_value,
+                            ufl.classes.MaxValue: self.max_value,
                             ufl.mathfunctions.Sqrt: self._cmath,
                             ufl.mathfunctions.Ln: self._cmath,
                             ufl.mathfunctions.Exp: self._cmath,
@@ -265,6 +269,22 @@ class UFL2CNodesTranslatorCpp(object):
             raise type(e)("Math function not found:", self.scalar_type, k)
         if name is None:
             raise RuntimeError("Not supported in current scalar mode")
+        return self.L.Call(name, args)
+
+    def max_value(self, o, *args):
+        if "complex" in self.scalar_type:
+            logger.warning("Maximum is ambiguous in complex mode")
+
+        k = o._ufl_handler_name_
+        name = math_table[self.scalar_type].get(k)
+        return self.L.Call(name, args)
+
+    def min_value(self, o, *args):
+        if "complex" in self.scalar_type:
+            logger.warning("Minimum is ambiguous in complex mode")
+
+        k = o._ufl_handler_name_
+        name = math_table[self.scalar_type].get(k)
         return self.L.Call(name, args)
 
     # === Formatting rules for bessel functions ===

--- a/ffc/codegeneration/C/ufl_to_cnodes.py
+++ b/ffc/codegeneration/C/ufl_to_cnodes.py
@@ -160,8 +160,8 @@ class UFL2CNodesTranslatorCpp(object):
                             ufl.classes.OrCondition: self.or_condition,
                             ufl.classes.NotCondition: self.not_condition,
                             ufl.classes.Conditional: self.conditional,
-                            ufl.classes.MinValue: self.min_value,
-                            ufl.classes.MaxValue: self.max_value,
+                            ufl.classes.MinValue: self._cmath,
+                            ufl.classes.MaxValue: self._cmath,
                             ufl.mathfunctions.Sqrt: self._cmath,
                             ufl.mathfunctions.Ln: self._cmath,
                             ufl.mathfunctions.Exp: self._cmath,
@@ -269,22 +269,6 @@ class UFL2CNodesTranslatorCpp(object):
             raise type(e)("Math function not found:", self.scalar_type, k)
         if name is None:
             raise RuntimeError("Not supported in current scalar mode")
-        return self.L.Call(name, args)
-
-    def max_value(self, o, *args):
-        if "complex" in self.scalar_type:
-            logger.warning("Maximum is ambiguous in complex mode")
-
-        k = o._ufl_handler_name_
-        name = math_table[self.scalar_type].get(k)
-        return self.L.Call(name, args)
-
-    def min_value(self, o, *args):
-        if "complex" in self.scalar_type:
-            logger.warning("Minimum is ambiguous in complex mode")
-
-        k = o._ufl_handler_name_
-        name = math_table[self.scalar_type].get(k)
         return self.L.Call(name, args)
 
     # === Formatting rules for bessel functions ===


### PR DESCRIPTION
Addresses https://github.com/FEniCS/ffcx/issues/145

The complex case then falls to `fmax/fmaxf` which basically compares only first `double/float` bits of the complex number, effectively taking only maximum of the real parts of the numbers.

This is safe when arguments are complex but with zero imaginary part (geometric quantities). However, it does not prevent user from `Max(Coefficient())`.

PETSc VecMax/Min takes the maximum of real part only too.