### PR TITLE
Do not run coveralls in remote repos

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -50,7 +50,7 @@ jobs:
           pip install coveralls coverage pytest pytest-cov pytest-xdist
           pytest -n auto --cov=ffcx/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml test/
       - name: Upload to Coveralls
-        if: ${{ github.head_ref == '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
+        if: ${{ github.repository == 'FEniCS/ffcx' && github.head_ref == '' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |


### PR DESCRIPTION
One more check to skip coveralls on remote repo.

`github.head_ref` is empty on PR coming from a fork and `github.repository` is the name of repository where actions are run.