### PR TITLE
Fix offsets calculation for interior facet integrals

### DIFF
--- a/ffc/ir/uflacs/uflacsrepresentation.py
+++ b/ffc/ir/uflacs/uflacsrepresentation.py
@@ -106,10 +106,17 @@ def compute_integral_ir(itg_data, form_data, form_id, element_numbers, classname
 
     index_to_coeff = sorted([(v, k) for k, v in coefficient_numbering.items()])
     offsets = {}
+
+    if integral_type in ("interior_facet"):
+        # For interior facet integrals we need + and - restrictions
+        width = 2
+    else:
+        width = 1
+
     _offset = 0
     for k, el in zip(index_to_coeff, form_data.coefficient_elements):
         offsets[k[1]] = _offset
-        _offset += ir["element_dimensions"][el]
+        _offset += width * ir["element_dimensions"][el]
 
     # Copy offsets also into IR
     ir["coefficient_offsets"] = offsets


### PR DESCRIPTION
This PR changes layout of coefficients for form.
New layout is flattened `w[coefficient][restriction][dof]`.

For `f * ufl.dx + g * ufl.dS` FFC generates two integral tabulation kernels. Cell integral expects coefficients as
`[f_dof0, f_dof1, f_dof2, g_dof0, g_dof1, g_dof2]`
while interior facet integral expects
`[f_r0_dof0, f_r0_dof1, f_r0_dof2, f_r1_dof0, f_r1_dof1, f_r1_dof2, ... the same pattern for g]`.