### PR TITLE
Init and destroy functions for ufc objects

### DIFF
--- a/ffcx/codegeneration/coordinate_mapping_template.py
+++ b/ffcx/codegeneration/coordinate_mapping_template.py
@@ -4,12 +4,16 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2018
 
 declaration = """
+int init_{factory_name}(ufc_coordinate_mapping* cmap);
+void destroy_{factory_name}(ufc_coordinate_mapping* cmap);
 ufc_coordinate_mapping* create_{factory_name}(void);
 
-// Helper used to create coordinate map using name given to the
-// UFL file.
-// This helper is called in user c++ code.
+// Helper functions used to create coordinate maps
+// based on the name of the UFL file.
+// These helpers are called in user c++ code.
 //
+int init_coordinate_map_{prefix}(ufc_coordinate_mapping* cmap);
+void destroy_coordinate_map_{prefix}(ufc_coordinate_mapping* cmap);
 ufc_coordinate_mapping* create_coordinate_map_{prefix}(void);
 """
 
@@ -77,14 +81,19 @@ void compute_reference_geometry_{factory_name}(double* restrict X, double* restr
 {compute_reference_geometry}
 }}
 
-ufc_coordinate_mapping* create_{factory_name}(void)
+void destroy_{factory_name}(ufc_coordinate_mapping* cmap);
+ufc_coordinate_mapping* create_{factory_name}(void);
+
+int init_{factory_name}(ufc_coordinate_mapping* cmap)
 {{
-  ufc_coordinate_mapping* cmap = malloc(sizeof(*cmap));
   cmap->signature = {signature};
+  cmap->init = init_{factory_name};
+  cmap->destroy = destroy_{factory_name};
   cmap->create = create_{factory_name};
   cmap->geometric_dimension = {geometric_dimension};
   cmap->topological_dimension = {topological_dimension};
   cmap->cell_shape = {cell_shape};
+  cmap->init_scalar_dofmap = init_{scalar_dofmap_name};
   cmap->create_scalar_dofmap = create_{scalar_dofmap_name};
   cmap->compute_physical_coordinates = compute_physical_coordinates_{factory_name};
   cmap->compute_reference_coordinates = compute_reference_coordinates_{factory_name};
@@ -94,7 +103,28 @@ ufc_coordinate_mapping* create_{factory_name}(void)
   cmap->compute_jacobian_inverses = compute_jacobian_inverses_{factory_name};
   cmap->compute_geometry = compute_geometry_{factory_name};
   cmap->compute_midpoint_geometry = compute_midpoint_geometry_{factory_name};
+  return 0;
+}}
+
+void destroy_{factory_name}(ufc_coordinate_mapping* cmap)
+{{
+}}
+
+ufc_coordinate_mapping* create_{factory_name}(void)
+{{
+  ufc_coordinate_mapping* cmap = malloc(sizeof(*cmap));
+  init_{factory_name}(cmap);
   return cmap;
+}}
+
+int init_coordinate_map_{prefix}(ufc_coordinate_mapping* cmap)
+{{
+  return init_{factory_name}(cmap);
+}}
+
+void destroy_coordinate_map_{prefix}(ufc_coordinate_mapping* cmap)
+{{
+  destroy_{factory_name}(cmap);
 }}
 
 ufc_coordinate_mapping* create_coordinate_map_{prefix}(void)

--- a/ffcx/codegeneration/dofmap.py
+++ b/ffcx/codegeneration/dofmap.py
@@ -8,7 +8,8 @@
 # old implementation in FFC
 
 import ffcx.codegeneration.dofmap_template as ufc_dofmap
-from ffcx.codegeneration.utils import generate_return_new_switch
+from ffcx.codegeneration.utils import (
+    generate_return_new_switch, generate_return_init_switch)
 
 
 def tabulate_entity_dofs(L, ir):
@@ -51,6 +52,11 @@ def tabulate_entity_dofs(L, ir):
         return L.NoOp()
 
 
+def init_sub_dofmap(L, ir):
+    classnames = ir.init_sub_dofmap
+    return generate_return_init_switch(L, "dofmap", "i", classnames)
+
+
 def create_sub_dofmap(L, ir):
     classnames = ir.create_sub_dofmap
     return generate_return_new_switch(L, "i", classnames)
@@ -60,6 +66,7 @@ def sub_dofmap_declaration(L, ir):
     classnames = set(ir.create_sub_dofmap)
     code = ""
     for name in classnames:
+        code += "int init_{name}(ufc_dofmap* dofmap);\n".format(name=name)
         code += "ufc_dofmap* create_{name}(void);\n".format(name=name)
     return code
 
@@ -96,6 +103,7 @@ def generator(ir, parameters):
     # Functions
     d["tabulate_entity_dofs"] = tabulate_entity_dofs(L, ir)
     d["sub_dofmap_declaration"] = sub_dofmap_declaration(L, ir)
+    d["init_sub_dofmap"] = init_sub_dofmap(L, ir)
     d["create_sub_dofmap"] = create_sub_dofmap(L, ir)
 
     # Check that no keys are redundant or have been missed

--- a/ffcx/codegeneration/dofmap_template.py
+++ b/ffcx/codegeneration/dofmap_template.py
@@ -4,6 +4,8 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2018.
 
 declaration = """
+int init_{factory_name}(ufc_dofmap* dofmap);
+void destroy_{factory_name}(ufc_dofmap* dofmap);
 ufc_dofmap* create_{factory_name}(void);
 """
 
