### PR TITLE
Add test for mixed form with gradients

### DIFF
--- a/test/ufc/MixedGradient.ufl
+++ b/test/ufc/MixedGradient.ufl
@@ -1,0 +1,8 @@
+element1 = FiniteElement("DG", triangle, 1)
+element2 = FiniteElement("DGT", triangle, 1)
+element = MixedElement(element1, element2)
+
+u = TrialFunctions(element)[0]
+v = TestFunctions(element)[0]
+
+a = inner(grad(u), grad(v)) * ds

--- a/test/ufc/test_forms.py
+++ b/test/ufc/test_forms.py
@@ -20,3 +20,4 @@ def test_forms():
     ffc.main(["-v", "VectorLaplaceGradCurl.ufl"])
     ffc.main(["-v", "ProjectionManifold.ufl"])
     ffc.main(["-v", "Symmetry.ufl"])
+    ffc.main(["-v", "MixedGradient.ufl"])


### PR DESCRIPTION
Adds a test for the error detailed in https://github.com/FEniCS/dolfinx/issues/684

`test_forms.py` is expected to fail with "ValueError: too many values to unpack (expected 1)" until the fix https://github.com/FEniCS/ffcx/pull/179 is merged.