### PR TITLE
Pass extra compile args explicitly to JIT interface

### DIFF
--- a/bench/bench.py
+++ b/bench/bench.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Runs a benchmark study on the form files found in the current directory.
 It relies on the regression test script for timings."""
 

--- a/bench/plot.py
+++ b/bench/plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Plots the results found in bench.log."""
 
 # Copyright (C) 2010 Anders Logg

--- a/bench/utils.py
+++ b/bench/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010 Anders Logg
 #
 # This file is part of FFC.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # Configuration file for the Sphinx documentation builder.
 #
 # This file does only contain a selection of the most common options. For a

--- a/ffc/__init__.py
+++ b/ffc/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2018 FEniCS Project
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/__main__.py
+++ b/ffc/__main__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (C) 2017-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/analysis.py
+++ b/ffc/analysis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2007-2019 Anders Logg, Martin Alnaes, Kristian B. Oelgaard,
 #                         Michal Habera and others
 #

--- a/ffc/classname.py
+++ b/ffc/classname.py
@@ -18,8 +18,8 @@ def make_name(prefix, basename, signature):
     return "{}{}_{}".format(pre, basename, sig)
 
 
-def make_integral_name(prefix, integral_type, original_form, form_id, subdomain_id, parameters):
-    sig = compute_signature([original_form], str(form_id) + ffc.parameters.compute_jit_signature(parameters))
+def make_integral_name(prefix, integral_type, original_form, form_id, subdomain_id):
+    sig = compute_signature([original_form], str(form_id))
     basename = "{}_integral_{}".format(integral_type, sig)
     return make_name(prefix, basename, subdomain_id)
 