@@ -16,14 +18,21 @@ void tabulate_entity_dofs_{factory_name}(int* restrict dofs, int d, int i)
 }}
 
 {sub_dofmap_declaration}
+int init_sub_dofmap_{factory_name}(ufc_dofmap* dofmap, int i)
+{{
+{init_sub_dofmap}
+}}
+
 ufc_dofmap* create_sub_dofmap_{factory_name}(int i)
 {{
 {create_sub_dofmap}
 }}
 
-ufc_dofmap* create_{factory_name}(void)
+void destroy_{factory_name}(ufc_dofmap* dofmap);
+ufc_dofmap* create_{factory_name}(void);
+
+int init_{factory_name}(ufc_dofmap* dofmap)
 {{
-  ufc_dofmap* dofmap = malloc(sizeof(*dofmap));
   dofmap->signature = {signature};
   dofmap->num_global_support_dofs = {num_global_support_dofs};
   dofmap->num_element_support_dofs = {num_element_support_dofs};
@@ -34,11 +43,24 @@ ufc_dofmap* create_{factory_name}(void)
   dofmap->tabulate_entity_dofs = tabulate_entity_dofs_{factory_name};
   dofmap->num_sub_dofmaps = {num_sub_dofmaps};
   dofmap->create_sub_dofmap = create_sub_dofmap_{factory_name};
+  dofmap->init = init_{factory_name};
+  dofmap->destroy = destroy_{factory_name};
   dofmap->create = create_{factory_name};
 
   dofmap->size_base_permutations = {size_base_permutations};
   {base_permutations}
 
+  return 0;
+}}
+
+void destroy_{factory_name}(ufc_dofmap* dofmap)
+{{
+}}
+
+ufc_dofmap* create_{factory_name}(void)
+{{
+  ufc_dofmap* dofmap = malloc(sizeof(*dofmap));
+  init_{factory_name}(dofmap);
   return dofmap;
 }}
 

--- a/ffcx/codegeneration/finite_element.py
+++ b/ffcx/codegeneration/finite_element.py
@@ -17,7 +17,8 @@ from ffcx.codegeneration.evalderivs import (_generate_combinations,
 from ffcx.codegeneration.evaluatebasis import generate_evaluate_reference_basis
 from ffcx.codegeneration.evaluatedof import generate_transform_values
 from ffcx.codegeneration.utils import (generate_return_int_switch,
-                                       generate_return_new_switch)
+                                       generate_return_new_switch,
+                                       generate_return_init_switch)
 
 index_type = "int"
 
@@ -73,8 +74,14 @@ def sub_element_declaration(L, ir):
     classnames = set(ir.create_sub_element)
     code = ""
     for name in classnames:
+        code += "int init_{name}(ufc_finite_element* element);\n".format(name=name)
         code += "ufc_finite_element* create_{name}(void);\n".format(name=name)
     return code
+
+
+def init_sub_element(L, ir):
+    classnames = ir.init_sub_element
+    return generate_return_init_switch(L, "element", "i", classnames)
 
 
 def create_sub_element(L, ir):
@@ -448,9 +455,9 @@ def generator(ir, parameters):
     statements = tabulate_reference_dof_coordinates(L, ir, parameters)
     d["tabulate_reference_dof_coordinates"] = L.StatementList(statements)
 
-    statements = create_sub_element(L, ir)
     d["sub_element_declaration"] = sub_element_declaration(L, ir)
-    d["create_sub_element"] = statements
+    d["init_sub_element"] = init_sub_element(L, ir)
+    d["create_sub_element"] = create_sub_element(L, ir)
 
     # Check that no keys are redundant or have been missed
     from string import Formatter

--- a/ffcx/codegeneration/finite_element_template.py
+++ b/ffcx/codegeneration/finite_element_template.py
@@ -4,6 +4,8 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2018.
 
 declaration = """
+int init_{factory_name}(ufc_finite_element* element);
+void destroy_{factory_name}(ufc_finite_element* element);
 ufc_finite_element* create_{factory_name}(void);
 """
 
@@ -59,15 +61,21 @@ int tabulate_reference_dof_coordinates_{factory_name}(double* restrict reference
 }}
 
 {sub_element_declaration}
+int init_sub_element_{factory_name}(ufc_finite_element* element, int i)
+{{
+  {init_sub_element}
+}}
+
 ufc_finite_element* create_sub_element_{factory_name}(int i)
 {{
   {create_sub_element}
 }}
 
