### PR TITLE
Strip fewer zeros

### DIFF
--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -85,7 +85,14 @@ def strip_table_zeros(table, block_size, rtol=default_rtol, atol=default_atol):
         begin = 0
         end = 0
 
-    dofmap = tuple(range(begin, end, block_size))
+    for i in dofmap:
+        if i % block_size != dofmap[0] % block_size:
+            # If dofs are not all in the same block component, don't remove intermediate zeros
+            dofmap = tuple(range(begin, end))
+            break
+    else:
+        # If dofs are all in the same block component, keep only that block component
+        dofmap = tuple(range(begin, end, block_size))
 
     # Make subtable by dropping zero columns
     stripped_table = table[..., dofmap]


### PR DESCRIPTION
Zeros in a table between non-zero entries should only be stripped when they are due to being components of a blocked element.

Currently, all zeros are stripped, causing for example N1curl's derivatives to all be stripped to all have the same table, then the wrong permutations ending up for some components: this causes FEniCS/dolfinx#1148. (This is a bugfix of a change in #273.)

I've added a bad test to a branch of dolfinx to confirm that this fix is correct:

https://github.com/FEniCS/dolfinx/blob/88be6d9ccedf1586ff75f0ea5aef74f83462abe2/python/test/unit/fem/test_element_integrals.py#L411-L426

I'm currently working on a better test.