--- a/ffc/classname.py
+++ b/ffc/classname.py
@@ -26,15 +26,18 @@ def make_integral_name(prefix, integral_type, original_form, form_id, subdomain_
 
 def compute_signature(ufl_objects, tag, coordinate_mapping=False):
     """Compute the signature hash for jit modules.
-    Based on the UFL type of the objects,
-    relevant compilation parameters, signatures of this ffc version, ufc.h and ufc_geometry.h
-    and an additional optional 'tag' (used with filename for command-line invocation).
+
+    Based on the UFL type of the objects, relevant compilation
+    parameters, signatures of this ffc version, ufc.h and ufc_geometry.h
+    and an additional optional 'tag' (used with filename for
+    command-line invocation).
 
     Note:
     ----
-    The parameter `coordinate_mapping` is used to force compilation of finite element
-    as a coordinate mapping element. There is no way to find this information
-    just by looking at type of `ufl_object` passed.
+    The parameter `coordinate_mapping` is used to force compilation of
+    finite element as a coordinate mapping element. There is no way to
+    find this information just by looking at type of `ufl_object`
+    passed.
 
     """
 
@@ -59,14 +62,6 @@ def compute_signature(ufl_objects, tag, coordinate_mapping=False):
             raise RuntimeError("Unknown ufl object type {}".format(ufl_object.__class__.__name__))
 
     # Build combined signature
-    signatures = [
-        object_signature,
-        str(ffc.__version__),
-        ffc.codegeneration.get_signature(),
-        kind,
-        tag
-    ]
+    signatures = [object_signature, str(ffc.__version__), ffc.codegeneration.get_signature(), kind, tag]
     string = ";".join(signatures)
-    sig = hashlib.sha1(string.encode('utf-8')).hexdigest()
-
-    return sig
+    return hashlib.sha1(string.encode('utf-8')).hexdigest()

--- a/ffc/classname.py
+++ b/ffc/classname.py
@@ -19,12 +19,12 @@ def make_name(prefix, basename, signature):
 
 
 def make_integral_name(prefix, integral_type, original_form, form_id, subdomain_id, parameters):
-    sig = compute_signature([original_form], str(form_id), parameters)
+    sig = compute_signature([original_form], str(form_id) + ffc.parameters.compute_jit_signature(parameters))
     basename = "{}_integral_{}".format(integral_type, sig)
     return make_name(prefix, basename, subdomain_id)
 
 
-def compute_signature(ufl_objects, tag, parameters, coordinate_mapping=False):
+def compute_signature(ufl_objects, tag, coordinate_mapping=False):
     """Compute the signature hash for jit modules.
     Based on the UFL type of the objects,
     relevant compilation parameters, signatures of this ffc version, ufc.h and ufc_geometry.h
@@ -59,12 +59,11 @@ def compute_signature(ufl_objects, tag, parameters, coordinate_mapping=False):
             raise RuntimeError("Unknown ufl object type {}".format(ufl_object.__class__.__name__))
 
     # Compute deterministic string of relevant parameters
-    parameters_signature = ffc.parameters.compute_jit_signature(parameters)
+    # parameters_signature = ffc.parameters.compute_jit_signature(parameters)
 
     # Build combined signature
     signatures = [
         object_signature,
-        parameters_signature,
         str(ffc.__version__),
         ffc.codegeneration.get_signature(),
         kind,

--- a/ffc/classname.py
+++ b/ffc/classname.py
@@ -58,9 +58,6 @@ def compute_signature(ufl_objects, tag, coordinate_mapping=False):
         else:
             raise RuntimeError("Unknown ufl object type {}".format(ufl_object.__class__.__name__))
 
-    # Compute deterministic string of relevant parameters
-    # parameters_signature = ffc.parameters.compute_jit_signature(parameters)
-
     # Build combined signature
     signatures = [
         object_signature,

--- a/ffc/classname.py
+++ b/ffc/classname.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2017 Anders Logg
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/classname.py
+++ b/ffc/classname.py
@@ -26,10 +26,8 @@ def make_integral_name(prefix, integral_type, original_form, form_id, subdomain_
 def compute_signature(ufl_objects, tag, coordinate_mapping=False):
     """Compute the signature hash for jit modules.
 
-    Based on the UFL type of the objects, relevant compilation
-    parameters, signatures of this ffc version, ufc.h and ufc_geometry.h
-    and an additional optional 'tag' (used with filename for
-    command-line invocation).
+    Based on the UFL type of the objects and an additional optional
+    'tag'.
 
     Note:
     ----

--- a/ffc/codegeneration/C/cnodes.py
+++ b/ffc/codegeneration/C/cnodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/C/format_lines.py
+++ b/ffc/codegeneration/C/format_lines.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # This file is part of FFC (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later

--- a/ffc/codegeneration/C/format_value.py
+++ b/ffc/codegeneration/C/format_value.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # This file is part of FFC (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later

--- a/ffc/codegeneration/C/precedence.py
+++ b/ffc/codegeneration/C/precedence.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/C/ufl_to_cnodes.py
+++ b/ffc/codegeneration/C/ufl_to_cnodes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/access.py
+++ b/ffc/codegeneration/access.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/backend.py
+++ b/ffc/codegeneration/backend.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/codegeneration.py
+++ b/ffc/codegeneration/codegeneration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2017 Anders Logg, Martin Sandve Alnæs, Marie E. Rognes,
 # Kristian B. Oelgaard, and others
 #

--- a/ffc/codegeneration/coordinate_mapping.py
+++ b/ffc/codegeneration/coordinate_mapping.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/coordinate_mapping_template.py
+++ b/ffc/codegeneration/coordinate_mapping_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Code generation format strings for UFC (Unified Form-assembly Code)
 # This code is released into the public domain.
 #

--- a/ffc/codegeneration/definitions.py
+++ b/ffc/codegeneration/definitions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/dofmap.py
+++ b/ffc/codegeneration/dofmap.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2018 Anders Logg, Martin Sandve Alnæs and Garth N. Wells
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/dofmap_template.py
+++ b/ffc/codegeneration/dofmap_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Code generation format strings for UFC (Unified Form-assembly Code)
 # This code is released into the public domain.
 #

--- a/ffc/codegeneration/dolfin.py
+++ b/ffc/codegeneration/dolfin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2018 Marie E. Rognes and Garth N. Wells
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/evalderivs.py
+++ b/ffc/codegeneration/evalderivs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Work in progress translation of FFC evaluatebasis code to uflacs CNodes format."""
 
 import logging

--- a/ffc/codegeneration/evaluatebasis.py
+++ b/ffc/codegeneration/evaluatebasis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 
 import numpy

--- a/ffc/codegeneration/evaluatedof.py
+++ b/ffc/codegeneration/evaluatedof.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2017 Anders Logg and Martin Sandve Alnæs, Chris Richardson
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/finite_element.py
+++ b/ffc/codegeneration/finite_element.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2017 Anders Logg and Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/finite_element_template.py
+++ b/ffc/codegeneration/finite_element_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Code generation format strings for UFC (Unified Form-assembly Code)
 # This code is released into the public domain.
 #

--- a/ffc/codegeneration/form.py
+++ b/ffc/codegeneration/form.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2017 Anders Logg and Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/form_template.py
+++ b/ffc/codegeneration/form_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Code generation format strings for UFC (Unified Form-assembly Code)
 # This code is released into the public domain.
 #

--- a/ffc/codegeneration/integrals.py
+++ b/ffc/codegeneration/integrals.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/integrals_template.py
+++ b/ffc/codegeneration/integrals_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Code generation format strings for UFC (Unified Form-assembly Code)
 # This code is released into the public domain.
 #

--- a/ffc/codegeneration/jacobian.py
+++ b/ffc/codegeneration/jacobian.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2017 Anders Logg and Martin Sandve Alnæs, Chris Richardson
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -109,9 +109,9 @@ def compile_elements(elements, parameters=None, extra_compile_args=None):
 
     names = []
     for e in elements:
-        name = ffc.ir.representation.make_finite_element_classname(e, "JIT" + compute_jit_signature(p))
+        name = ffc.ir.representation.make_finite_element_classname(e, "JIT")
         names.append(name)
-        name = ffc.ir.representation.make_dofmap_classname(e, "JIT" + compute_jit_signature(p))
+        name = ffc.ir.representation.make_dofmap_classname(e, "JIT")
         names.append(name)
 
     if p['use_cache']:
@@ -150,7 +150,7 @@ def compile_forms(forms, parameters=None, extra_compile_args=None):
         ffc.classname.compute_signature(forms, compute_jit_signature(p) + str(extra_compile_args))
 
     form_names = [ffc.classname.make_name("JIT", "form",
-                                          ffc.classname.compute_signature([form], str(i) + compute_jit_signature(p)))
+                                          ffc.classname.compute_signature([form], str(i)))
                   for i, form in enumerate(forms)]
 
     if p['use_cache']:
@@ -182,7 +182,7 @@ def compile_coordinate_maps(meshes, parameters=None, extra_compile_args=None):
         ffc.classname.compute_signature(meshes, compute_jit_signature(p) + str(extra_compile_args), True)
 
     cmap_names = [ffc.ir.representation.make_coordinate_map_classname(
-        mesh.ufl_coordinate_element(), "JIT" + compute_jit_signature(p)) for mesh in meshes]
+        mesh.ufl_coordinate_element(), "JIT") for mesh in meshes]
 
     if p['use_cache']:
         obj, mod = get_cached_module(module_name, cmap_names, p.get("cache_dir"), p.get("timeout"))

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -105,7 +105,7 @@ def compile_elements(elements, parameters=None, extra_compile_args=None):
 
     # Get a signature for these elements
     module_name = 'libffc_elements_' + \
-        ffc.classname.compute_signature(elements, compute_jit_signature(p))
+        ffc.classname.compute_signature(elements, compute_jit_signature(p) + str(extra_compile_args))
 
     names = []
     for e in elements:
@@ -146,7 +146,8 @@ def compile_forms(forms, parameters=None, extra_compile_args=None):
     logger.info('Compiling forms: ' + str(forms))
 
     # Get a signature for these forms
-    module_name = 'libffc_forms_' + ffc.classname.compute_signature(forms, compute_jit_signature(p))
+    module_name = 'libffc_forms_' + \
+        ffc.classname.compute_signature(forms, compute_jit_signature(p) + str(extra_compile_args))
 
     form_names = [ffc.classname.make_name("JIT", "form",
                                           ffc.classname.compute_signature([form], str(i) + compute_jit_signature(p)))
@@ -177,7 +178,8 @@ def compile_coordinate_maps(meshes, parameters=None, extra_compile_args=None):
     logger.info('Compiling cmaps: ' + str(meshes))
 
     # Get a signature for these cmaps
-    module_name = 'libffc_cmaps_' + ffc.classname.compute_signature(meshes, compute_jit_signature(p), True)
+    module_name = 'libffc_cmaps_' + \
+        ffc.classname.compute_signature(meshes, compute_jit_signature(p) + str(extra_compile_args), True)
 
     cmap_names = [ffc.ir.representation.make_coordinate_mapping_jit_classname(
         mesh.ufl_coordinate_element(), "JIT" + compute_jit_signature(p)) for mesh in meshes]

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2018 Garth N. Wells
+rth N. Wells
 #
 # This file is part of FFC (https://www.fenicsproject.org)
 #

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -109,9 +109,9 @@ def compile_elements(elements, parameters=None, extra_compile_args=None):
 
     names = []
     for e in elements:
-        name = ffc.ir.representation.make_finite_element_jit_classname(e, "JIT", p)
+        name = ffc.ir.representation.make_finite_element_jit_classname(e, "JIT" + compute_jit_signature(p))
         names.append(name)
-        name = ffc.ir.representation.make_dofmap_jit_classname(e, "JIT", p)
+        name = ffc.ir.representation.make_dofmap_jit_classname(e, "JIT" + compute_jit_signature(p))
         names.append(name)
 
     if p['use_cache']:
@@ -180,7 +180,7 @@ def compile_coordinate_maps(meshes, parameters=None, extra_compile_args=None):
     module_name = 'libffc_cmaps_' + ffc.classname.compute_signature(meshes, compute_jit_signature(p), True)
 
     cmap_names = [ffc.ir.representation.make_coordinate_mapping_jit_classname(
-        mesh.ufl_coordinate_element(), "JIT", p) for mesh in meshes]
+        mesh.ufl_coordinate_element(), "JIT" + compute_jit_signature(p)) for mesh in meshes]
 
     if p['use_cache']:
         obj, mod = get_cached_module(module_name, cmap_names, p.get("cache_dir"), p.get("timeout"))

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -17,6 +17,7 @@ import cffi
 
 import ffc
 import ffc.config
+from ffc.parameters import compute_jit_signature
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +104,8 @@ def compile_elements(elements, parameters=None, extra_compile_args=None):
     logger.info('Compiling elements: ' + str(elements))
 
     # Get a signature for these elements
-    module_name = 'libffc_elements_' + ffc.classname.compute_signature(elements, '', p)
+    module_name = 'libffc_elements_' + \
+        ffc.classname.compute_signature(elements, compute_jit_signature(p))
 
     names = []
     for e in elements:
@@ -144,9 +146,10 @@ def compile_forms(forms, parameters=None, extra_compile_args=None):
     logger.info('Compiling forms: ' + str(forms))
 
     # Get a signature for these forms
-    module_name = 'libffc_forms_' + ffc.classname.compute_signature(forms, '', p)
+    module_name = 'libffc_forms_' + ffc.classname.compute_signature(forms, compute_jit_signature(p))
 
-    form_names = [ffc.classname.make_name("JIT", "form", ffc.classname.compute_signature([form], str(i), p))
+    form_names = [ffc.classname.make_name("JIT", "form",
+                                          ffc.classname.compute_signature([form], str(i) + compute_jit_signature(p)))
                   for i, form in enumerate(forms)]
 
     if p['use_cache']:
@@ -174,7 +177,7 @@ def compile_coordinate_maps(meshes, parameters=None, extra_compile_args=None):
     logger.info('Compiling cmaps: ' + str(meshes))
 
     # Get a signature for these cmaps
-    module_name = 'libffc_cmaps_' + ffc.classname.compute_signature(meshes, '', p, True)
+    module_name = 'libffc_cmaps_' + ffc.classname.compute_signature(meshes, compute_jit_signature(p), True)
 
     cmap_names = [ffc.ir.representation.make_coordinate_mapping_jit_classname(
         mesh.ufl_coordinate_element(), "JIT", p) for mesh in meshes]

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -149,8 +149,7 @@ def compile_forms(forms, parameters=None, extra_compile_args=None):
     module_name = 'libffc_forms_' + \
         ffc.classname.compute_signature(forms, compute_jit_signature(p) + str(extra_compile_args))
 
-    form_names = [ffc.classname.make_name("JIT", "form",
-                                          ffc.classname.compute_signature([form], str(i)))
+    form_names = [ffc.classname.make_name("JIT", "form", ffc.classname.compute_signature([form], str(i)))
                   for i, form in enumerate(forms)]
 
     if p['use_cache']:

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -219,7 +219,7 @@ def _compile_objects(decl, ufl_objects, object_names, module_name, parameters,
 
     # Compile (ensuring that compile dir exists)
     compile_dir.mkdir(exist_ok=True, parents=True)
-    ffibuilder.compile(tmpdir=compile_dir, verbose=False)
+    ffibuilder.compile(tmpdir=compile_dir, verbose=cffi_verbose, debug=cffi_debug)
 
     # Create a "status ready" file. If this fails, it is an error,
     # because it should not exist yet.

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -109,9 +109,9 @@ def compile_elements(elements, parameters=None, extra_compile_args=None):
 
     names = []
     for e in elements:
-        name = ffc.ir.representation.make_finite_element_jit_classname(e, "JIT" + compute_jit_signature(p))
+        name = ffc.ir.representation.make_finite_element_classname(e, "JIT" + compute_jit_signature(p))
         names.append(name)
-        name = ffc.ir.representation.make_dofmap_jit_classname(e, "JIT" + compute_jit_signature(p))
+        name = ffc.ir.representation.make_dofmap_classname(e, "JIT" + compute_jit_signature(p))
         names.append(name)
 
     if p['use_cache']:
@@ -181,7 +181,7 @@ def compile_coordinate_maps(meshes, parameters=None, extra_compile_args=None):
     module_name = 'libffc_cmaps_' + \
         ffc.classname.compute_signature(meshes, compute_jit_signature(p) + str(extra_compile_args), True)
 
-    cmap_names = [ffc.ir.representation.make_coordinate_mapping_jit_classname(
+    cmap_names = [ffc.ir.representation.make_coordinate_map_classname(
         mesh.ufl_coordinate_element(), "JIT" + compute_jit_signature(p)) for mesh in meshes]
 
     if p['use_cache']:

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -166,7 +166,7 @@ def compile_forms(forms, parameters=None, extra_compile_args=None):
     return _compile_objects(decl, forms, form_names, module_name, p, extra_compile_args)
 
 
-def compile_coordinate_maps(meshes, parameters=None):
+def compile_coordinate_maps(meshes, parameters=None, extra_compile_args=None):
     """Compile a list of UFL coordinate mappings into UFC Python objects."""
     p = ffc.parameters.default_parameters()
     if parameters is not None:

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -57,10 +57,9 @@ UFC_INTEGRAL_DECL += '\n'.join(re.findall('typedef struct ufc_custom_integral.*?
                                           ufc_h, re.DOTALL))
 
 
-def get_cached_module(module_name, object_names, parameters):
+def get_cached_module(module_name, object_names, cache_dir, timeout):
     """Look for an existing C file and wait for compilation, or if it does not exist, create it."""
-    cache_dir = ffc.config.get_cache_path(parameters)
-    timeout = int(parameters.get("timeout", 10))
+    cache_dir = ffc.config.get_cache_path(cache_dir)
     c_filename = cache_dir.joinpath(module_name).with_suffix(".c")
     ready_name = c_filename.with_suffix(".c.cached")
 
@@ -114,7 +113,7 @@ def compile_elements(elements, parameters=None, extra_compile_args=None):
         names.append(name)
 
     if p['use_cache']:
-        obj, mod = get_cached_module(module_name, names, p)
+        obj, mod = get_cached_module(module_name, names, p.get("cache_dir"), p.get("timeout"))
         if obj is not None:
             # Pair up elements with dofmaps
             obj = list(zip(obj[::2], obj[1::2]))
@@ -151,7 +150,7 @@ def compile_forms(forms, parameters=None, extra_compile_args=None):
                   for i, form in enumerate(forms)]
 
     if p['use_cache']:
-        obj, mod = get_cached_module(module_name, form_names, p)
+        obj, mod = get_cached_module(module_name, form_names, p.get("cache_dir"), p.get("timeout"))
         if obj is not None:
             return obj, mod
 
@@ -181,7 +180,7 @@ def compile_coordinate_maps(meshes, parameters=None, extra_compile_args=None):
         mesh.ufl_coordinate_element(), "JIT", p) for mesh in meshes]
 
     if p['use_cache']:
-        obj, mod = get_cached_module(module_name, cmap_names, p)
+        obj, mod = get_cached_module(module_name, cmap_names, p.get("cache_dir"), p.get("timeout"))
         if obj is not None:
             return obj, mod
 
@@ -198,7 +197,7 @@ def compile_coordinate_maps(meshes, parameters=None, extra_compile_args=None):
 def _compile_objects(decl, ufl_objects, object_names, module_name, parameters,
                      extra_compile_args):
     if (parameters['use_cache']):
-        compile_dir = ffc.config.get_cache_path(parameters)
+        compile_dir = ffc.config.get_cache_path(parameters.get("cache_dir"))
     else:
         compile_dir = Path(tempfile.mkdtemp())
     _, code_body = ffc.compiler.compile_ufl_objects(ufl_objects, prefix="JIT", parameters=parameters)

--- a/ffc/codegeneration/symbols.py
+++ b/ffc/codegeneration/symbols.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/uflacsgenerator.py
+++ b/ffc/codegeneration/uflacsgenerator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/codegeneration/utils.py
+++ b/ffc/codegeneration/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2007-2017 Anders Logg
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/config.py
+++ b/ffc/config.py
@@ -11,14 +11,13 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def get_cache_path(parameters):
+def get_cache_path(cache_dir):
     """Get the path for the JIT cache."""
+    # Use local cache if cache_dir is None
+    if cache_dir is None:
+        cache_dir = Path.cwd() / "compile-cache"
 
-    # Get cache path from parameters, with fallback to current working
-    # directory
-    cache_dir = parameters.get("cache_dir", Path.cwd() / "compile-cache")
-
-    # Check for cache environment variable
+    # If cache environment variable is set, override
     cache_dir = os.getenv('FENICS_CACHE_DIR', cache_dir)
 
     return Path(cache_dir).expanduser()

--- a/ffc/fiatinterface.py
+++ b/ffc/fiatinterface.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2017 Kristian B. Oelgaard and Anders Logg
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/formatting.py
+++ b/ffc/formatting.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2018 Anders Logg and Garth N. Wells
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -128,7 +128,8 @@ def compute_ir(analysis: namedtuple, object_names, prefix, parameters):
     # Compute representation of elements
     logger.info("Computing representation of {} elements".format(len(analysis.unique_elements)))
     ir_elements = [
-        _compute_element_ir(e, analysis.element_numbers, classnames, parameters["epsilon"]) for e in analysis.unique_elements
+        _compute_element_ir(e, analysis.element_numbers, classnames, parameters["epsilon"])
+        for e in analysis.unique_elements
     ]
 
     # Compute representation of dofmaps

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -84,34 +84,34 @@ ir_evaluate_dof = namedtuple('ir_evaluate_dof', ['mappings', 'reference_value_si
 ir_data = namedtuple('ir_data', ['elements', 'dofmaps', 'coordinate_mappings', 'integrals', 'forms'])
 
 
-def make_finite_element_jit_classname(ufl_element, tag, p):
+def make_finite_element_jit_classname(ufl_element, tag):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
-    sig = classname.compute_signature([ufl_element], tag + compute_jit_signature(p))
+    sig = classname.compute_signature([ufl_element], tag)
     return classname.make_name("ffc_element_{}".format(sig), "finite_element", "main")
 
 
-def make_dofmap_jit_classname(ufl_element, tag, p):
+def make_dofmap_jit_classname(ufl_element, tag):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
-    sig = classname.compute_signature([ufl_element], tag + compute_jit_signature(p))
+    sig = classname.compute_signature([ufl_element], tag)
     return classname.make_name("ffc_element_{}".format(sig), "dofmap", "main")
 
 
-def make_coordinate_mapping_jit_classname(ufl_element, tag, p):
+def make_coordinate_mapping_jit_classname(ufl_element, tag):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
     sig = classname.compute_signature(
-        [ufl_element], tag + compute_jit_signature(p), coordinate_mapping=True)
+        [ufl_element], tag, coordinate_mapping=True)
     return classname.make_name("ffc_coordinate_mapping_{}".format(sig), "coordinate_mapping", "main")
 
 
 def make_all_element_classnames(prefix, elements, coordinate_elements, parameters):
     # Make unique classnames to match separately jit-compiled module
     classnames = {
-        "finite_element": {e: make_finite_element_jit_classname(e, prefix, parameters)
+        "finite_element": {e: make_finite_element_jit_classname(e, prefix + compute_jit_signature(parameters))
                            for e in elements},
-        "dofmap": {e: make_dofmap_jit_classname(e, prefix, parameters)
+        "dofmap": {e: make_dofmap_jit_classname(e, prefix + compute_jit_signature(parameters))
                    for e in elements},
         "coordinate_mapping":
-        {e: make_coordinate_mapping_jit_classname(e, prefix, parameters)
+        {e: make_coordinate_mapping_jit_classname(e, prefix + compute_jit_signature(parameters))
          for e in coordinate_elements},
     }
     return classnames

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -128,20 +128,20 @@ def compute_ir(analysis: namedtuple, object_names, prefix, parameters):
     # Compute representation of elements
     logger.info("Computing representation of {} elements".format(len(analysis.unique_elements)))
     ir_elements = [
-        _compute_element_ir(e, analysis.element_numbers, classnames, parameters) for e in analysis.unique_elements
+        _compute_element_ir(e, analysis.element_numbers, classnames, parameters["epsilon"]) for e in analysis.unique_elements
     ]
 
     # Compute representation of dofmaps
     logger.info("Computing representation of {} dofmaps".format(len(analysis.unique_elements)))
     ir_dofmaps = [
-        _compute_dofmap_ir(e, analysis.element_numbers, classnames, parameters) for e in analysis.unique_elements
+        _compute_dofmap_ir(e, analysis.element_numbers, classnames) for e in analysis.unique_elements
     ]
 
     # Compute representation of coordinate mappings
     logger.info("Computing representation of {} coordinate mappings".format(
         len(analysis.unique_coordinate_elements)))
     ir_coordinate_mappings = [
-        _compute_coordinate_mapping_ir(e, analysis.element_numbers, classnames, parameters)
+        _compute_coordinate_mapping_ir(e, analysis.element_numbers, classnames)
         for e in analysis.unique_coordinate_elements
     ]
 
@@ -166,7 +166,7 @@ def compute_ir(analysis: namedtuple, object_names, prefix, parameters):
                    integrals=ir_integrals, forms=ir_forms)
 
 
-def _compute_element_ir(ufl_element, element_numbers, classnames, parameters):
+def _compute_element_ir(ufl_element, element_numbers, classnames, epsilon):
     """Compute intermediate representation of element."""
     # Create FIAT element
     fiat_element = create_element(ufl_element)
@@ -189,7 +189,7 @@ def _compute_element_ir(ufl_element, element_numbers, classnames, parameters):
     ir["degree"] = ufl_element.degree()
     ir["family"] = ufl_element.family()
 
-    ir["evaluate_basis"] = _evaluate_basis(ufl_element, fiat_element, parameters["epsilon"])
+    ir["evaluate_basis"] = _evaluate_basis(ufl_element, fiat_element, epsilon)
     ir["evaluate_dof"] = _evaluate_dof(ufl_element, fiat_element)
     ir["tabulate_dof_coordinates"] = _tabulate_dof_coordinates(ufl_element, fiat_element)
     ir["num_sub_elements"] = ufl_element.num_sub_elements()
@@ -198,7 +198,7 @@ def _compute_element_ir(ufl_element, element_numbers, classnames, parameters):
     return ir_element(**ir)
 
 
-def _compute_dofmap_ir(ufl_element, element_numbers, classnames, parameters):
+def _compute_dofmap_ir(ufl_element, element_numbers, classnames):
     """Compute intermediate representation of dofmap."""
     # Create FIAT element
     fiat_element = create_element(ufl_element)
@@ -278,8 +278,7 @@ def _tabulate_coordinate_mapping_basis(ufl_element):
 
 def _compute_coordinate_mapping_ir(ufl_coordinate_element,
                                    element_numbers,
-                                   classnames,
-                                   parameters):
+                                   classnames):
     """Compute intermediate representation of coordinate mapping."""
     cell = ufl_coordinate_element.cell()
     cellname = cell.cellname()

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -28,6 +28,7 @@ from ffc import classname
 from ffc.fiatinterface import (EnrichedElement, FlattenedDimensions,
                                MixedElement, QuadratureElement, SpaceOfReals,
                                create_element)
+from ffc.parameters import compute_jit_signature
 from FIAT.hdiv_trace import HDivTrace
 
 logger = logging.getLogger(__name__)
@@ -83,21 +84,22 @@ ir_evaluate_dof = namedtuple('ir_evaluate_dof', ['mappings', 'reference_value_si
 ir_data = namedtuple('ir_data', ['elements', 'dofmaps', 'coordinate_mappings', 'integrals', 'forms'])
 
 
-def make_finite_element_jit_classname(ufl_element, tag, parameters):
+def make_finite_element_jit_classname(ufl_element, tag, p):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
-    sig = classname.compute_signature([ufl_element], tag, parameters)
+    sig = classname.compute_signature([ufl_element], tag + compute_jit_signature(p))
     return classname.make_name("ffc_element_{}".format(sig), "finite_element", "main")
 
 
-def make_dofmap_jit_classname(ufl_element, tag, parameters):
+def make_dofmap_jit_classname(ufl_element, tag, p):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
-    sig = classname.compute_signature([ufl_element], tag, parameters)
+    sig = classname.compute_signature([ufl_element], tag + compute_jit_signature(p))
     return classname.make_name("ffc_element_{}".format(sig), "dofmap", "main")
 
 
-def make_coordinate_mapping_jit_classname(ufl_element, tag, parameters):
+def make_coordinate_mapping_jit_classname(ufl_element, tag, p):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
-    sig = classname.compute_signature([ufl_element], tag, parameters, coordinate_mapping=True)
+    sig = classname.compute_signature(
+        [ufl_element], tag + compute_jit_signature(p), coordinate_mapping=True)
     return classname.make_name("ffc_coordinate_mapping_{}".format(sig), "coordinate_mapping", "main")
 
 
@@ -386,7 +388,7 @@ def _compute_form_ir(form_data, form_id, prefix, element_numbers,
 
     # Compute common data
     ir["classname"] = classname.make_name(prefix, "form", classname.compute_signature([
-                                          form_data.original_form], str(form_id), parameters))
+                                          form_data.original_form], str(form_id) + compute_jit_signature(parameters)))
 
     ir["signature"] = form_data.original_form.signature()
 

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2017 Anders Logg, Martin Sandve Alnæs, Marie E. Rognes,
 # Kristian B. Oelgaard, and others
 #

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -84,19 +84,19 @@ ir_evaluate_dof = namedtuple('ir_evaluate_dof', ['mappings', 'reference_value_si
 ir_data = namedtuple('ir_data', ['elements', 'dofmaps', 'coordinate_mappings', 'integrals', 'forms'])
 
 
-def make_finite_element_jit_classname(ufl_element, tag):
+def make_finite_element_classname(ufl_element, tag):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
     sig = classname.compute_signature([ufl_element], tag)
     return classname.make_name("ffc_element_{}".format(sig), "finite_element", "main")
 
 
-def make_dofmap_jit_classname(ufl_element, tag):
+def make_dofmap_classname(ufl_element, tag):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
     sig = classname.compute_signature([ufl_element], tag)
     return classname.make_name("ffc_element_{}".format(sig), "dofmap", "main")
 
 
-def make_coordinate_mapping_jit_classname(ufl_element, tag):
+def make_coordinate_map_classname(ufl_element, tag):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
     sig = classname.compute_signature(
         [ufl_element], tag, coordinate_mapping=True)
@@ -106,12 +106,12 @@ def make_coordinate_mapping_jit_classname(ufl_element, tag):
 def make_all_element_classnames(prefix, elements, coordinate_elements, parameters):
     # Make unique classnames to match separately jit-compiled module
     classnames = {
-        "finite_element": {e: make_finite_element_jit_classname(e, prefix + compute_jit_signature(parameters))
+        "finite_element": {e: make_finite_element_classname(e, prefix + compute_jit_signature(parameters))
                            for e in elements},
-        "dofmap": {e: make_dofmap_jit_classname(e, prefix + compute_jit_signature(parameters))
+        "dofmap": {e: make_dofmap_classname(e, prefix + compute_jit_signature(parameters))
                    for e in elements},
         "coordinate_mapping":
-        {e: make_coordinate_mapping_jit_classname(e, prefix + compute_jit_signature(parameters))
+        {e: make_coordinate_map_classname(e, prefix + compute_jit_signature(parameters))
          for e in coordinate_elements},
     }
     return classnames

--- a/ffc/ir/representation.py
+++ b/ffc/ir/representation.py
@@ -97,21 +97,16 @@ def make_dofmap_classname(ufl_element, tag):
 
 def make_coordinate_map_classname(ufl_element, tag):
     assert isinstance(ufl_element, ufl.FiniteElementBase)
-    sig = classname.compute_signature(
-        [ufl_element], tag, coordinate_mapping=True)
+    sig = classname.compute_signature([ufl_element], tag, coordinate_mapping=True)
     return classname.make_name("ffc_coordinate_mapping_{}".format(sig), "coordinate_mapping", "main")
 
 
 def make_all_element_classnames(prefix, elements, coordinate_elements):
     # Make unique classnames to match separately jit-compiled module
     classnames = {
-        "finite_element": {e: make_finite_element_classname(e, prefix)
-                           for e in elements},
-        "dofmap": {e: make_dofmap_classname(e, prefix)
-                   for e in elements},
-        "coordinate_mapping":
-        {e: make_coordinate_map_classname(e, prefix)
-         for e in coordinate_elements},
+        "finite_element": {e: make_finite_element_classname(e, prefix) for e in elements},
+        "dofmap": {e: make_dofmap_classname(e, prefix) for e in elements},
+        "coordinate_mapping": {e: make_coordinate_map_classname(e, prefix) for e in coordinate_elements},
     }
     return classnames
 
@@ -158,13 +153,11 @@ def compute_ir(analysis: namedtuple, object_names, prefix, parameters):
     # Compute representation of forms
     logger.info("Computing representation of forms")
     ir_forms = [
-        _compute_form_ir(fd, i, prefix, analysis.element_numbers,
-                         classnames, object_names, parameters)
+        _compute_form_ir(fd, i, prefix, analysis.element_numbers, classnames, object_names)
         for (i, fd) in enumerate(analysis.form_data)
     ]
 
-    return ir_data(elements=ir_elements, dofmaps=ir_dofmaps,
-                   coordinate_mappings=ir_coordinate_mappings,
+    return ir_data(elements=ir_elements, dofmaps=ir_dofmaps, coordinate_mappings=ir_coordinate_mappings,
                    integrals=ir_integrals, forms=ir_forms)
 
 
@@ -374,8 +367,7 @@ def _compute_integral_ir(form_data, form_index, prefix, element_numbers, classna
     return irs
 
 
-def _compute_form_ir(form_data, form_id, prefix, element_numbers,
-                     classnames, object_names, parameters):
+def _compute_form_ir(form_data, form_id, prefix, element_numbers, classnames, object_names):
     """Compute intermediate representation of form."""
 
     # Store id
@@ -426,7 +418,7 @@ def _compute_form_ir(form_data, form_id, prefix, element_numbers,
     # Create integral ids and names using form prefix (integrals are
     # always generated as part of form so don't get their own prefix)
     for integral_type in ufc_integral_types:
-        irdata = _create_foo_integral(prefix, form_id, integral_type, form_data, parameters)
+        irdata = _create_foo_integral(prefix, form_id, integral_type, form_data)
         ir["create_{}_integral".format(integral_type)] = irdata
         ir["get_{}_integral_ids".format(integral_type)] = irdata
 
@@ -435,8 +427,11 @@ def _compute_form_ir(form_data, form_id, prefix, element_numbers,
 
 def _generate_reference_offsets(fiat_element, offset=0):
     """Generate offsets.
-    i.e. value offset for each basis function
-    relative to a reference element representation."""
+
+    I.e., value offset for each basis function relative to a reference
+    element representation.
+
+    """
     if isinstance(fiat_element, MixedElement):
         offsets = []
         for e in fiat_element.elements():
@@ -456,8 +451,11 @@ def _generate_reference_offsets(fiat_element, offset=0):
 
 def _generate_physical_offsets(ufl_element, offset=0):
     """Generate offsets.
-    i.e. value offset for each basis function
-    relative to a physical element representation."""
+
+    I.e.. value offset for each basis function relative to a physical
+    element representation.
+
+    """
     cell = ufl_element.cell()
     gdim = cell.geometric_dimension()
     tdim = cell.topological_dimension()
@@ -488,8 +486,11 @@ def _generate_physical_offsets(ufl_element, offset=0):
 
 def _generate_offsets(ufl_element, reference_offset=0, physical_offset=0):
     """Generate offsets.
-    i.e. value offset for each basis function
-    relative to a physical element representation."""
+
+    I.e., value offset for each basis function relative to a physical
+    element representation.
+
+    """
     if isinstance(ufl_element, ufl.MixedElement):
         offsets = []
         for e in ufl_element.sub_elements():
@@ -706,12 +707,10 @@ def _tabulate_dof_coordinates(ufl_element, element):
         cell_shape=cell.cellname())
 
 