-ufc_finite_element* create_{factory_name}(void)
-{{
-  ufc_finite_element* element = malloc(sizeof(*element));
+void destroy_{factory_name}(ufc_finite_element* element);
+ufc_finite_element* create_{factory_name}(void);
 
+int init_{factory_name}(ufc_finite_element* element)
+{{
   element->signature = {signature};
   element->cell_shape = {cell_shape};
   element->topological_dimension = {topological_dimension};
@@ -87,9 +95,22 @@ ufc_finite_element* create_{factory_name}(void)
   element->transform_values = transform_values_{factory_name};
   element->tabulate_reference_dof_coordinates = tabulate_reference_dof_coordinates_{factory_name};
   element->num_sub_elements = {num_sub_elements};
+  element->init_sub_element = init_sub_element_{factory_name};
   element->create_sub_element = create_sub_element_{factory_name};
+  element->init = init_{factory_name};
+  element->destroy = destroy_{factory_name};
   element->create = create_{factory_name};
+  return 0;
+}}
 
+void destroy_{factory_name}(ufc_finite_element* element)
+{{
+}}
+
+ufc_finite_element* create_{factory_name}(void)
+{{
+  ufc_finite_element* element = malloc(sizeof(*element));
+  init_{factory_name}(element);
   return element;
 }}
 

--- a/ffcx/codegeneration/form_template.py
+++ b/ffcx/codegeneration/form_template.py
@@ -16,12 +16,14 @@ int init_{name_from_uflfile}(ufc_form* form);
 void destroy_{name_from_uflfile}(ufc_form* form);
 ufc_form* create_{name_from_uflfile}(void);
 
-// Helper used to create function space using its name, as given in
-// the UFL file.
+// Helper functions used to create function spaces based on the name
+// which was given in the UFL file.
 // Note: There are in general more function spaces associated to the form,
 //       which is the reason why the helpers takes name as argument.
-// This helper is called in user c++ code.
+// These helpers is called in user c++ code.
 //
+int init_functionspace_{name_from_uflfile}(ufc_function_space* space, const char* fs_name);
+void destroy_functionspace_{name_from_uflfile}(ufc_function_space* space);
 ufc_function_space* create_functionspace_{name_from_uflfile}(const char* fs_name);
 
 """
@@ -231,9 +233,24 @@ ufc_form* create_{name_from_uflfile}(void)
   return create_{factory_name}();
 }}
 
+int init_functionspace_{name_from_uflfile}(ufc_function_space* space, const char* function_name)
+{{
+  {init_functionspace}
+}}
+
+void destroy_functionspace_{name_from_uflfile}(ufc_function_space* space)
+{{
+}}
+
 ufc_function_space* create_functionspace_{name_from_uflfile}(const char* function_name)
 {{
-  {create_functionspace}
+  ufc_function_space* space = (ufc_function_space*) malloc(sizeof(*space));
+  int err = init_functionspace_{name_from_uflfile}(space, function_name);
+  if (err) {{
+    free(space);
+    return NULL;
+  }}
+  return space;
 }}
 
 // End of code for form {factory_name}

--- a/ffcx/codegeneration/form_template.py
+++ b/ffcx/codegeneration/form_template.py
@@ -4,12 +4,16 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2020.
 
 declaration = """
+int init_{factory_name}(ufc_form* form);
+void destroy_{factory_name}(ufc_form* form);
 ufc_form* create_{factory_name}(void);
 
-// Helper used to create form using name which was given to the
-// form in the UFL file.
-// This helper is called in user c++ code.
+// Helper functions used to create forms based on
+// the name which was given to the form in the UFL file.
+// These helpers are called in user c++ code.
 //
+int init_{name_from_uflfile}(ufc_form* form);
+void destroy_{name_from_uflfile}(ufc_form* form);
 ufc_form* create_{name_from_uflfile}(void);
 
 // Helper used to create function space using its name, as given in
@@ -43,21 +47,41 @@ const char** constant_name_{factory_name}(void)
 }}
 
 {coordinate_mapping_declaration}
+int init_coordinate_mapping_{factory_name}(ufc_coordinate_mapping* cmap)
+{{
+  {init_coordinate_mapping}
+}}
+
 ufc_coordinate_mapping* create_coordinate_mapping_{factory_name}(void)
 {{
 {create_coordinate_mapping}
 }}
 
 {finite_element_declaration}
+int init_finite_element_{factory_name}(ufc_finite_element* element, int i)
+{{
+  {init_finite_element}
+}}
+
 ufc_finite_element* create_finite_element_{factory_name}(int i)
 {{
 {create_finite_element}
 }}
 
 {dofmap_declaration}
+int init_dofmap_{factory_name}(ufc_dofmap* dofmap, int i)
+{{
+  {init_dofmap}
+}}
+
 ufc_dofmap* create_dofmap_{factory_name}(int i)
 {{
 {create_dofmap}
+}}
+
+int init_cell_integral_{factory_name}(ufc_integral* integral, int subdomain_id)
+{{
+  {init_cell_integral}
 }}
 
 ufc_integral* create_cell_integral_{factory_name}(int subdomain_id)
@@ -70,6 +94,11 @@ void get_cell_integral_ids_{factory_name}(int *ids)
   {get_cell_integral_ids}
 }}
 
+int init_exterior_facet_integral_{factory_name}(ufc_integral* integral, int subdomain_id)
+{{
+  {init_exterior_facet_integral}
+}}
+
 ufc_integral* create_exterior_facet_integral_{factory_name}(int subdomain_id)
 {{
   {create_exterior_facet_integral}
@@ -78,6 +107,11 @@ ufc_integral* create_exterior_facet_integral_{factory_name}(int subdomain_id)
 void get_exterior_facet_integral_ids_{factory_name}(int *ids)
 {{
   {get_exterior_facet_integral_ids}
+}}
+
+int init_interior_facet_integral_{factory_name}(ufc_integral* integral, int subdomain_id)
+{{
+  {init_interior_facet_integral}
 }}
 
 ufc_integral* create_interior_facet_integral_{factory_name}(int subdomain_id)
@@ -90,6 +124,11 @@ void get_interior_facet_integral_ids_{factory_name}(int *ids)
   {get_interior_facet_integral_ids}
 }}
 
