### PR TITLE
Fix JIT memory leak

### DIFF
--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -321,9 +321,12 @@ def _load_objects(cache_dir, module_name, object_names):
     compiled_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(compiled_module)
 
-    compiled_objects = [getattr(compiled_module.lib, "create_" + name)() for name in object_names]
+    compiled_objects = []
+    for name in object_names:
+        # Call UFC factory to create object data struct (calls malloc)
+        obj = getattr(compiled_module.lib, "create_" + name)()
 
-    # Set garbage collector to use C free()
-    [compiled_module.ffi.gc(obj, compiled_module.lib.free) for obj in compiled_objects]
+        # Set garbage collector to use C free()
+        compiled_objects.append(compiled_module.ffi.gc(obj, compiled_module.lib.free))
 
     return compiled_objects, compiled_module

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -27,7 +27,7 @@ UFC_HEADER_DECL = "typedef {} ufc_scalar_t;  /* Hack to deal with scalar type */
 header = ufc_h.split("<HEADER_DECL>")[1].split("</HEADER_DECL>")[0].strip(" /\n")
 header = header.replace("{", "{{").replace("}", "}}")
 UFC_HEADER_DECL += header + "\n"
-
+UFC_HEADER_DECL += "void free(void *); \n"
 
 UFC_ELEMENT_DECL = '\n'.join(re.findall('typedef struct ufc_finite_element.*?ufc_finite_element;', ufc_h, re.DOTALL))
 UFC_DOFMAP_DECL = '\n'.join(re.findall('typedef struct ufc_dofmap.*?ufc_dofmap;', ufc_h, re.DOTALL))
@@ -322,5 +322,8 @@ def _load_objects(cache_dir, module_name, object_names):
     spec.loader.exec_module(compiled_module)
 
     compiled_objects = [getattr(compiled_module.lib, "create_" + name)() for name in object_names]
+
+    # Set garbage collector to use C free()
+    [compiled_module.ffi.gc(obj, compiled_module.lib.free) for obj in compiled_objects]
 
     return compiled_objects, compiled_module


### PR DESCRIPTION
Fix for #234, follows suggestion on https://stackoverflow.com/questions/47080411/do-i-need-to-free-memory-returned-from-a-c-function-called-via-cffi

This exposes standard C `free()` and wraps UFC create_foo() factory result using `ffi.gc()`. 