-def _create_foo_integral(prefix, form_id, integral_type, form_data, parameters):
+def _create_foo_integral(prefix, form_id, integral_type, form_data):
     """Compute intermediate representation of create_foo_integral."""
-
     subdomain_ids = []
     classnames = []
-
     itg_data = [itg_data for itg_data in form_data.integral_data
                 if (itg_data.integral_type == integral_type and itg_data.subdomain_id == "otherwise")]
 
@@ -751,9 +750,7 @@ def _num_dofs_per_entity(fiat_element):
 
 
 def uses_integral_moments(fiat_element):
-    """True if element uses integral moments for its degrees of freedom.
-
-    """
+    """True if element uses integral moments for its degrees of freedom."""
     integrals = set(["IntegralMoment", "FrobeniusIntegralMoment"])
     tags = set([L.get_type_tag() for L in fiat_element.dual_basis() if L])
     return len(integrals & tags) > 0

--- a/ffc/ir/representationutils.py
+++ b/ffc/ir/representationutils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012-2017 Marie Rognes
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/analysis/__init__.py
+++ b/ffc/ir/uflacs/analysis/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/analysis/factorization.py
+++ b/ffc/ir/uflacs/analysis/factorization.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/analysis/graph.py
+++ b/ffc/ir/uflacs/analysis/graph.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/analysis/indexing.py
+++ b/ffc/ir/uflacs/analysis/indexing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/analysis/modified_terminals.py
+++ b/ffc/ir/uflacs/analysis/modified_terminals.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/analysis/reconstruct.py
+++ b/ffc/ir/uflacs/analysis/reconstruct.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs and Chris Richardson
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/analysis/valuenumbering.py
+++ b/ffc/ir/uflacs/analysis/valuenumbering.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/analysis/visualise.py
+++ b/ffc/ir/uflacs/analysis/visualise.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2018 Chris Richardson
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/build_uflacs_ir.py
+++ b/ffc/ir/uflacs/build_uflacs_ir.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/elementtables.py
+++ b/ffc/ir/uflacs/elementtables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/tools.py
+++ b/ffc/ir/uflacs/tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2009-2017 Kristian B. Oelgaard and Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/ir/uflacs/uflacsrepresentation.py
+++ b/ffc/ir/uflacs/uflacsrepresentation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013-2017 Martin Sandve Alnæs
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/main.py
+++ b/ffc/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2004-2018 Anders Logg and Garth N. Wells
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/parameters.py
+++ b/ffc/parameters.py
@@ -109,6 +109,5 @@ def compilation_relevant_parameters(parameters):
 
 def compute_jit_signature(parameters):
     """Return parameters signature (some parameters must be ignored)."""