+int init_vertex_integral_{factory_name}(ufc_integral* integral, int subdomain_id)
+{{
+  {init_vertex_integral}
+}}
+
 ufc_integral* create_vertex_integral_{factory_name}(int subdomain_id)
 {{
 {create_vertex_integral}
@@ -98,6 +137,11 @@ ufc_integral* create_vertex_integral_{factory_name}(int subdomain_id)
 void get_vertex_integral_ids_{factory_name}(int *ids)
 {{
   {get_vertex_integral_ids}
+}}
+
+int init_custom_integral_{factory_name}(ufc_custom_integral* integral, int subdomain_id)
+{{
+  {init_custom_integral}
 }}
 
 ufc_custom_integral* create_custom_integral_{factory_name}(int subdomain_id)
@@ -110,21 +154,30 @@ void get_custom_integral_ids_{factory_name}(int *ids)
   {get_custom_integral_ids}
 }}
 
-ufc_form* create_{factory_name}(void)
-{{
-  ufc_form* form = malloc(sizeof(*form));
+void destroy_{factory_name}(ufc_form* form);
+ufc_form* create_{factory_name}(void);
 
+int init_{factory_name}(ufc_form* form)
+{{
   form->signature = {signature};
   form->rank = {rank};
   form->num_coefficients = {num_coefficients};
   form->num_constants = {num_constants};
+
+  form->init = init_{factory_name};
+  form->destroy = destroy_{factory_name};
+  form->create = create_{factory_name};
+
   form->original_coefficient_position = original_coefficient_position_{factory_name};
 
   form->coefficient_name_map = coefficient_name_{factory_name};
   form->constant_name_map = constant_name_{factory_name};
 
+  form->init_coordinate_mapping = init_coordinate_mapping_{factory_name};
   form->create_coordinate_mapping = create_coordinate_mapping_{factory_name};
+  form->init_finite_element = init_finite_element_{factory_name};
   form->create_finite_element = create_finite_element_{factory_name};
+  form->init_dofmap = init_dofmap_{factory_name};
   form->create_dofmap = create_dofmap_{factory_name};
 
   form->get_cell_integral_ids = get_cell_integral_ids_{factory_name};
@@ -139,13 +192,38 @@ ufc_form* create_{factory_name}(void)
   form->num_vertex_integrals = {num_vertex_integrals};
   form->num_custom_integrals = {num_custom_integrals};
 
+  form->init_cell_integral = init_cell_integral_{factory_name};
   form->create_cell_integral = create_cell_integral_{factory_name};
+  form->init_exterior_facet_integral = init_exterior_facet_integral_{factory_name};
   form->create_exterior_facet_integral = create_exterior_facet_integral_{factory_name};
+  form->init_interior_facet_integral = init_interior_facet_integral_{factory_name};
   form->create_interior_facet_integral = create_interior_facet_integral_{factory_name};
+  form->init_vertex_integral = init_vertex_integral_{factory_name};
   form->create_vertex_integral = create_vertex_integral_{factory_name};
+  form->init_custom_integral = init_custom_integral_{factory_name};
   form->create_custom_integral = create_custom_integral_{factory_name};
+  return 0;
+}}
 
+void destroy_{factory_name}(ufc_form* form)
+{{
+}}
+
+ufc_form* create_{factory_name}(void)
+{{
+  ufc_form* form = malloc(sizeof(*form));
+  init_{factory_name}(form);
   return form;
+}}
+
+int init_{name_from_uflfile}(ufc_form* form)
+{{
+  return init_{factory_name}(form);
+}}
+
+void destroy_{name_from_uflfile}(ufc_form* form)
+{{
+  destroy_{factory_name}(form);
 }}
 
 ufc_form* create_{name_from_uflfile}(void)

--- a/ffcx/codegeneration/integrals_template.py
+++ b/ffcx/codegeneration/integrals_template.py
@@ -4,10 +4,14 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2018
 
 declaration = """
+int init_{factory_name}(ufc_integral* integral);
+void destroy_{factory_name}(ufc_integral* integral);
 ufc_integral* create_{factory_name}(void);
 """
 
 custom_declaration = """
+int init_{factory_name}(ufc_custom_integral* integral);
+void destroy_{factory_name}(ufc_custom_integral* integral);
 ufc_custom_integral* create_{factory_name}(void);
 """
 
@@ -85,12 +89,28 @@ factory = """
 
 {tabulate_tensor}
 
-ufc_integral* create_{factory_name}(void)
+void destroy_{factory_name}(ufc_integral* integral);
+ufc_integral* create_{factory_name}(void);
+
+int init_{factory_name}(ufc_integral* integral)
 {{
   static const bool enabled{enabled_coefficients}
-  ufc_integral* integral = malloc(sizeof(*integral));
   integral->enabled_coefficients = enabled;
   integral->tabulate_tensor = tabulate_tensor_{factory_name};
+  integral->init = init_{factory_name};
+  integral->destroy = destroy_{factory_name};
+  integral->create = create_{factory_name};
+  return 0;
+}}
+
+void destroy_{factory_name}(ufc_integral* integral)
+{{
+}}
+
+ufc_integral* create_{factory_name}(void)
+{{
+  ufc_integral* integral = malloc(sizeof(*integral));
+  init_{factory_name}(integral);
   return integral;
 }}
 
@@ -102,12 +122,28 @@ custom_factory = """
 
 {tabulate_tensor}
 
-ufc_custom_integral* create_{factory_name}(void)
+void destroy_{factory_name}(ufc_custom_integral* integral);
+ufc_custom_integral* create_{factory_name}(void);
+
+int init_{factory_name}(ufc_custom_integral* integral)
 {{
   static const bool enabled{enabled_coefficients}
-  ufc_custom_integral* integral = malloc(sizeof(*integral));
   integral->enabled_coefficients = enabled;
   integral->tabulate_tensor = tabulate_tensor_{factory_name};
+  integral->init = init_{factory_name};
+  integral->destroy = destroy_{factory_name};
+  integral->create = create_{factory_name};
+  return 0;
+}}
+
+void destroy_{factory_name}(ufc_custom_integral* integral)
+{{
+}}
+
+ufc_custom_integral* create_{factory_name}(void)
+{{
+  ufc_custom_integral* integral = malloc(sizeof(*integral));
+  init_{factory_name}(integral);
   return integral;
 }}
 

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -151,10 +151,12 @@ extern "C"
     int num_sub_elements;
 
     /// Create a new finite element for sub element i (for a mixed
-    /// element)
+    /// element). Memory for the new object is obtained with malloc,
+    /// and can be freed with free.
     ufc_finite_element* (*create_sub_element)(int i);
 
-    /// Create a new class instance
+    /// Create a new class instance. Memory for the new object is
+    /// obtained with malloc, and can be freed with free.
     ufc_finite_element* (*create)(void);
   } ufc_finite_element;
 
@@ -187,10 +189,13 @@ extern "C"
     /// Return the number of sub dofmaps (for a mixed element)
     int num_sub_dofmaps;
 
-    /// Create a new dofmap for sub dofmap i (for a mixed element)
+    /// Create a new dofmap for sub dofmap i (for a mixed
+    /// element). Memory for the new object is obtained with malloc,
+    /// and can be freed with free.
     ufc_dofmap* (*create_sub_dofmap)(int i);
 
-    /// Create a new class instance
+    /// Create a new class instance. Memory for the new object is
+    /// obtained with malloc, and can be freed with free.
     ufc_dofmap* (*create)(void);
   } ufc_dofmap;
 
