### PR TITLE
Add test compile args

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
           name: Run unit tests
           command: |
             export PATH=$PATH:$HOME/.local/bin
-            python -m pytest --cov=ffcx/ -n 4 -v test/
+            cd test/
+            python -m pytest --cov=ffcx/ -n 4 -v .
             coveralls
       - run:
           name: Run demos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,7 @@ jobs:
           name: Run unit tests
           command: |
             export PATH=$PATH:$HOME/.local/bin
-            cd test/
-            python -m pytest --cov=ffcx/ -n 4 -v .
+            python -m pytest --cov=ffcx/ -n 4 -v test/
             coveralls
       - run:
           name: Run demos

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2020 Michal Habera
+#
+# This file is part of FFCX.(https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def compile_args():
+    return ["-O0", "-Wall", "-Werror"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,4 +9,4 @@ import pytest
 
 @pytest.fixture(scope="module")
 def compile_args():
-    return ["-O0", "-Wall", "-Werror", "-pedantic-errors"]
+    return ["-O0", "-Wall", "-Werror"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,4 +9,4 @@ import pytest
 
 @pytest.fixture(scope="module")
 def compile_args():
-    return ["-O0", "-Wall", "-Werror"]
+    return ["-O0", "-Wall", "-Werror", "-pedantic-errors"]

--- a/test/test_add_mode.py
+++ b/test/test_add_mode.py
@@ -29,13 +29,14 @@ def float_to_type(name):
 
 
 @pytest.mark.parametrize("mode", ["double", "float", "long double", "double complex", "float complex"])
-def test_additive_facet_integral(mode):
+def test_additive_facet_integral(mode, compile_args):
     cell = ufl.triangle
     element = ufl.FiniteElement("Lagrange", cell, 1)
     u, v = ufl.TrialFunction(element), ufl.TestFunction(element)
     a = ufl.inner(u, v) * ufl.ds
     forms = [a]
-    compiled_forms, module = ffcx.codegeneration.jit.compile_forms(forms, parameters={'scalar_type': mode})
+    compiled_forms, module = ffcx.codegeneration.jit.compile_forms(
+        forms, parameters={'scalar_type': mode}, cffi_extra_compile_args=compile_args)
 
     for f, compiled_f in zip(forms, compiled_forms):
         assert compiled_f.rank == len(f.arguments())
@@ -71,13 +72,14 @@ def test_additive_facet_integral(mode):
 
 
 @pytest.mark.parametrize("mode", ["double", "float", "long double", "double complex", "float complex"])
-def test_additive_cell_integral(mode):
+def test_additive_cell_integral(mode, compile_args):
     cell = ufl.triangle
     element = ufl.FiniteElement("Lagrange", cell, 1)
     u, v = ufl.TrialFunction(element), ufl.TestFunction(element)
     a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
     forms = [a]
-    compiled_forms, module = ffcx.codegeneration.jit.compile_forms(forms, parameters={'scalar_type': mode})
+    compiled_forms, module = ffcx.codegeneration.jit.compile_forms(
+        forms, parameters={'scalar_type': mode}, cffi_extra_compile_args=compile_args)
 
     for f, compiled_f in zip(forms, compiled_forms):
         assert compiled_f.rank == len(f.arguments())

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -10,7 +10,7 @@ import ffcx.codegeneration.jit
 import ufl
 
 
-def test_cache_modes():
+def test_cache_modes(compile_args):
     cell = ufl.triangle
     element = ufl.FiniteElement("Lagrange", cell, 1)
     u, v = ufl.TrialFunction(element), ufl.TestFunction(element)
@@ -18,14 +18,15 @@ def test_cache_modes():
     forms = [a]
 
     # Load form from /tmp
-    compiled_forms, module = ffcx.codegeneration.jit.compile_forms(forms)
+    compiled_forms, module = ffcx.codegeneration.jit.compile_forms(forms, cffi_extra_compile_args=compile_args)
     tmpname = module.__name__
     tmpfile = module.__file__
     print(tmpname, tmpfile)
     del sys.modules[tmpname]
 
     # Load form from cache
-    compiled_forms, module = ffcx.codegeneration.jit.compile_forms(forms, cache_dir="./compile-cache")
+    compiled_forms, module = ffcx.codegeneration.jit.compile_forms(
+        forms, cache_dir="./compile-cache", cffi_extra_compile_args=compile_args)
     newname = module.__name__
     newfile = module.__file__
     print(newname, newfile)

--- a/test/test_jit_elements.py
+++ b/test/test_jit_elements.py
@@ -119,7 +119,8 @@ def test_cmap_quads(degree, coords, compile_args):
     cell = ufl.quadrilateral
     e = ufl.VectorElement("Lagrange", cell, degree)
     mesh = ufl.Mesh(e)
-    compiled_cmap, module = ffcx.codegeneration.jit.compile_coordinate_maps([mesh], cffi_extra_compile_args=compile_args)
+    compiled_cmap, module = ffcx.codegeneration.jit.compile_coordinate_maps(
+        [mesh], cffi_extra_compile_args=compile_args)
 
     coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
 

--- a/test/test_jit_elements.py
+++ b/test/test_jit_elements.py
@@ -17,12 +17,13 @@ degrees = [1, 2, 3, 4]
 
 
 @pytest.fixture(scope="module")
-def lagrange_elements():
+def lagrange_elements(compile_args):
     elements = {}
     for cell in cells:
         for degree in degrees:
             ufl_element = ufl.FiniteElement("Lagrange", cell, degree)
-            compiled_elements, module = ffcx.codegeneration.jit.compile_elements([ufl_element])
+            compiled_elements, module = ffcx.codegeneration.jit.compile_elements(
+                [ufl_element], cffi_extra_compile_args=compile_args)
             elements[(cell, degree)] = (ufl_element, compiled_elements[0], module)
 
     return elements
@@ -89,11 +90,12 @@ def test_evaluate_reference_basis(cell, degree, lagrange_elements, reference_poi
     assert (np.isclose(vals.T, fiat_vals[(0,) * tdim])).all()
 
 
-def test_cmap_triangle():
+def test_cmap_triangle(compile_args):
     cell = ufl.triangle
     element = ufl.VectorElement("Lagrange", cell, 1)
     mesh = ufl.Mesh(element)
-    compiled_cmap, module = ffcx.codegeneration.jit.compile_coordinate_maps([mesh])
+    compiled_cmap, module = ffcx.codegeneration.jit.compile_coordinate_maps(
+        [mesh], cffi_extra_compile_args=compile_args)
     x = np.array([[0.5, 0.5]], dtype=np.float64)
     x_ptr = module.ffi.cast("double *", module.ffi.from_buffer(x))
     X = np.zeros_like(x)
@@ -110,14 +112,14 @@ def test_cmap_triangle():
                                            (2, np.array([[0, 0], [0, 2], [0, 1], [3, 0],
                                                          [3, 2], [3, 1], [1.5, 0], [1.5, 2], [1.5, 1]],
                                                         dtype=np.float64))])
-def test_cmap_quads(degree, coords):
+def test_cmap_quads(degree, coords, compile_args):
     # Test for first and second order quadrilateral meshes,
     # assuming FIAT Tensor Product layout of cell.
 
     cell = ufl.quadrilateral
     e = ufl.VectorElement("Lagrange", cell, degree)
     mesh = ufl.Mesh(e)
-    compiled_cmap, module = ffcx.codegeneration.jit.compile_coordinate_maps([mesh])
+    compiled_cmap, module = ffcx.codegeneration.jit.compile_coordinate_maps([mesh], cffi_extra_compile_args=compile_args)
 
     coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
 
@@ -145,14 +147,15 @@ def test_cmap_quads(degree, coords):
                                                          [0.5, 0, 0], [0.5, 0, 3], [0.5, 0, 1.5],
                                                          [0.5, 2, 0], [0.5, 2, 3], [0.5, 2, 1.5],
                                                          [0.5, 1, 0], [0.5, 1, 3], [0.5, 1, 1.5]], dtype=np.float64))])
-def test_cmap_hex(degree, coords):
+def test_cmap_hex(degree, coords, compile_args):
     # Test for first and second order quadrilateral meshes,
     # assuming FIAT Tensor Product layout of cell.
 
     cell = ufl.hexahedron
     e = ufl.VectorElement("Lagrange", cell, degree)
     mesh = ufl.Mesh(e)
-    compiled_cmap, module = ffcx.codegeneration.jit.compile_coordinate_maps([mesh])
+    compiled_cmap, module = ffcx.codegeneration.jit.compile_coordinate_maps(
+        [mesh], cffi_extra_compile_args=compile_args)
 
     coords_ptr = module.ffi.cast("double *", module.ffi.from_buffer(coords))
 


### PR DESCRIPTION
Added `-O0` to speed-up tests a bit.
Added `-Werror` to fail if compiler issues warning. Currently, `-pedantic` produces too many error for me to fix.