-    from ufl.utils.sorting import canonicalize_metadata
     parameters = compilation_relevant_parameters(parameters)
-    return str(canonicalize_metadata(parameters))
+    return str(sorted(parameters.items()))

--- a/ffc/parameters.py
+++ b/ffc/parameters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2005-2017 Anders Logg
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/ffc/parameters.py
+++ b/ffc/parameters.py
@@ -108,6 +108,6 @@ def compilation_relevant_parameters(parameters):
 
 
 def compute_jit_signature(parameters):
-    """Return parameters signature (some parameters must be ignored)."""
+    """Return parameters signature (some parameters should not affect signature)."""
     parameters = compilation_relevant_parameters(parameters)
     return str(sorted(parameters.items()))

--- a/ffc/parameters.py
+++ b/ffc/parameters.py
@@ -30,8 +30,6 @@ _FFC_CACHE_PARAMETERS = {
     "output_dir": ".",  # output directory for generated code
 }
 _FFC_LOG_PARAMETERS = {
-    # "log_level": INFO + 5,  # log level, displaying only messages with level >= log_level
-    "log_prefix": "",  # log prefix
     "visualise": False,
 }
 FFC_PARAMETERS = {}

--- a/ffc/parameters.py
+++ b/ffc/parameters.py
@@ -25,9 +25,6 @@ _FFC_GENERATE_PARAMETERS = {
     "timeout": 10,  # Max time to wait on cache if not building on this process (seconds)
     "external_includes": "",  # ':' separated list of include filenames to add to generated code
 }
