### PR TITLE
Fix CI failure after recent updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get update && sudo apt-get install --no-install-recommends graphviz libgraphviz-dev
-            sudo pip install cffi flake8 pydocstyle pytest pytest-cov pytest-xdist pygraphviz coveralls --upgrade
+            sudo pip install cffi flake8 pydocstyle pytest pytest-cov pytest-xdist pygraphviz 'coveralls<1.9' --upgrade
       - run:
           name: Install FEniCS dependencies
           command: |
@@ -30,3 +30,4 @@ jobs:
           command: |
             export PATH=$PATH:$HOME/.local/bin
             python -m pytest --cov=ffc/ -n 4 -v test/
+            coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     working_directory: ~/ffc-test
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
     working_directory: ~/ffc-test
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,4 +30,3 @@ jobs:
           command: |
             export PATH=$PATH:$HOME/.local/bin
             python -m pytest --cov=ffc/ -n 4 -v test/
-            coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get update && sudo apt-get install --no-install-recommends graphviz libgraphviz-dev
-            sudo pip install cffi flake8 pydocstyle pytest pytest-cov pytest-xdist pygraphviz 'coveralls<1.9' --upgrade
+            sudo pip install cffi flake8 pydocstyle pytest pytest-cov pytest-xdist pygraphviz coveralls --upgrade
       - run:
           name: Install FEniCS dependencies
           command: |
@@ -29,5 +29,5 @@ jobs:
           name: Run unit tests
           command: |
             export PATH=$PATH:$HOME/.local/bin
-            python -m pytest --cov=ffc/ -n 4 -v test/
+            coverage run -m pytest --cov=ffc/ -n 4 -v test/
             coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get update && sudo apt-get install --no-install-recommends graphviz libgraphviz-dev
-            sudo pip install cffi flake8 pydocstyle pytest pytest-cov pytest-xdist pygraphviz coveralls --upgrade
+            sudo pip install cffi flake8 pydocstyle pytest 'coverage<5' pytest-cov pytest-xdist pygraphviz coveralls --upgrade
       - run:
           name: Install FEniCS dependencies
           command: |

