### PR TITLE
Changing FFCx ordering to be TensorProduct for quads and hexes to match FIAT

### DIFF
--- a/ffc/codegeneration/evaluatebasis.py
+++ b/ffc/codegeneration/evaluatebasis.py
@@ -364,7 +364,7 @@ def _generate_compute_hex_basisvalues(L, basisvalues, Y, embedded_degree,
         bz[r] *= numpy.sqrt(r + 0.5)
 
     for r in range(p * p * p):
-        code += [L.Assign(basisvalues[r], bx[r % p] * by[(r // p) % p] * bz[r // (p * p)])]
+        code += [L.Assign(basisvalues[r], bx[r // (p * p)] * by[(r // p) % p] * bz[r % p])]
 
     return code
 

--- a/ffc/codegeneration/evaluatebasis.py
+++ b/ffc/codegeneration/evaluatebasis.py
@@ -327,7 +327,28 @@ def _generate_compute_quad_basisvalues(L, basisvalues, Y, embedded_degree,
         by[r] *= numpy.sqrt(r + 0.5)
 
     for r in range(p * p):
-        code += [L.Assign(basisvalues[r], bx[r % p] * by[r // p])]
+        # Assumes lexicographical ordering
+        # print(r // p, r % p)
+        # print(r, r % p, r // p)
+        code += [L.Assign(basisvalues[r], bx[r % p] * by[r // p])] # Lexicographic
+        # code += [L.Assign(basisvalues[r], bx[r // p] * by[r % p])] # Correct for P1
+
+    # Add basis values in tensor product ordering, (x0, y0), (x0, yp), ...
+    # rows = [0, p-1, ] +[i for i in range(1,p-1)]
+    # c = 0
+    # for r in rows:
+    #     code += [L.Assign(basisvalues[c], bx[r] * by[0])]
+    #     #print(c, r, 0)
+    #     c+=1
+    #     code += [L.Assign(basisvalues[c], bx[r] * by[p-1])]
+    #     #print(c, r, p-1)
+    #     c+=1
+    #     for y_coord in range(1, p-1):
+    #         code += [L.Assign(basisvalues[c], bx[r] * by[y_coord])]
+    #         #print(c, r, y_coord)
+    #         c+=1
+    # for i in range(c, c+p*p):
+    #     code += [L.Assign(basisvalues[i], bx[(i-p*p) % p] * by[(i-p*p) // p])]
 
     return code
 

--- a/ffc/codegeneration/evaluatebasis.py
+++ b/ffc/codegeneration/evaluatebasis.py
@@ -327,28 +327,7 @@ def _generate_compute_quad_basisvalues(L, basisvalues, Y, embedded_degree,
         by[r] *= numpy.sqrt(r + 0.5)
 
     for r in range(p * p):
-        # Assumes lexicographical ordering
-        # print(r // p, r % p)
-        # print(r, r % p, r // p)
-        code += [L.Assign(basisvalues[r], bx[r % p] * by[r // p])] # Lexicographic
-        # code += [L.Assign(basisvalues[r], bx[r // p] * by[r % p])] # Correct for P1
-
-    # Add basis values in tensor product ordering, (x0, y0), (x0, yp), ...
-    # rows = [0, p-1, ] +[i for i in range(1,p-1)]
-    # c = 0
-    # for r in rows:
-    #     code += [L.Assign(basisvalues[c], bx[r] * by[0])]
-    #     #print(c, r, 0)
-    #     c+=1
-    #     code += [L.Assign(basisvalues[c], bx[r] * by[p-1])]
-    #     #print(c, r, p-1)
-    #     c+=1
-    #     for y_coord in range(1, p-1):
-    #         code += [L.Assign(basisvalues[c], bx[r] * by[y_coord])]
-    #         #print(c, r, y_coord)
-    #         c+=1
-    # for i in range(c, c+p*p):
-    #     code += [L.Assign(basisvalues[i], bx[(i-p*p) % p] * by[(i-p*p) // p])]
+        code += [L.Assign(basisvalues[r], bx[r // p] * by[r % p])]
 
     return code
 

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -214,7 +214,6 @@ def _compile_objects(decl, ufl_objects, object_names, module_name, parameters, c
     else:
         cache_dir = Path(cache_dir)
     _, code_body = ffc.compiler.compile_ufl_objects(ufl_objects, prefix="JIT", parameters=parameters)
-    print(code_body)
 
     ffibuilder = cffi.FFI()
     ffibuilder.set_source(module_name, code_body, include_dirs=[ffc.codegeneration.get_include_path()],

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -126,19 +126,18 @@ def test_cmap_quads(degree, coords):
     e = ufl.VectorElement("Lagrange", cell, degree)
     mesh = ufl.Mesh(e)
     compiled_cmap, module = ffc.codegeneration.jit.compile_coordinate_maps([mesh])
-    X = np.zeros_like(x)
-    X_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X))
 
     coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
 
     x = np.array([[1 / 3, 1 / 3]], dtype=np.float64)
     x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))
-    X_physical = np.zeros_like(x)
-    X_physical_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X_physical))
-    compiled_cmap[0].compute_physical_coordinates(X_physical_ptr, X.shape[0], x_ptr, coords_ptr)
+    X = np.zeros_like(x)
+    X_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X))
 
-    assert(np.isclose(X_physical[0, 0], 3 * x[0, 0]))
-    assert(np.isclose(X_physical[0, 1], 2 * x[0, 1]))
+    compiled_cmap[0].compute_physical_coordinates(X_ptr, X.shape[0], x_ptr, coords_ptr)
+
+    assert(np.isclose(X[0, 0], 3 * x[0, 0]))
+    assert(np.isclose(X[0, 1], 2 * x[0, 1]))
 
 
 @pytest.mark.parametrize("mode,expected_result", [

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -113,6 +113,28 @@ def test_cmap():
     assert(np.isclose(X[0, 1], 0.125))
 
 
+@pytest.mark.parametrize("degree,coords", [(1, np.array([[0, 0], [0, 2], [2, 0], [2, 2]], dtype=np.float64)),
+                                           (2, np.array([[0, 0], [0, 2], [0, 1], [2, 0],
+                                                         [2, 2], [2, 1], [1, 0], [1, 2], [1, 1]], dtype=np.float64))])
+def test_cmap_quads(degree, coords):
+    # Test for first and second order quadrilateral meshes,
+    # assuming FIAT Tensor Product layout of cell.
+
+    cell = ufl.quadrilateral
+    e = ufl.VectorElement("Lagrange", cell, degree)
+    mesh = ufl.Mesh(e)
+    compiled_cmap, module = ffc.codegeneration.jit.compile_coordinate_maps([mesh])
+    x = np.array([[1, 0.5]], dtype=np.float64)
+    x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))
+    X = np.zeros_like(x)
+    X_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X))
+
+    coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
+    compiled_cmap[0].compute_reference_coordinates(X_ptr, X.shape[0], x_ptr, coords_ptr, 0)
+    assert(np.isclose(X[0, 0], x[0, 0] / 2))
+    assert(np.isclose(X[0, 1], x[0, 1] / 2))
+
+
 @pytest.mark.parametrize("mode,expected_result", [
     ("double", np.array([[1.0, -0.5, -0.5], [-0.5, 0.5, 0.0], [-0.5, 0.0, 0.5]], dtype=np.float64)),
     ("double complex",

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -109,13 +109,15 @@ def test_cmap():
     coords = np.array([0.0, 0.0, 2.0, 0.0, 0.0, 4.0], dtype=np.float64)
     coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
     compiled_cmap[0].compute_reference_coordinates(X_ptr, X.shape[0], x_ptr, coords_ptr, 0)
+
     assert(np.isclose(X[0, 0], 0.25))
     assert(np.isclose(X[0, 1], 0.125))
 
 
-@pytest.mark.parametrize("degree,coords", [(1, np.array([[0, 0], [0, 2], [2, 0], [2, 2]], dtype=np.float64)),
-                                           (2, np.array([[0, 0], [0, 2], [0, 1], [2, 0],
-                                                         [2, 2], [2, 1], [1, 0], [1, 2], [1, 1]], dtype=np.float64))])
+@pytest.mark.parametrize("degree,coords", [(1, np.array([[0, 0], [0, 2], [3, 0], [3, 2]], dtype=np.float64)),
+                                           (2, np.array([[0, 0], [0, 2], [0, 1], [3, 0],
+                                                         [3, 2], [3, 1], [1.5, 0], [1.5, 2], [1.5, 1]],
+                                                        dtype=np.float64))])
 def test_cmap_quads(degree, coords):
     # Test for first and second order quadrilateral meshes,
     # assuming FIAT Tensor Product layout of cell.
@@ -124,15 +126,25 @@ def test_cmap_quads(degree, coords):
     e = ufl.VectorElement("Lagrange", cell, degree)
     mesh = ufl.Mesh(e)
     compiled_cmap, module = ffc.codegeneration.jit.compile_coordinate_maps([mesh])
-    x = np.array([[1, 0.5]], dtype=np.float64)
+    x = np.array([[0.5, 0.5]], dtype=np.float64)
     x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))
     X = np.zeros_like(x)
     X_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X))
 
     coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
     compiled_cmap[0].compute_reference_coordinates(X_ptr, X.shape[0], x_ptr, coords_ptr, 0)
-    assert(np.isclose(X[0, 0], x[0, 0] / 2))
+
+    assert(np.isclose(X[0, 0], x[0, 0] / 3))
     assert(np.isclose(X[0, 1], x[0, 1] / 2))
+
+    x = np.array([[1 / 3, 1 / 3]], dtype=np.float64)
+    x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))
+    X_physical = np.zeros_like(x)
+    X_physical_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X_physical))
+    compiled_cmap[0].compute_physical_coordinates(X_physical_ptr, X.shape[0], x_ptr, coords_ptr)
+
+    assert(np.isclose(X_physical[0, 0], 3 * x[0, 0]))
+    assert(np.isclose(X_physical[0, 1], 2 * x[0, 1]))
 
 
 @pytest.mark.parametrize("mode,expected_result", [

--- a/test/ufc/test_cffi.py
+++ b/test/ufc/test_cffi.py
@@ -126,16 +126,10 @@ def test_cmap_quads(degree, coords):
     e = ufl.VectorElement("Lagrange", cell, degree)
     mesh = ufl.Mesh(e)
     compiled_cmap, module = ffc.codegeneration.jit.compile_coordinate_maps([mesh])
-    x = np.array([[0.5, 0.5]], dtype=np.float64)
-    x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))
     X = np.zeros_like(x)
     X_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X))
 
     coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
-    compiled_cmap[0].compute_reference_coordinates(X_ptr, X.shape[0], x_ptr, coords_ptr, 0)
-
-    assert(np.isclose(X[0, 0], x[0, 0] / 3))
-    assert(np.isclose(X[0, 1], x[0, 1] / 2))
 
     x = np.array([[1 / 3, 1 / 3]], dtype=np.float64)
     x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))

--- a/test/ufc/test_cffi_3d.py
+++ b/test/ufc/test_cffi_3d.py
@@ -74,8 +74,8 @@ def test_evaluate_reference_basis_hex(hexahedral_element):
 
 @pytest.mark.parametrize("degree,coords", [(1, np.array([[0, 0, 0], [0, 0, 3],
                                                          [0, 2, 0], [0, 2, 3],
-                                                         [1, 0, 0], [2, 0, 3],
-                                                         [1, 2, 0], [2, 2, 3]], dtype=np.float64)),
+                                                         [1, 0, 0], [1, 0, 3],
+                                                         [1, 2, 0], [1, 2, 3]], dtype=np.float64)),
                                            (2, np.array([[0, 0, 0], [0, 0, 3], [0, 0, 1.5],
                                                          [0, 2, 0], [0, 2, 3], [0, 2, 1.5],
                                                          [0, 1, 0], [0, 1, 3], [0, 1, 1.5],
@@ -104,6 +104,16 @@ def test_cmap_hex(degree, coords):
     assert(np.isclose(X[0, 0], x[0, 0] / 1))
     assert(np.isclose(X[0, 1], x[0, 1] / 2))
     assert(np.isclose(X[0, 2], x[0, 2] / 3))
+
+    x = np.array([[1 / 3, 3 / 2, 1]], dtype=np.float64)
+    x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))
+    X_physical = np.zeros_like(x)
+    X_physical_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X_physical))
+    compiled_cmap[0].compute_physical_coordinates(X_physical_ptr, X.shape[0], x_ptr, coords_ptr)
+
+    assert(np.isclose(X_physical[0, 0], x[0, 0]))
+    assert(np.isclose(X_physical[0, 1], 2 * x[0, 1]))
+    assert(np.isclose(X_physical[0, 2], 3 * x[0, 2]))
 
 
 @pytest.mark.parametrize("mode,expected_result", [

--- a/test/ufc/test_cffi_3d.py
+++ b/test/ufc/test_cffi_3d.py
@@ -93,17 +93,10 @@ def test_cmap_hex(degree, coords):
     e = ufl.VectorElement("Lagrange", cell, degree)
     mesh = ufl.Mesh(e)
     compiled_cmap, module = ffc.codegeneration.jit.compile_coordinate_maps([mesh])
-    x = np.array([[0.5, 0.5, 0.5]], dtype=np.float64)
-    x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))
     X = np.zeros_like(x)
     X_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X))
 
     coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
-    compiled_cmap[0].compute_reference_coordinates(X_ptr, X.shape[0], x_ptr, coords_ptr, 0)
-
-    assert(np.isclose(X[0, 0], x[0, 0] / 1))
-    assert(np.isclose(X[0, 1], x[0, 1] / 2))
-    assert(np.isclose(X[0, 2], x[0, 2] / 3))
 
     x = np.array([[1 / 3, 3 / 2, 1]], dtype=np.float64)
     x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))

