### PR TITLE
Fix coveralls issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Install dependencies
           command: |
             sudo apt-get update && sudo apt-get install --no-install-recommends graphviz libgraphviz-dev
-            sudo pip install cffi flake8 pydocstyle pytest pytest-cov pytest-xdist pygraphviz coveralls --upgrade
+            sudo pip install cffi 'coverage<5' flake8 pydocstyle pytest pytest-cov pytest-xdist pygraphviz coveralls --upgrade
       - run:
           name: Install FEniCS dependencies
           command: |

--- a/ffc/git_commit_hash.py.in
+++ b/ffc/git_commit_hash.py.in
@@ -6,5 +6,5 @@
 
 
 def git_commit_hash():
-    """Return git changeset hash (returns "unknown" if changeset is not known)"""
+    """Return git changeset hash (returns "unknown" if changeset is not known)."""
     return "@GIT_COMMIT_HASH"

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,5 +19,5 @@ ignore = D100,D101,D102,D103,D104,D105,D107,
          D200,D202,
          D203,  # this error should be disabled
          D205,D209,D213,
-         D401,D416
+         D401,D416, D417
 # convention = numpy


### PR DESCRIPTION
Coveralls requires coverage<5.0, but the docker container currently has coverage=5.
Error message:

>  ERROR: coveralls 1.9.2 has requirement coverage<5.0,>=3.6, but you'll have coverage 5.0 which is incompatible

- Skip pydocstyle D417