--- a/ffc/analysis.py
+++ b/ffc/analysis.py
@@ -33,10 +33,10 @@ def analyze_ufl_objects(ufl_objects: typing.Union[typing.List[ufl.form.Form], ty
                         parameters: typing.Dict) -> ufl_data:
     """Analyze ufl object(s).
 
-    Parameters
+    Attributes
     ----------
     ufl_objects
-    parameters
+        Objects to be analysed. Accepts elements, forms, expressions, meshes.
 
     Returns
     -------
@@ -128,13 +128,15 @@ def _analyze_expression(expression: ufl.core.expr.Expr, parameters: typing.Dict)
     return expression
 
 
-def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithms.formdata.FormData:
+def _analyze_form(form: ufl.form.Form, params: typing.Dict) -> ufl.algorithms.formdata.FormData:
     """Analyzes UFL form and attaches metadata.
 
-    Parameters
+    Attributes
     ----------
     form
+        teste
     parameters
+        teste
 
     Returns
     -------

--- a/ffc/analysis.py
+++ b/ffc/analysis.py
@@ -33,7 +33,7 @@ def analyze_ufl_objects(ufl_objects: typing.Union[typing.List[ufl.form.Form], ty
                         parameters: typing.Dict) -> ufl_data:
     """Analyze ufl object(s).
 
-    Attributes
+    Parameters
     ----------
     ufl_objects
         Objects to be analysed. Accepts elements, forms, expressions, meshes.
@@ -131,7 +131,7 @@ def _analyze_expression(expression: ufl.core.expr.Expr, parameters: typing.Dict)
 def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithms.formdata.FormData:
     """Analyzes UFL form and attaches metadata.
 
-    Attributes
+    Parameters
     ----------
     ufl_objects
         Form object to be analyzed

--- a/ffc/analysis.py
+++ b/ffc/analysis.py
@@ -130,14 +130,14 @@ def _analyze_expression(expression: ufl.core.expr.Expr, params: typing.Dict):
     return expression
 
 
-def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithms.formdata.FormData:
+def _analyze_form(form: ufl.form.Form, params: typing.Dict) -> ufl.algorithms.formdata.FormData:
     """Analyzes UFL form and attaches metadata.
 
     Parameters
     ----------
     form
         Form object to be analyzed
-    parameters
+    params
         Dict of FFC parameters
 
     Returns

--- a/ffc/analysis.py
+++ b/ffc/analysis.py
@@ -133,10 +133,8 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
 
     Attributes
     ----------
-    form
-        teste
-    parameters
-        teste
+    ufl_objects
+        Form object to be analyzed
 
     Returns
     -------

--- a/ffc/analysis.py
+++ b/ffc/analysis.py
@@ -128,7 +128,7 @@ def _analyze_expression(expression: ufl.core.expr.Expr, parameters: typing.Dict)
     return expression
 
 
-def _analyze_form(form: ufl.form.Form, params: typing.Dict) -> ufl.algorithms.formdata.FormData:
+def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithms.formdata.FormData:
     """Analyzes UFL form and attaches metadata.
 
     Attributes

--- a/ffc/codegeneration/dolfin.py
+++ b/ffc/codegeneration/dolfin.py
@@ -264,7 +264,7 @@ class UFCFormNames:
                  ufc_dofmap_classnames, ufc_coordinate_mapping_classnames):
         """Encapsulation of the names related to a generated UFC form.
 
-        Attributes
+        Parameters
         ----------
         name
             Name of form (e.g. 'a', 'L', 'M').

--- a/ffc/codegeneration/dolfin.py
+++ b/ffc/codegeneration/dolfin.py
@@ -264,21 +264,21 @@ class UFCFormNames:
                  ufc_dofmap_classnames, ufc_coordinate_mapping_classnames):
         """Encapsulation of the names related to a generated UFC form.
 
-        Arguments:
-        ---------
-        @param name:
+        Attributes
+        ----------
+        name
             Name of form (e.g. 'a', 'L', 'M').
-        @param coefficient_names:
+        coefficient_names
             List of names of form coefficients (e.g. 'f', 'g').
-        @param ufc_form_classname:
+        ufc_form_classname
             Name of ufc::form subclass.
-        @param ufc_finite_element_classnames:
+        ufc_finite_element_classnames
             List of names of ufc::finite_element subclasses (length
             rank + num_coefficients).
-        @param ufc_dofmap_classnames:
+        ufc_dofmap_classnames
             List of names of ufc::dofmap subclasses (length rank +
             num_coefficients).
-        @param ufc_coordinate_mapping_classnames:
+        ufc_coordinate_mapping_classnames
             List of names of ufc::coordinate_mapping subclasses
 
         """

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -179,7 +179,7 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
                         cffi_verbose=False, cffi_debug=None):
     """Compile a list of UFL expressions into UFC Python objects.
 
-    Attributes
+    Parameters
     ----------
     expressions
         List of (UFL expression, evaluation points).

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -179,7 +179,7 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
                         cffi_verbose=False, cffi_debug=None):
     """Compile a list of UFL expressions into UFC Python objects.
 
-    Parameters
+    Attributes
     ----------
     expressions
         List of (UFL expression, evaluation points).

--- a/ffc/codegeneration/jit.py
+++ b/ffc/codegeneration/jit.py
@@ -177,14 +177,7 @@ def compile_forms(forms, parameters=None, cache_dir=None, timeout=10, cffi_extra
 
 def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10, cffi_extra_compile_args=None,
                         cffi_verbose=False, cffi_debug=None):
-    """Compile a list of UFL expressions into UFC Python objects.
-
-    Parameters
-    ----------
-    expressions
-        List of (UFL expression, evaluation points).
-
-    """
+    """Compile a list of UFL expressions into UFC Python objects."""
     p = ffc.parameters.default_parameters()
     if parameters is not None:
         p.update(parameters)

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -91,9 +91,9 @@ def compile_ufl_objects(ufl_objects: typing.Union[typing.List, typing.Tuple],
                         visualise: bool = False):
     """Generate UFC code for a given UFL objects.
 
