### PR TITLE
Pack permutation info

### DIFF
--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -442,7 +442,7 @@ class BinOp(CExprOperator):
         rhs = self.rhs.ce_format(precision)
 
         # Apply parentheses
-        if self.lhs.precedence > self.precedence:
+        if self.lhs.precedence >= self.precedence:
             lhs = '(' + lhs + ')'
         if self.rhs.precedence >= self.precedence:
             rhs = '(' + rhs + ')'
@@ -621,19 +621,19 @@ class GE(BinOp):
 
 class BitwiseAnd(BinOp):
     __slots__ = ()
-    precedence = PRECEDENCE.AND
+    precedence = PRECEDENCE.BITAND
     op = "&"
 
 
 class BitShiftR(BinOp):
     __slots__ = ()
-    precedence = PRECEDENCE.OR
+    precedence = PRECEDENCE.BITSHIFT
     op = ">>"
 
 
 class BitShiftL(BinOp):
     __slots__ = ()
-    precedence = PRECEDENCE.OR
+    precedence = PRECEDENCE.BITSHIFT
     op = "<<"
 
 

--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -444,11 +444,16 @@ class BinOp(CExprOperator):
         # Apply parentheses
         if self.lhs.precedence > self.precedence:
             lhs = '(' + lhs + ')'
+        elif self.lhs.precedence == self.precedence and self.is_equality():
+            lhs = '(' + lhs + ')'
         if self.rhs.precedence >= self.precedence:
             rhs = '(' + rhs + ')'
 
         # Return combined string
         return lhs + (" " + self.op + " ") + rhs
+
+    def is_equality(self):
+        return self.precedence in [PRECEDENCE.EQ, PRECEDENCE.NE]
 
     def __eq__(self, other):
         return (isinstance(other, type(self)) and self.lhs == other.lhs and self.rhs == other.rhs)

--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -444,16 +444,11 @@ class BinOp(CExprOperator):
         # Apply parentheses
         if self.lhs.precedence > self.precedence:
             lhs = '(' + lhs + ')'
-        elif self.lhs.precedence == self.precedence and self.is_equality():
-            lhs = '(' + lhs + ')'
         if self.rhs.precedence >= self.precedence:
             rhs = '(' + rhs + ')'
 
         # Return combined string
         return lhs + (" " + self.op + " ") + rhs
-
-    def is_equality(self):
-        return self.precedence in [PRECEDENCE.EQ, PRECEDENCE.NE]
 
     def __eq__(self, other):
         return (isinstance(other, type(self)) and self.lhs == other.lhs and self.rhs == other.rhs)

--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -619,6 +619,24 @@ class GE(BinOp):
     op = ">="
 
 
+class BitwiseAnd(BinOp):
+    __slots__ = ()
+    precedence = PRECEDENCE.AND
+    op = "&"
+
+
+class BitShiftR(BinOp):
+    __slots__ = ()
+    precedence = PRECEDENCE.OR
+    op = ">>"
+
+
+class BitShiftL(BinOp):
+    __slots__ = ()
+    precedence = PRECEDENCE.OR
+    op = "<<"
+
+
 class And(BinOp):
     __slots__ = ()
     precedence = PRECEDENCE.AND

--- a/ffcx/codegeneration/C/precedence.py
+++ b/ffcx/codegeneration/C/precedence.py
@@ -38,13 +38,17 @@ class PRECEDENCE:
     ADD = 5
     SUB = 5
 
-    LT = 6
-    LE = 6
-    GT = 6
-    GE = 6
+    BITSHIFT = 6
 
-    EQ = 7
-    NE = 7
+    LT = 7
+    LE = 7
+    GT = 7
+    GE = 7
+
+    EQ = 8
+    NE = 8
+
+    BITAND = 9
 
     AND = 11
     OR = 12

--- a/ffcx/codegeneration/finite_element.py
+++ b/ffcx/codegeneration/finite_element.py
@@ -133,16 +133,24 @@ def evaluate_reference_basis_derivatives(L, ir, parameters):
     return generate_evaluate_reference_basis_derivatives(L, data, ir.name, parameters)
 
 