-_FFC_BUILD_PARAMETERS = {
-    "external_include_dirs": "",  # ':' separated list of include dirs to add when JIT compiling
-}
 _FFC_CACHE_PARAMETERS = {
     "use_cache": True,
     "cache_dir": "~/.cache/fenics",  # cache dir used by default
@@ -39,7 +36,6 @@ _FFC_LOG_PARAMETERS = {
     "visualise": False,
 }
 FFC_PARAMETERS = {}
-FFC_PARAMETERS.update(_FFC_BUILD_PARAMETERS)
 FFC_PARAMETERS.update(_FFC_CACHE_PARAMETERS)
 FFC_PARAMETERS.update(_FFC_LOG_PARAMETERS)
 FFC_PARAMETERS.update(_FFC_GENERATE_PARAMETERS)

--- a/ffc/wrappers.py
+++ b/ffc/wrappers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010-2017 Anders Logg
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 import subprocess

--- a/test/ffc/test_elements.py
+++ b/test/ffc/test_elements.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 "Unit tests for FFC"
 
 # Copyright (C) 2007-2017 Anders Logg and Garth N. Wells

--- a/test/ufc/test_add_mode.py
+++ b/test/ufc/test_add_mode.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2019 Chris Richardson
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/test/ufc/test_cache.py
+++ b/test/ufc/test_cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2019 Chris Richardson
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2018 Garth N. Wells
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/test/ufc/test_cffi_3d.py
+++ b/test/ufc/test_cffi_3d.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2018 Chris Richardson
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/test/ufc/test_cmdline.py
+++ b/test/ufc/test_cmdline.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2018 Chris N. Richardson
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/test/ufc/test_forms.py
+++ b/test/ufc/test_forms.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2018 Chris N. Richardson
 #
 # This file is part of FFC (https://www.fenicsproject.org)

--- a/test/ufc/xtest_evaluate.py
+++ b/test/ufc/xtest_evaluate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2017 Garth N. Wells
 #
 # This file is part of FFC.


### PR DESCRIPTION
- Remove hardwiring of compiler options (fixes #163).
- Add compiler options to the hash that is added to the module name. This was missing.
- Remove unnecessary hashing of  FFC options for function/object names. The parameters are encoded into the JIT module name.  