### PR TITLE
Compute_physical_coordinates round-off error

### DIFF
--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -878,6 +878,9 @@ class Call(CExprOperator):
 def Sqrt(x):
     return Call("sqrt", x)
 
+def Abs(x):
+    return Call("fabs", x)
+
 
 # Convertion function to expression nodes
 

--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -878,6 +878,7 @@ class Call(CExprOperator):
 def Sqrt(x):
     return Call("sqrt", x)
 
+
 def Abs(x):
     return Call("fabs", x)
 

--- a/ffcx/codegeneration/coordinate_mapping.py
+++ b/ffcx/codegeneration/coordinate_mapping.py
@@ -149,6 +149,9 @@ def compute_physical_coordinates(L, ir):
     num_dofs = ir.num_scalar_coordinate_element_dofs
     scalar_coordinate_element_classname = ir.scalar_coordinate_finite_element_classname
 
+    # Tolerance for coordinates
+    epsilon = L.LiteralFloat(1e-16)
+
     # Dimensions
     gdim = ir.geometric_dimension
     tdim = ir.topological_dimension
@@ -197,6 +200,8 @@ def compute_physical_coordinates(L, ir):
                     index_type=index_type,
                     body=L.AssignAdd(x[ip, i], coordinate_dofs[d, i] * phi[d]))
             ]),
+        L.ForRanges((ip, 0, num_points), (i, 0, gdim), index_type=index_type,
+                    body=L.If(L.LT(L.Abs(x[ip, i]), epsilon), L.Assign(x[ip, i], 0.0)))
     ]
 
     return code


### PR DESCRIPTION
Currently, compute_physical_coordinates has been suffering from round-off errors, yielding:
```

import dolfinx
from mpi4py import MPI
mesh = dolfinx.BoxMesh(MPI.COMM_WORLD, [np.array([0.0, 0.0, 0.0]),
                                        np.array([1.0, 1.0, 1.0])],
                       [1, 1, 1])
V = dolfinx.VectorFunctionSpace(mesh, ("Lagrange", 1))
x_coords = V.tabulate_dof_coordinates()
print(x_coords)
```
with output
```
[[-5.67415156e-18 -2.50165692e-17  1.00000000e+00]
 [-5.67415156e-18 -2.50165692e-17  1.00000000e+00]
 [-5.67415156e-18 -2.50165692e-17  1.00000000e+00]
 [-5.67415156e-18 -4.10828855e-17 -7.86268010e-18]
 [-5.67415156e-18 -4.10828855e-17 -7.86268010e-18]
 [-5.67415156e-18 -4.10828855e-17 -7.86268010e-18]
 [ 1.00000000e+00  1.00000000e+00  1.00000000e+00]
 [ 1.00000000e+00  1.00000000e+00  1.00000000e+00]
 [ 1.00000000e+00  1.00000000e+00  1.00000000e+00]
 [ 1.00000000e+00 -2.18852853e-18  1.00000000e+00]
 [ 1.00000000e+00 -2.18852853e-18  1.00000000e+00]
 [ 1.00000000e+00 -2.18852853e-18  1.00000000e+00]
 [-5.67415156e-18  1.00000000e+00  1.00000000e+00]
 [-5.67415156e-18  1.00000000e+00  1.00000000e+00]
 [-5.67415156e-18  1.00000000e+00  1.00000000e+00]
 [ 1.00000000e+00 -2.18852853e-18 -7.86268010e-18]
 [ 1.00000000e+00 -2.18852853e-18 -7.86268010e-18]
 [ 1.00000000e+00 -2.18852853e-18 -7.86268010e-18]
 [ 1.00000000e+00  1.00000000e+00 -5.67415156e-18]
 [ 1.00000000e+00  1.00000000e+00 -5.67415156e-18]
 [ 1.00000000e+00  1.00000000e+00 -5.67415156e-18]
 [-5.67415156e-18  1.00000000e+00 -7.86268010e-18]
 [-5.67415156e-18  1.00000000e+00 -7.86268010e-18]
 [-5.67415156e-18  1.00000000e+00 -7.86268010e-18]]
[-5.67415156e-18  1.00000000e+00 -7.86268010e-18]
```
This PR removes round of errors on 0 coordinates.