### PR TITLE
Fix Quadrature FE on recontructed cells (quads, hexes)

### DIFF
--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -616,7 +616,7 @@ def _evaluate_basis(ufl_element, fiat_element, epsilon):
         if isinstance(e, QuadratureElement):
             return "Function not supported/implemented for QuadratureElement."
         if isinstance(e, FlattenedDimensions) and isinstance(e.element, QuadratureElement):
-            # Case for quad/hex element
+            # Case for quad/hex cell
             return "Function not supported/implemented for QuadratureElement."
         if isinstance(e, HDivTrace):
             return "Function not supported for Trace elements"

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -615,6 +615,9 @@ def _evaluate_basis(ufl_element, fiat_element, epsilon):
     for e in elements:
         if isinstance(e, QuadratureElement):
             return "Function not supported/implemented for QuadratureElement."
+        if isinstance(e, FlattenedDimensions) and isinstance(e.element, QuadratureElement):
+            # Case for quad/hex element
+            return "Function not supported/implemented for QuadratureElement."
         if isinstance(e, HDivTrace):
             return "Function not supported for Trace elements"
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,7 +48,12 @@ elements = [("Lagrange", ufl.interval, 1),
             ("N2curl", ufl.triangle, 2),
             ("N2curl", ufl.tetrahedron, 2),
             ("N2curl", ufl.triangle, 3),
-            ("N2curl", ufl.tetrahedron, 3)]
+            ("N2curl", ufl.tetrahedron, 3),
+            ("Quadrature", ufl.interval, 2, None, "default"),
+            ("Quadrature", ufl.triangle, 2, None, "default"),
+            ("Quadrature", ufl.tetrahedron, 2, None, "default"),
+            ("Quadrature", ufl.quadrilateral, 2, None, "default"),
+            ("Quadrature", ufl.hexahedron, 2, None, "default")]
 
 
 @pytest.fixture(scope="module")

--- a/test/test_jit_elements.py
+++ b/test/test_jit_elements.py
@@ -44,8 +44,8 @@ def test_dim_degree(compiled_element):
 def test_tabulate_reference_dof_coordinates(compiled_element):
     ufl_element, compiled_element, module = compiled_element
 
-    if ufl_element.family() != "Lagrange":
-        pytest.skip("Cannot tabulate dofs for non-lagrange FE.")
+    if ufl_element.family() not in ["Lagrange", "Quadrature"]:
+        pytest.skip("Cannot tabulate dofs for this FE.")
 
     fiat_element = ffcx.fiatinterface._create_fiat_element(ufl_element)
 
@@ -61,6 +61,9 @@ def test_tabulate_reference_dof_coordinates(compiled_element):
 
 def test_evaluate_reference_basis(compiled_element, reference_points):
     ufl_element, compiled_element, module = compiled_element
+
+    if ufl_element.family() in ["Quadrature"]:
+        pytest.skip("Cannot evaluate basis for this FE.")
 
     fiat_element = ffcx.fiatinterface._create_fiat_element(ufl_element)
 


### PR DESCRIPTION
This fixes a bug in construction of Quadrature FE on quadrilaterals and hexahedra.

Quadrature element needs more tests, incl. in dolfinx.