### PR TITLE
Add parameters documentation as a string

### DIFF
--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 import numpy
 
 import ufl
-from ffcx.parameters import FFCX_PARAMETERS
+from ffcx.parameters import default_parameters
 
 logger = logging.getLogger("ffcx")
 
@@ -166,6 +166,8 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
         do_append_everywhere_integrals=False,  # do not add dx integrals to dx(i) in UFL
         complex_mode=complex_mode)
 
+    parameters = default_parameters()
+
     # Determine unique quadrature degree, quadrature scheme and
     # precision per each integral data
     for id, integral_data in enumerate(form_data.integral_data):
@@ -183,7 +185,7 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
         #
         # 1. parameters["precision"]
         # 2. specified in metadata of integral
-        p_default = FFCX_PARAMETERS["precision"]
+        p_default = parameters["precision"]
         precisions = set([integral.metadata().get("precision", p_default)
                           for integral in integral_data.integrals])
         precisions.discard(p_default)
@@ -201,8 +203,8 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
 
         integral_data.metadata["precision"] = p
 
-        qd_default = FFCX_PARAMETERS["quadrature_degree"]
-        qr_default = FFCX_PARAMETERS["quadrature_rule"]
+        qd_default = parameters["quadrature_degree"]
+        qr_default = parameters["quadrature_rule"]
 
         for i, integral in enumerate(integral_data.integrals):
             # ----- Extract quadrature degree

--- a/ffcx/codegeneration/expressions.py
+++ b/ffcx/codegeneration/expressions.py
@@ -307,6 +307,8 @@ class ExpressionGenerator:
         definitions = []
         intermediates = []
 
+        use_symbol_array = True
+
         for i, attr in F.nodes.items():
             if attr['status'] != mode:
                 continue
@@ -361,7 +363,7 @@ class ExpressionGenerator:
                 else:
                     # Record assignment of vexpr to intermediate variable
                     j = len(intermediates)
-                    if self.ir.params["use_symbol_array"]:
+                    if use_symbol_array:
                         vaccess = symbol[j]
                         intermediates.append(L.Assign(vaccess, vexpr))
                     else:
@@ -377,7 +379,7 @@ class ExpressionGenerator:
         if definitions:
             parts += definitions
         if intermediates:
-            if self.ir.params["use_symbol_array"]:
+            if use_symbol_array:
                 alignas = self.ir.params["alignas"]
                 parts += [L.ArrayDecl("ufc_scalar_t", symbol, len(intermediates), alignas=alignas)]
             parts += intermediates

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -186,7 +186,7 @@ class IntegralGenerator(object):
         parts = []
 
         alignment = self.ir.params['assume_aligned']