-def entity_reflection(L, i):
+def entity_reflection(L, i, cell_shape):
     """Returns the bool that says whether or not an entity has been reflected."""
+    cell_info = L.Symbol("cell_permutation")
+    if cell_shape in ["triangle", "quadrilateral"]:
+        num_faces = 0
+        face_bitsize = 1
+        assert i[0] == 1
+    if cell_shape == "tetrahedron":
+        num_faces = 4
+        face_bitsize = 3
+    if cell_shape == "hexahedron":
+        num_faces = 4
+        face_bitsize = 3
     if i[0] == 1:
-        edge_reflections = L.Symbol("edge_reflections")
-        return edge_reflections[i[1]]
+        return L.NE(L.BitwiseAnd(cell_info, L.BitShiftL(1, face_bitsize * num_faces + i[1])), 0)
     elif i[0] == 2:
-        face_reflections = L.Symbol("face_reflections")
-        return face_reflections[i[1]]
-    else:
-        return L.LiteralBool(False)
+        return L.NE(L.BitwiseAnd(cell_info, L.BitShiftL(1, face_bitsize * i[1])), 0)
+    return L.LiteralBool(False)
 
 
 def transform_reference_basis_derivatives(L, ir, parameters):
@@ -287,12 +295,16 @@ def transform_reference_basis_derivatives(L, ir, parameters):
             # make a conditional
             ref = c_false
             for j in dre:
+                new_ref = entity_reflection(L, j, ir.cell_shape)
                 if ref == c_false:
                     # No condition has been added yet, so overwrite false
-                    ref = entity_reflection(L, j)
+                    ref = new_ref
+                elif ref == new_ref:
+                    # A != A is false
+                    ref = c_false
                 else:
                     # This is not the first condition, so XOR
-                    ref = L.Conditional(entity_reflection(L, j), L.Not(ref), ref)
+                    ref = L.NE(ref, new_ref)
             reflect_dofs.append(ref)
             if ref != c_false:
                 # Mark this space as needing reflections

--- a/ffcx/codegeneration/finite_element_template.py
+++ b/ffcx/codegeneration/finite_element_template.py
@@ -39,8 +39,7 @@ int transform_reference_basis_derivatives_{factory_name}(
     const double * restrict reference_values,
     const double * restrict X, const double * restrict J,
     const double * restrict detJ, const double * restrict K,
-    const bool* restrict edge_reflections, const bool* restrict face_reflections,
-    const uint8_t* restrict face_rotations)
+    const uint32_t cell_permutation)
 {{
   {transform_reference_basis_derivatives}
 }}

--- a/ffcx/codegeneration/integrals_generator.py
+++ b/ffcx/codegeneration/integrals_generator.py
@@ -278,7 +278,7 @@ class IntegralGenerator(object):
                                                  [dofmap.index(dof)],
                                                  *[range(n) for n in table.shape[dof_index + 1:]]):
                     for entity in entities:
-                        entity_ref = self.backend.symbols.entity_reflection(L, entity)
+                        entity_ref = self.backend.symbols.entity_reflection(L, entity, self.ir.cell_shape)
                         if conditions[indices] == c_false:
                             # No condition has been added yet, so overwrite false
                             conditions[indices] = entity_ref
@@ -346,7 +346,7 @@ class IntegralGenerator(object):
                     continue
 
                 # Swap the values of two dofs if their face is reflected
