### PR TITLE
Only create cell permutation info if it is needed

### DIFF
--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -86,13 +86,13 @@ def generator(ir, parameters):
             factory_name=factory_name,
             enabled_coefficients=code["enabled_coefficients"],
             tabulate_tensor=tabulate_tensor_fn,
-            needs_permutation_data=1)
+            needs_permutation_data=ir.needs_permutation_data)
     else:
         implementation = ufc_integrals.factory.format(
             factory_name=factory_name,
             enabled_coefficients=code["enabled_coefficients"],
             tabulate_tensor=tabulate_tensor_fn,
-            needs_permutation_data=1)
+            needs_permutation_data=ir.needs_permutation_data)
 
     return declaration, implementation
 

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -85,12 +85,14 @@ def generator(ir, parameters):
         implementation = ufc_integrals.custom_factory.format(
             factory_name=factory_name,
             enabled_coefficients=code["enabled_coefficients"],
-            tabulate_tensor=tabulate_tensor_fn)
+            tabulate_tensor=tabulate_tensor_fn,
+            needs_permutation_data=1)
     else:
         implementation = ufc_integrals.factory.format(
             factory_name=factory_name,
             enabled_coefficients=code["enabled_coefficients"],
-            tabulate_tensor=tabulate_tensor_fn)
+            tabulate_tensor=tabulate_tensor_fn,
+            needs_permutation_data=1)
 
     return declaration, implementation
 

--- a/ffcx/codegeneration/integrals_template.py
+++ b/ffcx/codegeneration/integrals_template.py
@@ -91,6 +91,7 @@ ufc_integral* create_{factory_name}(void)
   ufc_integral* integral = (ufc_integral*)malloc(sizeof(*integral));
   integral->enabled_coefficients = enabled;
   integral->tabulate_tensor = tabulate_tensor_{factory_name};
+  integral->needs_permutation_data = {needs_permutation_data};
   return integral;
 }}
 
@@ -108,6 +109,7 @@ ufc_custom_integral* create_{factory_name}(void)
   ufc_custom_integral* integral = (ufc_custom_integral*)malloc(sizeof(*integral));
   integral->enabled_coefficients = enabled;
   integral->tabulate_tensor = tabulate_tensor_{factory_name};
+  integral->needs_permutation_data = {needs_permutation_data};
   return integral;
 }}
 

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -313,12 +313,14 @@ extern "C"
   {
     const bool* enabled_coefficients;
     ufc_tabulate_tensor* tabulate_tensor;
+    bool needs_permutation_data;
   } ufc_integral;
 
   typedef struct ufc_custom_integral
   {
     const bool* enabled_coefficients;
     ufc_tabulate_tensor_custom* tabulate_tensor;
+    bool needs_permutation_data;
   } ufc_custom_integral;
 
   typedef struct ufc_expression

