### PR TITLE
Custom compile time quadrature rules

### DIFF
--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -251,8 +251,11 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
             logger.info("--- quadrature degree: {}".format(qd))
             logger.info("--- precision: {}".format(p))
 
-            integral_data.integrals[i] = integral.reconstruct(
-                metadata={"quadrature_degree": qd, "quadrature_rule": qr, "precision": p})
+            # Update the old metadata
+            metadata = integral.metadata()
+            metadata.update({"quadrature_degree": qd, "quadrature_rule": qr, "precision": p})
+
+            integral_data.integrals[i] = integral.reconstruct(metadata=metadata)
 
     return form_data
 

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -92,6 +92,8 @@ def generator(ir, parameters):
             enabled_coefficients=code["enabled_coefficients"],
             tabulate_tensor=tabulate_tensor_fn)
 
+    print(implementation)
+
     return declaration, implementation
 
 
@@ -745,8 +747,6 @@ class IntegralGenerator(object):
 
             if td.ttype == "ones":
                 arg_factor = 1
-            elif td.ttype == "quadrature":  # TODO: Revisit all quadrature ttype checks
-                arg_factor = table[iq]
             else:
                 # Assuming B sparsity follows element table sparsity
                 arg_factor = table[indices[i]]
@@ -781,10 +781,7 @@ class IntegralGenerator(object):
         arg_indices = tuple(self.backend.symbols.argument_loop_index(i) for i in range(block_rank))
         B_indices = []
         for i in range(block_rank):
-            if ttypes[i] == "quadrature":
-                B_indices.append(iq)
-            else:
-                B_indices.append(arg_indices[i])
+            B_indices.append(arg_indices[i])
         B_indices = list(B_indices)
 
         # Get factor expression

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -92,8 +92,6 @@ def generator(ir, parameters):
             enabled_coefficients=code["enabled_coefficients"],
             tabulate_tensor=tabulate_tensor_fn)
 
-    print(implementation)
-
     return declaration, implementation
 
 

--- a/ffcx/fiatinterface.py
+++ b/ffcx/fiatinterface.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import logging
-import warnings
 
 import numpy
 
@@ -171,29 +170,6 @@ def create_quadrature(shape, degree, scheme="default"):
 
     if shape in ufl.cell.cellname2dim and ufl.cell.cellname2dim[shape] == 0:
         return (numpy.zeros((1, 0)), numpy.ones((1, )))
-
-    if scheme == "vertex":
-        # The vertex scheme, i.e., averaging the function value in the
-        # vertices and multiplying with the simplex volume, is only of
-        # order 1 and inferior to other generic schemes in terms of
-        # error reduction. Equation systems generated with the vertex
-        # scheme have some properties that other schemes lack, e.g., the
-        # mass matrix is a simple diagonal matrix. This may be
-        # prescribed in certain cases.
-        if degree > 1:
-            warnings.warn(
-                "Explicitly selected vertex quadrature (degree 1), but requested degree is {}.".
-                format(degree))
-        if shape == "tetrahedron":
-            return (numpy.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0,
-                                                                                     1.0]]),
-                    numpy.array([1.0 / 24.0, 1.0 / 24.0, 1.0 / 24.0, 1.0 / 24.0]))
-        elif shape == "triangle":
-            return (numpy.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]),
-                    numpy.array([1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0]))
-        elif shape == "interval":
-            # Trapezoidal rule.
-            return (numpy.array([[0.0], [1.0]]), numpy.array([1.0 / 2.0, 1.0 / 2.0]))
 
     quad_rule = FIAT.create_quadrature(reference_cell(shape), degree, scheme)
     points = numpy.asarray(quad_rule.get_points())

--- a/ffcx/ir/representationutils.py
+++ b/ffcx/ir/representationutils.py
@@ -54,8 +54,6 @@ def create_quadrature_points_and_weights(integral_type, cell, degree, rule):
                                               rule)
     elif integral_type in ufl.measure.point_integral_types:
         (points, weights) = create_quadrature("vertex", degree, rule)
-    elif integral_type in ufl.custom_integral_types:
-        (points, weights) = (None, None)
     elif integral_type == "expression":
         (points, weights) = (None, None)
     else:


### PR DESCRIPTION
Allows a user to pass his own set of points and weights as metadata in integral.

The syntax is following
```python
points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.5, 0.5], [0.0, 0.5], [0.5, 0.0]]
weights = [1 / 12] * 6
u * v * ufl.dx(metadata={"quadrature_rule": "custom", "quadrature_points": points, "quadrature_weights": weights})
```