-                reflected = self.backend.symbols.entity_reflection(L, entity)
+                reflected = self.backend.symbols.entity_reflection(L, entity, self.ir.cell_shape)
                 di0 = dofmap.index(dofs[0])
                 di1 = dofmap.index(dofs[1])
                 for indices in itertools.product(itertools.product(*[range(n) for n in table.shape[:dof_index]]),
@@ -403,7 +403,7 @@ class IntegralGenerator(object):
                         body0 = L.ForRange(index, 0, table.shape[k], body0)
                         body1 = L.ForRange(index, 0, table.shape[k], body1)
                 # Do rotation if the face is rotated
-                rotations = self.backend.symbols.entity_rotations(L, entity)
+                rotations = self.backend.symbols.entity_rotations(L, entity, self.ir.cell_shape)
                 parts += [L.If(L.EQ(rotations, 1), body0),
                           L.ElseIf(L.EQ(rotations, 2), body1)]
 

--- a/ffcx/codegeneration/integrals_template.py
+++ b/ffcx/codegeneration/integrals_template.py
@@ -20,9 +20,7 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
                                     const double* restrict coordinate_dofs,
                                     const int* restrict unused_local_index,
                                     const uint8_t* restrict quadrature_permutation,
-                                    const bool* restrict edge_reflections,
-                                    const bool* restrict face_reflections,
-                                    const uint8_t* restrict face_rotations)
+                                    const uint32_t cell_permutation)
 {{
 {tabulate_tensor}
 }}
@@ -35,9 +33,7 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
                                     const double* restrict coordinate_dofs,
                                     const int* restrict facet,
                                     const uint8_t* restrict quadrature_permutation,
-                                    const bool* restrict edge_reflections,
-                                    const bool* restrict face_reflections,
-                                    const uint8_t* restrict face_rotations)
+                                    const uint32_t cell_permutation)
 {{
 {tabulate_tensor}
 }}
@@ -50,9 +46,7 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
                                     const double* restrict coordinate_dofs,
                                     const int* restrict facet,
                                     const uint8_t* restrict quadrature_permutation,
-                                    const bool* restrict edge_reflections,
-                                    const bool* restrict face_reflections,
-                                    const uint8_t* restrict face_rotations)
+                                    const uint32_t cell_permutation)
 {{
 {tabulate_tensor}
 }}
@@ -65,9 +59,7 @@ void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
                                     const double* restrict coordinate_dofs,
                                     const int* restrict vertex,
                                     const uint8_t* restrict quadrature_permutation,
-                                    const bool* restrict edge_reflections,
-                                    const bool* restrict face_reflections,
-                                    const uint8_t* restrict face_rotations)
+                                    const uint32_t cell_permutation)
 {{
 {tabulate_tensor}
 }}

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -119,7 +119,7 @@ class FFCXBackendSymbols(object):
         if cell_shape == "hexahedron":
             face_bitsize = 3
         if i[0] == 2:
-            return L.BitwiseAnd(cell_info, L.BitShiftL(3, face_bitsize * i[1] + 1))
+            return L.BitwiseAnd(L.BitShiftR(cell_info, face_bitsize * i[1] + 1), 3)
         return L.LiteralBool(False)
 
     def coefficient_dof_sum_index(self):

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -106,7 +106,7 @@ class FFCXBackendSymbols(object):
             num_faces = 4
             face_bitsize = 3
         if i[0] == 1:
-            return L.BitwiseAnd(L.BitshiftR(cell_info, face_bitsize * num_faces + i[1]), 1)
+            return L.BitwiseAnd(L.BitShiftR(cell_info, face_bitsize * num_faces + i[1]), 1)
         elif i[0] == 2:
             return L.BitwiseAnd(L.BitShiftR(cell_info, face_bitsize * i[1]), 1)
         return L.LiteralBool(False)

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -106,9 +106,9 @@ class FFCXBackendSymbols(object):
             num_faces = 4
             face_bitsize = 3
         if i[0] == 1:
-            return L.NE(L.BitwiseAnd(cell_info, L.BitShiftL(1, face_bitsize * num_faces + i[1])), 0)
+            return L.BitwiseAnd(L.BitshiftR(cell_info, face_bitsize * num_faces + i[1]), 1)
         elif i[0] == 2:
-            return L.NE(L.BitwiseAnd(cell_info, L.BitShiftL(1, face_bitsize * i[1])), 0)
+            return L.BitwiseAnd(L.BitShiftR(cell_info, face_bitsize * i[1]), 1)
         return L.LiteralBool(False)
 
     def entity_rotations(self, L, i, cell_shape):

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -92,24 +92,35 @@ class FFCXBackendSymbols(object):
         indices = ["i", "j", "k", "l"]
         return self.S(indices[iarg])
 