-    Parameters
+    Attributes
     ----------
-    @param ufl_objects:
+    ufl_objects:
         Objects to be compiled. Accepts elements, forms, integrals or coordinate mappings.
 
     """

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -91,7 +91,7 @@ def compile_ufl_objects(ufl_objects: typing.Union[typing.List, typing.Tuple],
                         visualise: bool = False):
     """Generate UFC code for a given UFL objects.
 
-    Attributes
+    Parameters
     ----------
     ufl_objects:
         Objects to be compiled. Accepts elements, forms, integrals or coordinate mappings.

--- a/ffc/compiler.py
+++ b/ffc/compiler.py
@@ -95,6 +95,14 @@ def compile_ufl_objects(ufl_objects: typing.Union[typing.List, typing.Tuple],
     ----------
     ufl_objects:
         Objects to be compiled. Accepts elements, forms, integrals or coordinate mappings.
+    object_names
+        Object names
+    prefix
+        prefix for all ufl object names
+    parameters
+        Dict of FFC parameters
+    visualise
+        visualise the IR graph
 
     """
     logger.info("Compiling {}\n".format(prefix))

--- a/ffc/git_commit_hash.py.in
+++ b/ffc/git_commit_hash.py.in
@@ -6,5 +6,5 @@
 
 
 def git_commit_hash():
-    """Return git changeset hash (returns "unknown" if changeset is not known)"""
+    """Return git changeset hash (returns "unknown" if changeset is not known)."""
     return "@GIT_COMMIT_HASH"

--- a/ffc/ir/uflacs/uflacsrepresentation.py
+++ b/ffc/ir/uflacs/uflacsrepresentation.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 def compute_expression_ir(expression, analysis, parameters, visualise):
     """Compute IR for expression.
 
-    Parameters
+    Attributes
     ----------
     expression
         Triple of (UFL expression, array of evaluation points, original UFL expression).

--- a/ffc/ir/uflacs/uflacsrepresentation.py
+++ b/ffc/ir/uflacs/uflacsrepresentation.py
@@ -30,6 +30,12 @@ def compute_expression_ir(expression, analysis, parameters, visualise):
     ----------
     expression
         Triple of (UFL expression, array of evaluation points, original UFL expression).
+    analysis
+        Preprocessed UFL expression
+    parameters
+        Dict of FFC parameters
+    visualise
+        Visualise the IR graph
 
     Note
     ----

--- a/ffc/ir/uflacs/uflacsrepresentation.py
+++ b/ffc/ir/uflacs/uflacsrepresentation.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 def compute_expression_ir(expression, analysis, parameters, visualise):
     """Compute IR for expression.
 
-    Attributes
+    Parameters
     ----------
     expression
         Triple of (UFL expression, array of evaluation points, original UFL expression).


### PR DESCRIPTION
After updates of _pydocstyle_ and _coveralls_, master is failing.

**_pydocstyle_:**
When the last agurment of a function is labeled `parameters`, _pydocstyle_ checking breaks. Parameter is a keyword in the numpy doc style, so the confusion. See failing tests in https://circleci.com/gh/FEniCS/ffcx/1079
An alternative is to change the argument  name to `params` for avoiding this failure.

**_coveralls_:**
_Coveralls_ requires `coverage<5.0`, but the docker container has `coverage=5`.
Error message:

> ERROR: coveralls 1.9.2 has requirement coverage<5.0,>=3.6, but you'll have coverage 5.0 which is incompatible