### PR TITLE
Save the cffi build command to the status-ready file

### DIFF
--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -4,7 +4,9 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+from contextlib import redirect_stdout
 import importlib
+import io
 import logging
 import os
 import re
@@ -298,11 +300,19 @@ def _compile_objects(decl, ufl_objects, object_names, module_name, parameters, c
 
     # Compile (ensuring that compile dir exists)
     cache_dir.mkdir(exist_ok=True, parents=True)
-    ffibuilder.compile(tmpdir=cache_dir, verbose=cffi_verbose, debug=cffi_debug)
+
+    f = io.StringIO()
+    with redirect_stdout(f):
+        ffibuilder.compile(tmpdir=cache_dir, verbose=True, debug=cffi_debug)
+    s = f.getvalue()
+    if (cffi_verbose):
+        print(s)
 
     # Create a "status ready" file. If this fails, it is an error,
     # because it should not exist yet.
+    # Copy the stdout verbose output of the build into the ready file
     fd = open(ready_name, "x")
+    fd.write(s)
     fd.close()
 
 


### PR DESCRIPTION
Small change to save the compilation command to file. 
There is already a (zero-size) lock file, which is created on compilation, so that seems a logical place to put it. This can be useful when debugging generated code:

e.g. 
- go to the cache directory
- edit libffcx_cmaps_14b073cae1764e0bcfd32bb297be3687834d72a9.c
- `tail -2 libffcx_cmaps_14b073cae1764e0bcfd32bb297be3687834d72a9.c.cached  | bash` will recompile.