-    def entity_reflection(self, L, i):
+    def entity_reflection(self, L, i, cell_shape):
         """Returns the bool that says whether or not an entity has been reflected."""
+        cell_info = self.S("cell_permutation")
+        if cell_shape in ["triangle", "quadrilateral"]:
+            num_faces = 0
+            face_bitsize = 1
+            assert i[0] == 1
+        if cell_shape == "tetrahedron":
+            num_faces = 4
+            face_bitsize = 3
+        if cell_shape == "hexahedron":
+            num_faces = 4
+            face_bitsize = 3
         if i[0] == 1:
-            edge_reflections = L.Symbol("edge_reflections")
-            return edge_reflections[i[1]]
+            return L.NE(L.BitwiseAnd(cell_info, L.BitShiftL(1, face_bitsize * num_faces + i[1])), 0)
         elif i[0] == 2:
-            face_reflections = L.Symbol("face_reflections")
-            return face_reflections[i[1]]
-        else:
-            return L.LiteralBool(False)
+            return L.NE(L.BitwiseAnd(cell_info, L.BitShiftL(1, face_bitsize * i[1])), 0)
+        return L.LiteralBool(False)
 
-    def entity_rotations(self, L, i):
-        """Returns the integer that says how many times an entity has been rotated."""
+    def entity_rotations(self, L, i, cell_shape):
+        """Returns the bool that says whether or not an entity has been reflected."""
+        cell_info = self.S("cell_permutation")
+        if cell_shape == "tetrahedron":
+            face_bitsize = 3
+        if cell_shape == "hexahedron":
+            face_bitsize = 3
         if i[0] == 2:
-            face_rotations = L.Symbol("face_rotations")
-            return face_rotations[i[1]]
-        else:
-            return L.LiteralBool(False)
+            return L.BitwiseAnd(cell_info, L.BitShiftL(3, face_bitsize * i[1] + 1))
+        return L.LiteralBool(False)
 
     def coefficient_dof_sum_index(self):
         """Index for loops over coefficient dofs, assumed to never be used in two nested loops."""

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -124,23 +124,15 @@ extern "C"
         const double* restrict X);
 
     /// Map the reference values on to the cell
-    /// @param[in] edge_reflections An array of bools to say whether or not each
-    /// each edge has been reflected. This is used to ensure that vector dofs
-    /// are correctly oriented.
-    /// @param[in] face_reflections An array of bools to say whether or not each
-    /// each face has been reflected. This is used to ensure that vector dofs
-    /// are correctly oriented.
-    /// @param[in] face_rotations An array of integers to say how many times
-    /// each face needs to be rotated to match the low-to-high ordering. This
-    /// is used to ensure that FaceTangent vector dofs are correctly oriented.
+    /// @param[in] cell_permutations An integer that says how each entity of the
+    ///         cell of dimension < tdim has been permuted relative to a
+    ///         low-to-high ordering of the cell.
 
     int (*transform_reference_basis_derivatives)(
         double* restrict values, int order, int num_points,
         const double* restrict reference_values, const double* restrict X,
         const double* restrict J, const double* restrict detJ,
-        const double* restrict K, const bool* restrict edge_reflections,
-        const bool* restrict face_reflections,
-        const uint8_t* restrict face_rotations);
+        const double* restrict K, const uint32_t cell_permutation);
 
     /// Map values of field from physical to reference space which has
     /// been evaluated at points given by
@@ -425,26 +417,21 @@ extern "C"
   ///         interior facets the array will have size 2 (one permutation
   ///         for each cell adjacent to the facet). For exterior facets,
   ///         this will have size 1.