@@ -202,7 +207,8 @@ extern "C"
     /// Return coordinate_mapping signature string
     const char* signature;
 
-    /// Create object of the same type
+    /// Create object of the same type. Memory for the new object is
+    /// obtained with malloc, and can be freed with free.
     ufc_coordinate_mapping* (*create)(void);
 
     /// Return geometric dimension of the coordinate_mapping
@@ -214,7 +220,9 @@ extern "C"
     /// Return cell shape of the coordinate_mapping
     ufc_shape cell_shape;
 
-    /// Create dofmap for the underlying scalar element
+    /// Create dofmap for the underlying scalar element. Memory for
+    /// the new object is obtained with malloc, and can be freed with
+    /// free.
     ufc_dofmap* (*create_scalar_dofmap)(void);
 
     /// Compute physical coordinates x from reference coordinates X,
@@ -547,10 +555,13 @@ extern "C"
     /// Return list of names of constants
     const char** (*constant_name_map)(void);
 
-    /// Create a new coordinate mapping
+    /// Create a new coordinate mapping. Memory for the new object is
+    /// obtained with malloc, and can be freed with free.
     ufc_coordinate_mapping* (*create_coordinate_mapping)(void);
 
-    /// Create a new finite element for argument function 0 <= i < r+n
+    /// Create a new finite element for the i-th argument function,
+    /// where 0 <= i < r+n. Memory for the new object is obtained with
+    /// malloc, and can be freed with free.
     ///
     /// @param i
     ///        Argument number if 0 <= i < r
@@ -558,7 +569,9 @@ extern "C"
     ///
     ufc_finite_element* (*create_finite_element)(int i);
 
-    /// Create a new dofmap for argument function 0 <= i < r+n
+    /// Create a new dofmap for the i-th argument function, where
+    /// 0 <= i < r+n.  Memory for the new object is obtained with
+    /// malloc, and can be freed with free.
     ///
     /// @param i
     ///        Argument number if 0 <= i < r
@@ -596,19 +609,29 @@ extern "C"
     /// Number of custom integrals
     int num_custom_integrals;
 
-    /// Create a new cell integral on sub domain subdomain_id
+    /// Create a new cell integral on sub domain subdomain_id. Memory
+    /// for the new object is obtained with malloc, and can be freed
+    /// with free.
     ufc_integral* (*create_cell_integral)(int subdomain_id);
 
-    /// Create a new exterior facet integral on sub domain subdomain_id
+    /// Create a new exterior facet integral on sub domain
+    /// subdomain_id. Memory for the new object is obtained with
+    /// malloc, and can be freed with free.
     ufc_integral* (*create_exterior_facet_integral)(int subdomain_id);
 
-    /// Create a new interior facet integral on sub domain subdomain_id
+    /// Create a new interior facet integral on sub domain
+    /// subdomain_id. Memory for the new object is obtained with
+    /// malloc, and can be freed with free.
     ufc_integral* (*create_interior_facet_integral)(int subdomain_id);
 
