### PR TITLE
Fix naming clashes

### DIFF
--- a/ffc/classname.py
+++ b/ffc/classname.py
@@ -18,9 +18,9 @@ def make_name(prefix, basename, signature):
     return "{}{}_{}".format(pre, basename, sig)
 
 
-def make_integral_name(prefix, integral_type, form_id, subdomain_id):
-    basename = "{}_integral_{}".format(integral_type, str(form_id).lower())
-    return make_name(prefix, basename, subdomain_id)
+def make_integral_name(prefix, integral_type, original_form, form_id, subdomain_id, parameters):
+    sig = compute_signature([original_form], str(form_id), parameters)
+    basename = "{}_integral_{}".format(integral_type, sig)
 
 
 def compute_signature(ufl_objects, tag, parameters, coordinate_mapping=False):

--- a/ffc/classname.py
+++ b/ffc/classname.py
@@ -21,6 +21,7 @@ def make_name(prefix, basename, signature):
 def make_integral_name(prefix, integral_type, original_form, form_id, subdomain_id, parameters):
     sig = compute_signature([original_form], str(form_id), parameters)
     basename = "{}_integral_{}".format(integral_type, sig)
+    return make_name(prefix, basename, subdomain_id)
 
 
 def compute_signature(ufl_objects, tag, parameters, coordinate_mapping=False):

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -142,8 +142,8 @@ def compile_forms(forms, parameters=None):
     # Get a signature for these forms
     module_name = 'libffc_forms_' + ffc.classname.compute_signature(forms, '', p)
 
-    form_names = [ffc.classname.make_name("JIT", "form", i)
-                  for i in range(len(forms))]
+    form_names = [ffc.classname.make_name("JIT", "form", ffc.classname.compute_signature([form], str(i), p))
+                  for i, form in enumerate(forms)]
 
     if p['use_cache']:
         obj, mod = get_cached_module(module_name, form_names, p)

--- a/ffc/ir/representationutils.py
+++ b/ffc/ir/representationutils.py
@@ -11,7 +11,6 @@ import logging
 import numpy
 
 import ufl
-from ffc import classname
 from ffc.fiatinterface import (create_element, create_quadrature, map_facet_points,
                                reference_cell_vertices)
 

--- a/ffc/ir/representationutils.py
+++ b/ffc/ir/representationutils.py
@@ -141,8 +141,7 @@ def initialize_integral_code(ir, parameters):
     """
     code = {}
     code["class_type"] = ir.integral_type + "_integral"
-    code["classname"] = classname.make_integral_name(ir.prefix, ir.integral_type, ir.form_id,
-                                                     ir.subdomain_id)
+    code["classname"] = ir.classname
     code["members"] = ""
     code["constructor"] = ""
     code["constructor_arguments"] = ""


### PR DESCRIPTION
Fixes issue #105 by making a form and integral names not using just their position index (legacy behaviour), but a signature of original form.
Dolfin-x tested here https://github.com/FEniCS/dolfinx/commit/85e130330b834252bbd3e5b66616db9dc98b25fd