-  /// @param[in] edge_reflections An array of bools to say whether or not each
-  ///         each edge has been reflected. This is used to ensure that vector
-  ///         dofs are correctly oriented. This array will have one entry for
-  ///         each edge of the cell.
-  /// @param[in] face_reflections An array of bools to say whether or not each
-  ///         each face has been reflected. This is used to ensure that vector
-  ///         dofs are correctly oriented. This array will have one entry for
-  ///         each face of the cell.
-  /// @param[in] face_rotations An array of integers to say how many times
-  ///         each face needs to be rotated to match the low-to-high ordering.
-  ///         This is used to ensure that FaceTangent vector dofs are correctly
-  ///         oriented.
+  /// @param[in] cell_permutations An integer that says how each entity of the
+  ///         cell of dimension < tdim has been permuted relative to a
+  ///         low-to-high ordering of the cell. This bits of this integer
+  ///         represent (from least to most significant bits):
+  ///
+  ///          - Faces (3 bits each). Reflections are least significant bit,
+  ///          then next two bits give number of rotations.
+  ///          - Edges (1 bit each). The bit is 1 if the edge is reflected.
+  ///
   typedef void(ufc_tabulate_tensor)(
       ufc_scalar_t* restrict A, const ufc_scalar_t* restrict w,
       const ufc_scalar_t* restrict c, const double* restrict coordinate_dofs,
       const int* restrict entity_local_index,
       const uint8_t* restrict quadrature_permutation,
-      const bool* restrict edge_reflections,
-      const bool* restrict face_reflections,
-      const uint8_t* restrict face_rotations);
+      const uint32_t cell_permutation);
 
   /// Tabulate integral into tensor A with runtime quadrature rule
   ///

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -86,7 +86,7 @@ ir_expression = namedtuple('ir_expression', ['name', 'element_dimensions', 'para
                                              'unique_table_types', 'piecewise_ir', 'varying_irs', 'table_origins',
                                              'table_dofmaps',
                                              'table_dof_face_tangents', 'table_dof_reflection_entities',
-                                             'needs_rotations', 'needs_reflections', 'cell_shape',
+                                             'needs_rotations', 'needs_reflections',
                                              'all_num_points', 'coefficient_numbering', 'coefficient_offsets',
                                              'integral_type', 'entitytype', 'tensor_shape', 'expression_shape',
                                              'original_constant_offsets', 'original_coefficient_positions', 'points'])

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -73,7 +73,7 @@ ir_integral = namedtuple('ir_integral', ['representation', 'integral_type', 'sub
                                          'entitytype', 'num_facets', 'num_vertices', 'needs_oriented',
                                          'enabled_coefficients', 'element_dimensions', 'element_ids',
                                          'tensor_shape', 'quadrature_rules', 'coefficient_numbering',
-                                         'coefficient_offsets', 'original_constant_offsets', 'params',
+                                         'coefficient_offsets', 'original_constant_offsets', 'params', 'cell_shape',
                                          'unique_tables', 'unique_table_types', 'table_origins', 'table_dofmaps',
                                          'table_dof_face_tangents', 'table_dof_reflection_entities',
                                          'piecewise_ir', 'varying_irs', 'all_num_points', 'name',
@@ -86,7 +86,7 @@ ir_expression = namedtuple('ir_expression', ['name', 'element_dimensions', 'para
                                              'unique_table_types', 'piecewise_ir', 'varying_irs', 'table_origins',
                                              'table_dofmaps',
                                              'table_dof_face_tangents', 'table_dof_reflection_entities',
-                                             'needs_rotations', 'needs_reflections',
+                                             'needs_rotations', 'needs_reflections', 'cell_shape',
                                              'all_num_points', 'coefficient_numbering', 'coefficient_offsets',
                                              'integral_type', 'entitytype', 'tensor_shape', 'expression_shape',
                                              'original_constant_offsets', 'original_coefficient_positions', 'points'])
@@ -365,6 +365,7 @@ def _compute_integral_ir(form_data, form_index, prefix, element_numbers, integra
         # Compute representation
         entitytype = _entity_types[itg_data.integral_type]
         cell = itg_data.domain.ufl_cell()
+        cellname = cell.cellname()
         tdim = cell.topological_dimension()
         assert all(tdim == itg.ufl_domain().topological_dimension() for itg in itg_data.integrals)
 
@@ -379,7 +380,8 @@ def _compute_integral_ir(form_data, form_index, prefix, element_numbers, integra
             "num_facets": cell.num_facets(),
             "num_vertices": cell.num_vertices(),
             "needs_oriented": form_needs_oriented_jacobian(form_data),
-            "enabled_coefficients": itg_data.enabled_coefficients
+            "enabled_coefficients": itg_data.enabled_coefficients,
+            "cell_shape": cellname
         }
 
         ir = compute_integral_ir(ir, itg_data, form_data, element_numbers,

--- a/test/test_add_mode.py
+++ b/test/test_add_mode.py
@@ -68,7 +68,7 @@ def test_additive_facet_integral(mode, compile_args):
             ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
             ffi.cast('double *', coords.ctypes.data),
             ffi.cast('int *', facets.ctypes.data),
-            ffi.cast('uint8_t *', perm.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL)
+            ffi.cast('uint8_t *', perm.ctypes.data), 0)
 
         assert np.isclose(A.sum(), np.sqrt(12) * (i + 1))
 
@@ -107,7 +107,7 @@ def test_additive_cell_integral(mode, compile_args):
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, 0)
 
     A0 = np.array(A)
 
@@ -117,6 +117,6 @@ def test_additive_cell_integral(mode, compile_args):
             ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
             ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
             ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-            ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL)
+            ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, 0)
 
         assert np.all(np.isclose(A, (i + 2) * A0))

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -72,7 +72,7 @@ def test_laplace_bilinear_form_2d(mode, expected_result, compile_args):
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, 0)
 
     assert np.allclose(A, np.trace(kappa_value) * expected_result)
 