-    /// Create a new vertex integral on sub domain subdomain_id
+    /// Create a new vertex integral on sub domain
+    /// subdomain_id. Memory for the new object is obtained with
+    /// malloc, and can be freed with free.
     ufc_integral* (*create_vertex_integral)(int subdomain_id);
 
-    /// Create a new custom integral on sub domain subdomain_id
+    /// Create a new custom integral on sub domain
+    /// subdomain_id. Memory for the new object is obtained with
+    /// malloc, and can be freed with free.
     ufc_custom_integral* (*create_custom_integral)(int subdomain_id);
 
   } ufc_form;
@@ -616,13 +639,19 @@ extern "C"
   // FIXME: Formalise a UFC 'function space'.
   typedef struct ufc_function_space
   {
-    // Pointer to factory function that creates a new ufc_finite_element
+    // Pointer to factory function that creates a new
+    // ufc_finite_element. Memory for the new object is obtained with
+    // malloc, and can be freed with free.
     ufc_finite_element* (*create_element)(void);
 
-    // Pointer to factory function that creates a new ufc_dofmap
+    // Pointer to factory function that creates a new
+    // ufc_dofmap. Memory for the new object is obtained with malloc,
+    // and can be freed with free.
     ufc_dofmap* (*create_dofmap)(void);
 
-    // Pointer to factory function that creates a new ufc_coordinate_mapping
+    // Pointer to factory function that creates a new
+    // ufc_coordinate_mapping. Memory for the new object is obtained
+    // with malloc, and can be freed with free.
     ufc_coordinate_mapping* (*create_coordinate_mapping)(void);
   } ufc_function_space;
 

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -738,15 +738,24 @@ extern "C"
   // FIXME: Formalise a UFC 'function space'.
   typedef struct ufc_function_space
   {
+    // Create a new element.
+    int (*init_element)(ufc_finite_element* element);
+
     // Pointer to factory function that creates a new
     // ufc_finite_element. Memory for the new object is obtained with
     // malloc, and can be freed with free.
     ufc_finite_element* (*create_element)(void);
 
+    // Create a new dofmap.
+    int (*init_dofmap)(ufc_dofmap* dofmap);
+
     // Pointer to factory function that creates a new
     // ufc_dofmap. Memory for the new object is obtained with malloc,
     // and can be freed with free.
     ufc_dofmap* (*create_dofmap)(void);
+
+    // Create a new coordinate mapping.
+    int (*init_coordinate_mapping)(ufc_coordinate_mapping* cmap);
 
     // Pointer to factory function that creates a new
     // ufc_coordinate_mapping. Memory for the new object is obtained

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -199,10 +199,19 @@ extern "C"
     /// Return the number of sub dofmaps (for a mixed element)
     int num_sub_dofmaps;
 
+    /// Create a new dofmap for sub element i (for a mixed element)
+    int (*init_sub_dofmap)(ufc_dofmap* dofmap, int i);
+
     /// Create a new dofmap for sub dofmap i (for a mixed
     /// element). Memory for the new object is obtained with malloc,
     /// and can be freed with free.
     ufc_dofmap* (*create_sub_dofmap)(int i);
+
+    /// Create a new dofmap
+    int (*init)(ufc_dofmap* dofmap);
+
+    /// Destroy a dofmap
+    void (*destroy)(ufc_dofmap* element);
 
     /// Create a new class instance. Memory for the new object is
     /// obtained with malloc, and can be freed with free.

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -73,6 +73,7 @@ extern "C"
   typedef struct ufc_dofmap ufc_dofmap;
   typedef struct ufc_integral ufc_integral;
   typedef struct ufc_custom_integral ufc_custom_integral;
+  typedef struct ufc_form ufc_form;
 
 // </HEADER_DECL>
 
@@ -592,6 +593,16 @@ extern "C"
     /// Number of constants
     int num_constants;
 
+    /// Create a new form
+    int (*init)(ufc_form* form);
+
+    /// Destroy a form
+    void (*destroy)(ufc_form* form);
+
+    /// Create a new form. Memory for the new object is obtained with
+    /// malloc, and can be freed with free.
+    ufc_form* (*create)(void);
+
     /// Return original coefficient position for each coefficient
     ///
     /// @param i
@@ -605,9 +616,21 @@ extern "C"
     /// Return list of names of constants
     const char** (*constant_name_map)(void);
 
+    /// Create a new coordinate mapping
+    int (*init_coordinate_mapping)(ufc_coordinate_mapping* cmap);
+
     /// Create a new coordinate mapping. Memory for the new object is
     /// obtained with malloc, and can be freed with free.
     ufc_coordinate_mapping* (*create_coordinate_mapping)(void);
+
+    /// Create a new finite element for the i-th argument function,
+    /// where 0 <= i < r+n.
+    ///
+    /// @param i
+    ///        Argument number if 0 <= i < r
+    ///        Coefficient number j=i-r if r+j <= i < r+n
+    ///
+    int (*init_finite_element)(ufc_finite_element* element, int i);
 
     /// Create a new finite element for the i-th argument function,
     /// where 0 <= i < r+n. Memory for the new object is obtained with
@@ -618,6 +641,15 @@ extern "C"
     ///        Coefficient number j=i-r if r+j <= i < r+n
     ///
     ufc_finite_element* (*create_finite_element)(int i);
+
+    /// Create a new dofmap for the i-th argument function, where
+    /// 0 <= i < r+n.
+    ///
+    /// @param i
+    ///        Argument number if 0 <= i < r
+    ///        Coefficient number j=i-r if r+j <= i < r+n
+    ///
+    int (*init_dofmap)(ufc_dofmap* dofmap, int i);
 
     /// Create a new dofmap for the i-th argument function, where
     /// 0 <= i < r+n.  Memory for the new object is obtained with
@@ -659,10 +691,17 @@ extern "C"
     /// Number of custom integrals
     int num_custom_integrals;
 
+    /// Create a new cell integral on sub domain subdomain_id
+    int (*init_cell_integral)(ufc_integral* integral, int subdomain_id);
+
     /// Create a new cell integral on sub domain subdomain_id. Memory
     /// for the new object is obtained with malloc, and can be freed
     /// with free.
     ufc_integral* (*create_cell_integral)(int subdomain_id);
+
+    /// Create a new exterior facet integral on sub domain
+    /// subdomain_id
+    int (*init_exterior_facet_integral)(ufc_integral* integral, int subdomain_id);
 
     /// Create a new exterior facet integral on sub domain
     /// subdomain_id. Memory for the new object is obtained with
@@ -670,14 +709,24 @@ extern "C"
     ufc_integral* (*create_exterior_facet_integral)(int subdomain_id);
 
     /// Create a new interior facet integral on sub domain
+    /// subdomain_id
+    int (*init_interior_facet_integral)(ufc_integral* integral, int subdomain_id);
+
+    /// Create a new interior facet integral on sub domain
     /// subdomain_id. Memory for the new object is obtained with
     /// malloc, and can be freed with free.
     ufc_integral* (*create_interior_facet_integral)(int subdomain_id);
+
+    /// Create a new vertex integral on sub domain subdomain_id
+    int (*init_vertex_integral)(ufc_integral* integral, int subdomain_id);
 
     /// Create a new vertex integral on sub domain
     /// subdomain_id. Memory for the new object is obtained with
     /// malloc, and can be freed with free.
     ufc_integral* (*create_vertex_integral)(int subdomain_id);
+
+    /// Create a new custom integral on sub domain subdomain_id
+    int (*init_custom_integral)(ufc_custom_integral* custom_integral, int subdomain_id);
 
     /// Create a new custom integral on sub domain
     /// subdomain_id. Memory for the new object is obtained with

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -71,6 +71,8 @@ extern "C"
   typedef struct ufc_coordinate_mapping ufc_coordinate_mapping;
   typedef struct ufc_finite_element ufc_finite_element;
   typedef struct ufc_dofmap ufc_dofmap;
+  typedef struct ufc_integral ufc_integral;
+  typedef struct ufc_custom_integral ufc_custom_integral;
 
 // </HEADER_DECL>
 
@@ -487,12 +489,32 @@ extern "C"
   {
     const bool* enabled_coefficients;
     ufc_tabulate_tensor* tabulate_tensor;
+
+    /// Create a new integral
+    int (*init)(ufc_integral* integral);
+
+    /// Destroy an integral
+    void (*destroy)(ufc_integral* integral);
+
+    /// Create a new integral. Memory for the new object is obtained
+    /// with malloc, and can be freed with free.
+    ufc_integral* (*create)(void);
   } ufc_integral;
 
   typedef struct ufc_custom_integral
   {
     const bool* enabled_coefficients;
     ufc_tabulate_tensor_custom* tabulate_tensor;
+
+    /// Create a new custom integral
+    int (*init)(ufc_custom_integral* integral);
+
+    /// Destroy a custom integral
+    void (*destroy)(ufc_custom_integral* integral);
+
+    /// Create a new custom integral. Memory for the new object is
+    /// obtained with malloc, and can be freed with free.
+    ufc_custom_integral* (*create)(void);
   } ufc_custom_integral;
 
   typedef struct ufc_expression

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -226,6 +226,12 @@ extern "C"
     /// Return coordinate_mapping signature string
     const char* signature;
 
+    /// Create a coordinate mapping
+    int (*init)(ufc_coordinate_mapping* cmap);
+
+    /// Destroy a coordinate mapping
+    void (*destroy)(ufc_coordinate_mapping* cmap);
+
     /// Create object of the same type. Memory for the new object is
     /// obtained with malloc, and can be freed with free.
     ufc_coordinate_mapping* (*create)(void);
@@ -238,6 +244,9 @@ extern "C"
 
     /// Return cell shape of the coordinate_mapping
     ufc_shape cell_shape;
+
+    /// Create dofmap for the underlying scalar element
+    int (*init_scalar_dofmap)(ufc_dofmap* dofmap);
 
     /// Create dofmap for the underlying scalar element. Memory for
     /// the new object is obtained with malloc, and can be freed with

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -151,9 +151,19 @@ extern "C"
     int num_sub_elements;
 
     /// Create a new finite element for sub element i (for a mixed
+    /// element)
+    int (*init_sub_element)(ufc_finite_element* element, int i);
+
+    /// Create a new finite element for sub element i (for a mixed
     /// element). Memory for the new object is obtained with malloc,
     /// and can be freed with free.
     ufc_finite_element* (*create_sub_element)(int i);
+
+    /// Create a new finite element
+    int (*init)(ufc_finite_element* element);
+
+    /// Destroy a finite element
+    void (*destroy)(ufc_finite_element* element);
 
     /// Create a new class instance. Memory for the new object is
     /// obtained with malloc, and can be freed with free.

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -11,6 +11,27 @@ def generate_return_new(L, classname):
     return L.Return(L.Call("create_" + classname))
 
 
+def generate_return_init_switch(L, argname, i, classnames, args=None):
+
+    if isinstance(i, str):
+        i = L.Symbol(i)
+
+    def init(classname):
+        return L.Call("init_" + classname, (L.Symbol(argname)))
+
+    default = L.Return(L.LiteralInt(0))
+    if classnames:
+        cases = []
+        if args is None:
+            args = list(range(len(classnames)))
+        for j, classname in zip(args, classnames):
+            if classname:
+                cases.append((j, L.Return(init(classname))))
+        return L.Switch(i, cases, default=default)
+    else:
+        return default
+
+
 def generate_return_new_switch(L, i, classnames, args=None):
 
     if isinstance(i, str):

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -7,6 +7,10 @@
 # TODO: Move these to ffcx.language utils?
 
 
+def generate_return_init(L, argname, classname):
+    return L.Return(L.Call("init_" + classname, (L.Symbol(argname))))
+
+
 def generate_return_new(L, classname):
     return L.Return(L.Call("create_" + classname))
 

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -58,7 +58,7 @@ ir_element = namedtuple('ir_element', ['id', 'name', 'signature', 'cell_shape',
 ir_dofmap = namedtuple('ir_dofmap', ['id', 'name', 'signature', 'num_global_support_dofs',
                                      'num_element_support_dofs', 'num_entity_dofs',
                                      'tabulate_entity_dofs', 'base_permutations', 'dof_reflection_entities',
-                                     'num_sub_dofmaps', 'create_sub_dofmap', 'dof_types'])
+                                     'num_sub_dofmaps', 'init_sub_dofmap', 'create_sub_dofmap', 'dof_types'])
 ir_coordinate_map = namedtuple('ir_coordinate_map', ['id', 'prefix', 'name', 'signature', 'cell_shape',
                                                      'topological_dimension',
                                                      'geometric_dimension',
@@ -221,6 +221,7 @@ def _compute_dofmap_ir(ufl_element, element_numbers, dofmap_names):
     ir["num_entity_dofs"] = num_dofs_per_entity
     ir["tabulate_entity_dofs"] = (entity_dofs, num_dofs_per_entity)
     ir["num_sub_dofmaps"] = ufl_element.num_sub_elements()
+    ir["init_sub_dofmap"] = [dofmap_names[e] for e in ufl_element.sub_elements()]
     ir["create_sub_dofmap"] = [dofmap_names[e] for e in ufl_element.sub_elements()]
     ir["dof_types"] = [i.functional_type for i in fiat_element.dual_basis()]
     ir["base_permutations"] = dof_permutations.base_permutations(ufl_element)

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -53,7 +53,8 @@ ir_element = namedtuple('ir_element', ['id', 'name', 'signature', 'cell_shape',
                                        'reference_value_shape', 'degree', 'family', 'evaluate_basis',
                                        'evaluate_dof', 'tabulate_dof_coordinates', 'num_sub_elements',
                                        'base_permutations', 'dof_reflection_entities',
-                                       'create_sub_element', 'dof_types', 'entity_dofs'])
+                                       'init_sub_element', 'create_sub_element',
+                                       'dof_types', 'entity_dofs'])
 ir_dofmap = namedtuple('ir_dofmap', ['id', 'name', 'signature', 'num_global_support_dofs',
                                      'num_element_support_dofs', 'num_entity_dofs',
                                      'tabulate_entity_dofs', 'base_permutations', 'dof_reflection_entities',
@@ -188,6 +189,7 @@ def _compute_element_ir(ufl_element, element_numbers, finite_element_names, epsi
     ir["evaluate_dof"] = _evaluate_dof(ufl_element, fiat_element)
     ir["tabulate_dof_coordinates"] = _tabulate_dof_coordinates(ufl_element, fiat_element)
     ir["num_sub_elements"] = ufl_element.num_sub_elements()
+    ir["init_sub_element"] = [finite_element_names[e] for e in ufl_element.sub_elements()]
     ir["create_sub_element"] = [finite_element_names[e] for e in ufl_element.sub_elements()]
 
     ir["base_permutations"] = dof_permutations.base_permutations(ufl_element)


### PR DESCRIPTION
This pull requests adds a number of functions to the UFC api in `ufc.h`.

Previously, objects, such as `ufc_dofmap`, `ufc_form`, and so on, could be created by the user by calling the corresponding `create()` function. Such a function returns a pointer to the corresponding object. Internally, the `create()` function allocates storage for the object using `malloc()` and then sets the appropriate fields of the corresponding struct. The user is required to free the allocated memory by calling `free()` whenever they are done.

In these patches, I have added additional functions to each of the objects in the UFC API, so that they can be created without having UFC allocate storage. Instead, the user provides a pointer to the object and an `init()` function is used to initialise the members of the struct. In addition, I have added corresponding `destroy()` functions, which are intended to be used to free any resources that are associated with the object. As of now, `destroy()` does nothing, since there are no resources associated with any objects. However, I have in mind a future use case, where such functions are needed.

This pull request addresses Issue #236.