--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -720,6 +720,7 @@ def build_optimized_tables(quadrature_rule,
         unique_table_ttypes[ename] = unique_table_ttypes[uname]
         del unique_table_ttypes[uname]
 
+    needs_permutation_data = False
     # Build mapping from modified terminal to unique table with metadata
     # { mt: (unique name,
     #        (table dof range begin, table dof range end),
@@ -732,6 +733,8 @@ def build_optimized_tables(quadrature_rule,
         dofmap = table_dofmaps[name]
         original_dim = table_original_num_dofs[name]
         is_permuted = table_permuted[name]
+        if is_permuted:
+            needs_permutation_data = True
 
         # Map name -> uname
         uname = table_unames[name]
@@ -755,4 +758,5 @@ def build_optimized_tables(quadrature_rule,
             ename, unique_tables[ename], dofrange, dofmap, original_dim, ttype,
             ttype in piecewise_ttypes, ttype in uniform_ttypes, is_permuted)
 
-    return unique_tables, unique_table_ttypes, unique_table_num_dofs, mt_unique_table_reference, table_origins
+    return (unique_tables, unique_table_ttypes, unique_table_num_dofs,
+            mt_unique_table_reference, table_origins, needs_permutation_data)

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -62,6 +62,8 @@ def compute_integral_ir(cell, integral_type, entitytype, integrands, argument_sh
     ir["table_dof_face_tangents"] = {}
     ir["table_dof_reflection_entities"] = {}
 
+    ir["needs_permutation_data"] = 0
+
     for quadrature_rule, integrand in integrands.items():
 
         expression = integrand
@@ -86,7 +88,8 @@ def compute_integral_ir(cell, integral_type, entitytype, integrands, argument_sh
                              if is_modified_terminal(v['expression'])}
 
         (unique_tables, unique_table_types, unique_table_num_dofs,
-         mt_unique_table_reference, table_origins) = build_optimized_tables(
+         mt_unique_table_reference, table_origins,
+         needs_permutation_data) = build_optimized_tables(
             quadrature_rule,
             cell,
             integral_type,
@@ -96,9 +99,17 @@ def compute_integral_ir(cell, integral_type, entitytype, integrands, argument_sh
             rtol=p["table_rtol"],
             atol=p["table_atol"])
 
+        if needs_permutation_data:
+            ir["needs_permutation_data"] = 1
+
         for k, v in table_origins.items():
             ir["table_dof_face_tangents"][k] = dof_permutations.face_tangents(v[0])
             ir["table_dof_reflection_entities"][k] = dof_permutations.reflection_entities(v[0])
+            for j in ir["table_dof_face_tangents"][k]:
+                if j is not None:
+                    ir["needs_permutation_data"] = 1
+            if len(ir["table_dof_reflection_entities"][k]) > 0:
+                ir["needs_permutation_data"] = 1
 
         for td in mt_unique_table_reference.values():
             ir["table_dofmaps"][td.name] = td.dofmap

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -82,7 +82,7 @@ ir_integral = namedtuple('ir_integral', ['integral_type', 'subdomain_id',
                                          'coefficient_offsets', 'original_constant_offsets', 'params', 'cell_shape',
                                          'unique_tables', 'unique_table_types', 'table_dofmaps',
                                          'table_dof_face_tangents', 'table_dof_reflection_entities',
-                                         'integrand', 'name', 'precision'])
+                                         'integrand', 'name', 'precision', 'needs_permutation_data'])
 ir_tabulate_dof_coordinates = namedtuple('ir_tabulate_dof_coordinates', ['tdim', 'gdim', 'points', 'cell_shape'])
 ir_evaluate_dof = namedtuple('ir_evaluate_dof', ['mappings', 'reference_value_size', 'physical_value_size',
                                                  'geometric_dimension', 'topological_dimension', 'dofs',

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -92,7 +92,8 @@ ir_expression = namedtuple('ir_expression', ['name', 'element_dimensions', 'para
                                              'table_dof_face_tangents', 'table_dof_reflection_entities',
                                              'coefficient_numbering', 'coefficient_offsets',
                                              'integral_type', 'entitytype', 'tensor_shape', 'expression_shape',
-                                             'original_constant_offsets', 'original_coefficient_positions', 'points'])
+                                             'original_constant_offsets', 'original_coefficient_positions', 'points',
+                                             'needs_permutation_data'])
 
 ir_data = namedtuple('ir_data', ['elements', 'dofmaps', 'coordinate_mappings', 'integrals', 'forms', 'expressions'])
 


### PR DESCRIPTION
This PR adds `needs_permutation_data` to the integral ir and generated code. This indicates whether or not the cell permutation data passes into `tabulate_tensor` will be used (for example, for CG1 spaces, the data will not be used, so `needs_permutation_data` will be false; but for CG3 spaces, the data will be used, so `needs_permutation_data` will be true).

This PR is coupled with FEniCS/dolfinx#1101.