@@ -131,14 +131,14 @@ def test_mass_bilinear_form_2d(mode, expected_result, compile_args):
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, 0)
 
     b = np.zeros(3, dtype=np_type)
     form1.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), b.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, 0)
 
     assert np.allclose(A, expected_result)
     assert np.allclose(b, 1.0 / 6.0)
@@ -183,7 +183,7 @@ def test_helmholtz_form_2d(mode, expected_result, compile_args):
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, 0)
 
     assert np.allclose(A, expected_result)
 
@@ -229,7 +229,7 @@ def test_laplace_bilinear_form_3d(mode, expected_result, compile_args):
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, 0)
 
     assert np.allclose(A, expected_result)
 
@@ -259,7 +259,7 @@ def test_form_coefficient(compile_args):
         ffi.cast('double  *', w.ctypes.data),
         ffi.cast('double  *', c.ctypes.data),
         ffi.cast('double  *', coords.ctypes.data), ffi.NULL,
-        ffi.cast('uint8_t *', perm.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('uint8_t *', perm.ctypes.data), 0)
 
     A_analytic = np.array([[2, 1, 1], [1, 2, 1], [1, 1, 2]], dtype=np.float64) / 24.0
     A_diff = (A - A_analytic)
@@ -347,7 +347,7 @@ def test_interior_facet_integral(mode, compile_args):
         ffi.cast('{}  *'.format(c_type), w.ctypes.data),
         ffi.cast('{}  *'.format(c_type), c.ctypes.data),
         ffi.cast('double *', coords.ctypes.data), ffi.cast('int *', facets.ctypes.data),
-        ffi.cast('uint8_t *', perms.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('uint8_t *', perms.ctypes.data), 0)
 
 
 @pytest.mark.parametrize("mode", ["double", "double complex"])
@@ -386,7 +386,7 @@ def test_conditional(mode, compile_args):
         ffi.cast('{type} *'.format(type=c_type), A1.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w1.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, 0)
 
     expected_result = np.array([[2, -1, -1], [-1, 1, 0], [-1, 0, 1]], dtype=np_type)
     assert np.allclose(A1, expected_result)
@@ -399,7 +399,7 @@ def test_conditional(mode, compile_args):
         ffi.cast('{type} *'.format(type=c_type), A2.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w2.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL, ffi.NULL)
+        ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL, 0)
 
     expected_result = np.ones(3, dtype=np_type)
     assert np.allclose(A2, expected_result)


### PR DESCRIPTION
I have packed data that was stored in `face_rotations`, `face_reflections` and `edge_reflections` into a single 32 bit int for each cell. This pull requested is coupled with FEniCS/dolfinx#892, where there is more info about how the data is packed.

Resolves #203.