### PR TITLE
Restructured vector dof reflections and prevent form compilation warnings

### DIFF
--- a/ffcx/codegeneration/dofmap.py
+++ b/ffcx/codegeneration/dofmap.py
@@ -87,7 +87,7 @@ def generator(ir, parameters):
     for i, perm in enumerate(ir.base_permutations):
         for j, val in enumerate(perm):
             bp.append(str(val))
-    d["base_permutations"] = ("static const int bp[" + str(num_perms * num_dofs) + "] = {"
+    d["base_permutations"] = ("static int bp[" + str(num_perms * num_dofs) + "] = {"
                               + ",".join(bp) + "};\n  dofmap->base_permutations = bp;\n")
     d["size_base_permutations"] = num_perms * num_dofs
 

--- a/ffcx/codegeneration/dofmap.py
+++ b/ffcx/codegeneration/dofmap.py
@@ -87,7 +87,7 @@ def generator(ir, parameters):
     for i, perm in enumerate(ir.base_permutations):
         for j, val in enumerate(perm):
             bp.append(str(val))
-    d["base_permutations"] = ("static int bp[" + str(num_perms * num_dofs) + "] = {"
+    d["base_permutations"] = ("static const int bp[" + str(num_perms * num_dofs) + "] = {"
                               + ",".join(bp) + "};\n  dofmap->base_permutations = bp;\n")
     d["size_base_permutations"] = num_perms * num_dofs
 

--- a/ffcx/codegeneration/finite_element.py
+++ b/ffcx/codegeneration/finite_element.py
@@ -133,6 +133,18 @@ def evaluate_reference_basis_derivatives(L, ir, parameters):
     return generate_evaluate_reference_basis_derivatives(L, data, ir.name, parameters)
 
 
+def get_reflection(L, i):
+    """Returns the bool that says whether or not an entity has been reflected."""
+    if i[0] == 1:
+        edge_reflections = L.Symbol("edge_reflections")
+        return edge_reflections[i[1]]
+    elif i[0] == 2:
+        face_reflections = L.Symbol("face_reflections")
+        return face_reflections[i[1]]
+    else:
+        return L.LiteralBool(False)
+
+
 def transform_reference_basis_derivatives(L, ir, parameters):
     data = ir.evaluate_basis
     if isinstance(data, str):
@@ -265,17 +277,6 @@ def transform_reference_basis_derivatives(L, ir, parameters):
     contains_reflections = False
     reflect_dofs = []
     c_false = L.LiteralBool(False)
-
-    def get_reflection(L, i):
-        """Returns the bool that says whether or not an entity has been reflected."""
-        if i[0] == 1:
-            edge_reflections = L.Symbol("edge_reflections")
-            return edge_reflections[i[1]]
-        elif i[0] == 2:
-            face_reflections = L.Symbol("face_reflections")
-            return face_reflections[i[1]]
-        else:
-            return L.LiteralBool(False)
 
     for dre in ir.dof_reflection_entities:
         if dre is None:

--- a/ffcx/codegeneration/finite_element.py
+++ b/ffcx/codegeneration/finite_element.py
@@ -133,7 +133,7 @@ def evaluate_reference_basis_derivatives(L, ir, parameters):
     return generate_evaluate_reference_basis_derivatives(L, data, ir.name, parameters)
 
 
-def get_reflection(L, i):
+def entity_reflection(L, i):
     """Returns the bool that says whether or not an entity has been reflected."""
     if i[0] == 1:
         edge_reflections = L.Symbol("edge_reflections")
@@ -289,10 +289,10 @@ def transform_reference_basis_derivatives(L, ir, parameters):
             for j in dre:
                 if ref == c_false:
                     # No condition has been added yet, so overwrite false
-                    ref = get_reflection(L, j)
+                    ref = entity_reflection(L, j)
                 else:
                     # This is not the first condition, so XOR
-                    ref = L.Conditional(get_reflection(L, j), L.Not(ref), ref)
+                    ref = L.Conditional(entity_reflection(L, j), L.Not(ref), ref)
             reflect_dofs.append(ref)
             if ref != c_false:
                 # Mark this space as needing reflections

--- a/ffcx/codegeneration/integrals_generator.py
+++ b/ffcx/codegeneration/integrals_generator.py
@@ -165,10 +165,10 @@ class IntegralGenerator(object):
                     for j in dre:
                         if ref == c_false:
                             # No condition has been added yet, so overwrite false
-                            ref = self.backend.symbols.get_reflection(L, j)
+                            ref = self.backend.symbols.entity_reflection(L, j)
                         else:
                             # This is not the first condition, so XOR
-                            ref = L.Conditional(self.backend.symbols.get_reflection(L, j), L.Not(ref), ref)
+                            ref = L.Conditional(self.backend.symbols.entity_reflection(L, j), L.Not(ref), ref)
                     reflect_dofs.append(ref)
                     if ref != c_false:
                         # Mark this space as needing reflections

--- a/ffcx/codegeneration/integrals_generator.py
+++ b/ffcx/codegeneration/integrals_generator.py
@@ -1102,31 +1102,18 @@ class IntegralGenerator(object):
         if isinstance(origin[0], str):
             # If the table is preintegrated, then origin will be a tuple of strings
             # to identify which tables were used for each dof dimension
-            output = 1
-            for i, n in zip(origin, indices[-len(origin):]):
-                element = self.ir.table_origins[i][0]
-                vname = "ref_dof" + str(self.ir.element_ids[element])
-                if self.contains_reflections[vname]:
-                    # If at least one vector dof needs reflecting, return a conditional that gives -1
-                    # if the dof needs negating
-                    output *= L.Conditional(L.Symbol(vname)[get_table_dofmap(L, i, n)], 1, -1)
-
-                # TODO: remove these
-                # output *= get_vector_reflection(self.backend.language, n,
-                #                                "ref_dof" + str(self.ir.element_ids[element]), i)
-            return output
+            tablenames = origin
         else:
-            element = origin[0]
-            vname = "ref_dof" + str(self.ir.element_ids[element])
+            # Otherwise, there is only one tablename; put it in a list so we can iterate
+            tablenames = [pname]
+        used_indices = indices[-len(tablenames):]
 
+        output = 1
+        for tablename, index in zip(tablenames, used_indices):
+            element = self.ir.table_origins[tablename][0]
+            vname = "ref_dof" + str(self.ir.element_ids[element])
             if self.contains_reflections[vname]:
                 # If at least one vector dof needs reflecting, return a conditional that gives -1
                 # if the dof needs negating
-                return L.Conditional(L.Symbol(vname)[get_table_dofmap(L, pname, indices[-1])], 1, -1)
-            else:
-                # If no dofs need reflecting, return 1
-                return 1
-
-            # TODO: remove these
-            # return get_vector_reflection(self.backend.language, indices[-1],
-            #                             "ref_dof" + str(self.ir.element_ids[element]), pname)
+                output *= L.Conditional(L.Symbol(vname)[get_table_dofmap(L, tablename, index)], 1, -1)
+        return output

--- a/ffcx/codegeneration/integrals_generator.py
+++ b/ffcx/codegeneration/integrals_generator.py
@@ -181,18 +181,16 @@ class IntegralGenerator(object):
 
         self.table_dofmaps = {}
         for tname, dofmap in self.ir.table_dofmaps.items():
-            origin = self.ir.table_origins[tname]
-            if origin in self.ir.element_ids:
-                id = self.ir.element_ids[origin]
-                if self.contains_reflections[id]:
-                    # Write the dofmap as it will be needed
-                    for i, j in enumerate(dofmap):
-                        if i != j:
-                            # If a dof has been removed, write the data
-                            self.table_dofmaps[tname] = L.Symbol(tname + "_dofmap")
-                            parts.append(L.ArrayDecl(
-                                "const int", self.table_dofmaps[tname], (len(dofmap), ), values=dofmap))
-                            break
+            id = self.ir.element_ids[self.ir.table_origins[tname][0]]
+            if self.contains_reflections[id]:
+                # Write the dofmap as it will be needed
+                for i, j in enumerate(dofmap):
+                    if i != j:
+                        # If a dof has been removed, write the data
+                        self.table_dofmaps[tname] = L.Symbol(tname + "_dofmap")
+                        parts.append(L.ArrayDecl(
+                            "const int", self.table_dofmaps[tname], (len(dofmap), ), values=dofmap))
+                        break
 
         # Generate the tables of quadrature points and weights
         parts += self.generate_quadrature_tables()

--- a/ffcx/codegeneration/integrals_generator.py
+++ b/ffcx/codegeneration/integrals_generator.py
@@ -15,7 +15,6 @@ from ffcx.codegeneration.C.cnodes import pad_dim, pad_innermost_dim
 from ffcx.codegeneration.C.format_lines import format_indented_lines
 from ffcx.ir.representationutils import initialize_integral_code
 from ffcx.ir.uflacs.elementtables import piecewise_ttypes
-# from ffcx.codegeneration.utils import get_vector_reflection_array, get_vector_reflection, get_table_dofmap_array
 from ffcx.codegeneration.utils import get_table_dofmap_array, get_table_dofmap
 
 logger = logging.getLogger(__name__)

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -92,6 +92,17 @@ class FFCXBackendSymbols(object):
         indices = ["i", "j", "k", "l"]
         return self.S(indices[iarg])
 
+    def get_reflection(self, L, i):
+        """Returns the bool that says whether or not an entity has been reflected."""
+        if i[0] == 1:
+            edge_reflections = L.Symbol("edge_reflections")
+            return edge_reflections[i[1]]
+        elif i[0] == 2:
+            face_reflections = L.Symbol("face_reflections")
+            return face_reflections[i[1]]
+        else:
+            return L.LiteralBool(False)
+
     def coefficient_dof_sum_index(self):
         """Index for loops over coefficient dofs, assumed to never be used in two nested loops."""
         return self.S("ic")

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -92,7 +92,7 @@ class FFCXBackendSymbols(object):
         indices = ["i", "j", "k", "l"]
         return self.S(indices[iarg])
 
-    def get_reflection(self, L, i):
+    def entity_reflection(self, L, i):
         """Returns the bool that says whether or not an entity has been reflected."""
         if i[0] == 1:
             edge_reflections = L.Symbol("edge_reflections")

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -172,7 +172,7 @@ extern "C"
     const char* signature;
 
     /// The base DoF permutations
-    int* base_permutations;
+    const int* base_permutations;
 
     /// The size of the base DoF permutations array
     int size_base_permutations;

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -65,28 +65,3 @@ def generate_return_literal_switch(L,
 def generate_return_int_switch(L, i, values, default):
     return generate_return_literal_switch(L, i, values, default, L.LiteralInt,
                                           "int")
-
-
-_table_dofmaps = {}
-
-
-def get_table_dofmap_array(L, dofmap, pname):
-    """If some dofs have been stripped from a table, return an array to map table entries to dofs."""
-    for i, j in enumerate(dofmap):
-        if i != j:
-            # If a dof has been removed, write the data
-            _table_dofmaps[pname] = L.Symbol(pname + "_dofmap")
-            return [L.ArrayDecl(
-                "const int", _table_dofmaps[pname], (len(dofmap), ), values=dofmap)]
-    # If no dofs  have been removed, return nothing
-    _table_dofmaps[pname] = None
-    return []
-
-
-def get_table_dofmap(L, pname, idof):
-    """Returns the dof number corresponding to a row in the table."""
-    assert pname in _table_dofmaps
-    if _table_dofmaps[pname] is None:
-        # If no dofs have been removed, then idof is the dof number
-        return idof
-    return _table_dofmaps[pname][idof]


### PR DESCRIPTION
- Fixes #207.
- Remove global variables in `codegeneration/utils.py`:
https://github.com/FEniCS/ffcx/blob/c2e4b518985d52124499e734de93a79d025bbadd/ffcx/codegeneration/utils.py#L70-L71
- Moved vector reflection and table dofmap functions out of `codegeneration/utils.py`, and slightly simplified them in the two places they are used.