-        if alignment is not -1:
+        if alignment != -1:
             parts += [L.VerbatimStatement("A = (ufc_scalar_t*)__builtin_assume_aligned(A, {});"
                                           .format(alignment)),
                       L.VerbatimStatement("w = (const ufc_scalar_t*)__builtin_assume_aligned(w, {});"

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -186,7 +186,7 @@ class IntegralGenerator(object):
         parts = []
 
         alignment = self.ir.params['assume_aligned']
-        if alignment is not None:
+        if alignment is not -1:
             parts += [L.VerbatimStatement("A = (ufc_scalar_t*)__builtin_assume_aligned(A, {});"
                                           .format(alignment)),
                       L.VerbatimStatement("w = (const ufc_scalar_t*)__builtin_assume_aligned(w, {});"

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -452,7 +452,9 @@ class IntegralGenerator(object):
         assert self.ir.integral_type in ufl.custom_integral_types
 
         num_points = self.ir.fake_num_points
-        chunk_size = self.ir.params["chunk_size"]
+
+        # FIXME: Review this parameters and add a better name
+        chunk_size = 1
 
         gdim = self.ir.geometric_dimension
 
@@ -584,6 +586,8 @@ class IntegralGenerator(object):
         definitions = []
         intermediates = []
 
+        use_symbol_array = True
+
         for i, attr in F.nodes.items():
             if attr['status'] != mode:
                 continue
@@ -640,7 +644,7 @@ class IntegralGenerator(object):
                     else:
                         # Record assignment of vexpr to intermediate variable
                         j = len(intermediates)
-                        if self.ir.params["use_symbol_array"]:
+                        if use_symbol_array:
                             vaccess = symbol[j]
                             intermediates.append(L.Assign(vaccess, vexpr))
                         else:
@@ -656,7 +660,7 @@ class IntegralGenerator(object):
         if definitions:
             parts += definitions
         if intermediates:
-            if self.ir.params["use_symbol_array"]:
+            if use_symbol_array:
                 alignas = self.ir.params["alignas"]
                 padlen = self.ir.params["padlen"]
                 parts += [L.ArrayDecl("ufc_scalar_t", symbol, len(intermediates), alignas=alignas, padlen=padlen)]

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -18,7 +18,7 @@ import string
 import ufl
 from ffcx import __version__ as FFCX_VERSION
 from ffcx import compiler, formatting
-from ffcx.parameters import default_parameters
+from ffcx.parameters import FFCX_PARAMETERS
 
 logger = logging.getLogger("ffcx")
 
@@ -32,10 +32,9 @@ parser.add_argument("--visualise", action="store_true", help="visualise the IR g
 parser.add_argument("-p", "--profile", action='store_true', help="enable profiling")
 
 # Add all parameters from FFC parameter system
-parameters = default_parameters()
-for param_name, param_val in parameters.items():
+for param_name, (param_val, param_desc) in FFCX_PARAMETERS.items():
     parser.add_argument("--{}".format(param_name), default=param_val,
-                        type=type(param_val), help="default \"{}\"".format(param_val))
+                        type=type(param_val), help="{} (default={})".format(param_desc, param_val))
 
 parser.add_argument("ufl_file", nargs='+', help="UFL file(s) to be compiled")
 

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -18,7 +18,7 @@ import string
 import ufl
 from ffcx import __version__ as FFCX_VERSION
 from ffcx import compiler, formatting
-from ffcx.parameters import FFCX_PARAMETERS
+from ffcx.parameters import FFCX_PARAMETERS, default_parameters
 
 logger = logging.getLogger("ffcx")
 

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -31,8 +31,9 @@ FFCX_PARAMETERS = {
         (32, """Memory alignment (in bytes) of some temporary objects in tabulation kernel
                 (finite element tables, intermediate variables array)"""),
     "assume_aligned":
-        (4, """Assumes alignment (in bytes) of pointers to tabulated tensor, coefficients and constants array.
-               This value must be compatible with alignment of data structures allocated outside FFC."""),
+        (-1, """Assumes alignment (in bytes) of pointers to tabulated tensor, coefficients and constants array.
+               This value must be compatible with alignment of data structures allocated outside FFC.
+               (-1 means no alignment assumed, safe option)"""),
     "padlen":
         (1, "Pads every declared array in tabulation kernel such that its last dimension is divisible by given value.")
 }

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -4,42 +4,45 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import copy
 import logging
 
 logger = logging.getLogger("ffcx")
 
 FFCX_PARAMETERS = {
-    "quadrature_rule": "default",  # quadrature rule used for integration of element tensors
-    "quadrature_degree": -1,  # quadrature degree used for computing integrals (-1 means auto)
-    "precision": -1,  # precision used when writing numbers (-1 for max precision)
-    "epsilon": 1e-14,  # machine precision, used for dropping zero terms in tables
-    # Scalar type to be used in generated code (real or complex
-    # C double precision floating-point types)
-    "scalar_type": "double",
-    "external_includes": "",  # ':' separated list of include filenames to add to generated code
-    "tabulate_tensor_void": False,  # generate empty tabulation kernels, for benchmarking
-
-    # Relative precision to use when comparing finite element table
-    # values for table reuse
-    "table_rtol": 1e-6,
-
-    # Absolute precision to use when comparing finite element table
-    # values for table reuse and dropping of table zeros
-    "table_atol": 1e-9,
-
-    # Number of points to evaluate
-    "chunk_size": 8,
-
-    "alignas": 32,
-    "assume_aligned": None,
-    "padlen": 1,
-    "use_symbol_array": True
+    "quadrature_rule":
+        ("default", "Quadrature rule used for integration of element tensors."),
+    "quadrature_degree":
+        (-1, """Quadrature degree used for approximating integrals.
+                (-1 means automatically determined from integrand polynomial degree)"""),
+    "precision":
+        (-1, """Precision used when writing numbers (-1 for max precision).
+                Represents maximum number of digits after decimal point."""),
+    "epsilon":
+        (1e-14, "Machine precision, used for dropping zero terms in tables"),
+    "scalar_type":
+        ("double", "Scalar type used in generated code. Any of real or complex C floating-point types."),
+    "tabulate_tensor_void":
+        (False, "True to generate empty tabulation kernels."),
+    "table_rtol":
+        (1e-6, "Relative precision to use when comparing finite element table values for table reuse."),
+    "table_atol":
+        (1e-9, "Absolute precision to use when comparing finite element table values for reuse."),
+    "alignas":
+        (32, """Memory alignment (in bytes) of some temporary objects in tabulation kernel
+                (finite element tables, intermediate variables array)"""),
+    "assume_aligned":
+        (4, """Assumes alignment (in bytes) of pointers to tabulated tensor, coefficients and constants array.
+               This value must be compatible with alignment of data structures allocated outside FFC."""),
+    "padlen":
+        (1, "Pads every declared array in tabulation kernel such that its last dimension is divisible by given value.")
 }
 
 
 def default_parameters():
     """Return (a copy of) the default parameter values for FFCX."""
-    parameters = copy.deepcopy(FFCX_PARAMETERS)
+    parameters = {}
+
+    for param, (value, desc) in FFCX_PARAMETERS.items():
+        parameters[param] = value
 
     return parameters


### PR DESCRIPTION
A more systematic approach to document parameters. Description is now printed as help for CLI, e.g.
```
  --assume_aligned ASSUME_ALIGNED
                        Assumes alignment (in bytes) of pointers to tabulated tensor, coefficients and constants array. This value must be compatible with alignment of data structures
                        allocated outside FFC. (default=4)
```