--- a/test/ufc/test_cffi_3d.py
+++ b/test/ufc/test_cffi_3d.py
@@ -93,20 +93,18 @@ def test_cmap_hex(degree, coords):
     e = ufl.VectorElement("Lagrange", cell, degree)
     mesh = ufl.Mesh(e)
     compiled_cmap, module = ffc.codegeneration.jit.compile_coordinate_maps([mesh])
-    X = np.zeros_like(x)
-    X_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X))
 
     coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
 
     x = np.array([[1 / 3, 3 / 2, 1]], dtype=np.float64)
     x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))
-    X_physical = np.zeros_like(x)
-    X_physical_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X_physical))
-    compiled_cmap[0].compute_physical_coordinates(X_physical_ptr, X.shape[0], x_ptr, coords_ptr)
+    X = np.zeros_like(x)
+    X_ptr = module.ffi.cast("double *", module.ffi.from_buffer(X))
+    compiled_cmap[0].compute_physical_coordinates(X_ptr, X.shape[0], x_ptr, coords_ptr)
 
-    assert(np.isclose(X_physical[0, 0], x[0, 0]))
-    assert(np.isclose(X_physical[0, 1], 2 * x[0, 1]))
-    assert(np.isclose(X_physical[0, 2], 3 * x[0, 2]))
+    assert(np.isclose(X[0, 0], x[0, 0]))
+    assert(np.isclose(X[0, 1], 2 * x[0, 1]))
+    assert(np.isclose(X[0, 2], 3 * x[0, 2]))
 
 
 @pytest.mark.parametrize("mode,expected_result", [


### PR DESCRIPTION
Fixes bug in Quadrilateral meshes.
For second order meshes to be correct, the order in `basisvalues` should be lexicographic, with
x=0, y=0,..,p-1
x=1, y=-,...,p-1

Added test to check that the layout of a cell should be FIAT TensorProduct, i.e. 
```
1--7--4
|        |
2  8   5
|        |
0--6--3
```