### PR TITLE
Defer importing FIAT

### DIFF
--- a/ffcx/__init__.py
+++ b/ffcx/__init__.py
@@ -13,24 +13,11 @@ FFC compiles finite element variational forms into C code.
 import logging
 import pkg_resources
 
-from FIAT import supported_elements
-
 __version__ = pkg_resources.get_distribution("fenics-ffcx").version
-
 
 logging.basicConfig()
 logger = logging.getLogger("ffcx")
 logging.captureWarnings(capture=True)
 
-# Import main function, entry point to script
-from ffcx.main import main  # noqa: F401
-
 # Import default parameters
 from ffcx.parameters import default_parameters  # noqa: F401
-
-# Duplicate list of supported elements from FIAT and emove elements from
-# list that we don't support or don't trust
-supported_elements = sorted(supported_elements.keys())
-supported_elements.remove("Argyris")
-supported_elements.remove("Hermite")
-supported_elements.remove("Morley")

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -321,9 +321,12 @@ def _load_objects(cache_dir, module_name, object_names):
     compiled_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(compiled_module)
 
-    compiled_objects = [getattr(compiled_module.lib, "create_" + name)() for name in object_names]
+    compiled_objects = []
+    for name in object_names:
+        # Call UFC factory to create object data struct (calls malloc)
+        obj = getattr(compiled_module.lib, "create_" + name)()
 
-    # Set garbage collector to use C free()
-    [compiled_module.ffi.gc(obj, compiled_module.lib.free) for obj in compiled_objects]
+        # Set garbage collector to use C free()
+        compiled_objects.append(compiled_module.ffi.gc(obj, compiled_module.lib.free))
 
     return compiled_objects, compiled_module

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -27,7 +27,7 @@ UFC_HEADER_DECL = "typedef {} ufc_scalar_t;  /* Hack to deal with scalar type */
 header = ufc_h.split("<HEADER_DECL>")[1].split("</HEADER_DECL>")[0].strip(" /\n")
 header = header.replace("{", "{{").replace("}", "}}")
 UFC_HEADER_DECL += header + "\n"
-
+UFC_HEADER_DECL += "void free(void *); \n"
 
 UFC_ELEMENT_DECL = '\n'.join(re.findall('typedef struct ufc_finite_element.*?ufc_finite_element;', ufc_h, re.DOTALL))
 UFC_DOFMAP_DECL = '\n'.join(re.findall('typedef struct ufc_dofmap.*?ufc_dofmap;', ufc_h, re.DOTALL))
@@ -322,5 +322,8 @@ def _load_objects(cache_dir, module_name, object_names):
     spec.loader.exec_module(compiled_module)
 
     compiled_objects = [getattr(compiled_module.lib, "create_" + name)() for name in object_names]
+
+    # Set garbage collector to use C free()
+    [compiled_module.ffi.gc(obj, compiled_module.lib.free) for obj in compiled_objects]
 
     return compiled_objects, compiled_module

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -13,8 +13,8 @@ import time
 from pathlib import Path
 
 import cffi
-
 import ffcx
+import ffcx.naming
 
 logger = logging.getLogger(__name__)
 
@@ -283,6 +283,8 @@ def compile_coordinate_maps(meshes, parameters=None, cache_dir=None, timeout=10,
 
 def _compile_objects(decl, ufl_objects, object_names, module_name, parameters, cache_dir,
                      cffi_extra_compile_args, cffi_verbose, cffi_debug):
+
+    import ffcx.compiler
 
     _, code_body = ffcx.compiler.compile_ufl_objects(ufl_objects, prefix="JIT", parameters=parameters)
 


### PR DESCRIPTION
`FIAT` is very expensive to import, mainly because it imports `sympy`. Run `python3 -X importtime -c "import ffcx;"` to see.

In a typical use-case from dolfinx, where every code is cached and precompiled there is absolutely no need to import FIAT.

This gives speed-up more than 30% for hot runtime of small size problems.
Current master, incl. importing FIAT:

```
time python3 small_problem.py

real	0m3.134s
user	0m1.022s
sys	0m0.528s
```

With this PR:

```
time python3 small_problem.py

real	0m1.791s
user	0m0.579s
sys	0m0.456s
```