### PR TITLE
Remove alignas parameter

### DIFF
--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -1281,10 +1281,10 @@ class ArrayDecl(CStatement):
 
     """
 
-    __slots__ = ("typename", "symbol", "sizes", "alignas", "padlen", "values")
+    __slots__ = ("typename", "symbol", "sizes", "padlen", "values")
     is_scoped = False
 
-    def __init__(self, typename, symbol, sizes=None, values=None, alignas=None, padlen=0):
+    def __init__(self, typename, symbol, sizes=None, values=None, padlen=0):
         assert isinstance(typename, str)
         self.typename = typename
 
@@ -1308,7 +1308,6 @@ class ArrayDecl(CStatement):
         else:
             self.values = values
 
-        self.alignas = alignas
         self.padlen = padlen
 
     def cs_format(self, precision=None):
@@ -1323,12 +1322,6 @@ class ArrayDecl(CStatement):
 
         # Join declaration
         decl = self.typename + " " + self.symbol.name + brackets
-
-        # NB! C++11 style alignas prefix syntax.
-        # If trying other target languages, must use other syntax.
-        if self.alignas:
-            align = "alignas(%d)" % int(self.alignas)
-            decl = align + " " + decl
 
         if self.values is None:
             # Undefined initial values
@@ -1355,7 +1348,7 @@ class ArrayDecl(CStatement):
                 return (decl + " =", Indented(initializer_lists))
 
     def __eq__(self, other):
-        attributes = ("typename", "symbol", "sizes", "alignas", "padlen", "values")
+        attributes = ("typename", "symbol", "sizes", "padlen", "values")
         return (isinstance(other, type(self))
                 and all(getattr(self, name) == getattr(self, name) for name in attributes))
 

--- a/ffcx/codegeneration/evalderivs.py
+++ b/ffcx/codegeneration/evalderivs.py
@@ -310,8 +310,6 @@ def generate_evaluate_reference_basis_derivatives(L, data, classname, parameters
 def generate_tabulate_dmats(L, dofs_data):
     """Tabulate the derivatives of the polynomial base."""
 
-    alignas = 32
-
     # Emit code for the dmats we've actually used
     dmats_code = [L.Comment("Tables of derivatives of the polynomial base (transpose).")]
 
@@ -352,8 +350,7 @@ def generate_tabulate_dmats(L, dofs_data):
             decl = L.ArrayDecl(
                 "static const double",
                 name, (num_mats, num_members, num_members),
-                values=matrix,
-                alignas=alignas)
+                values=matrix)
             dmats_code.append(decl)
 
         # Append name for each dof

--- a/ffcx/codegeneration/expressions.py
+++ b/ffcx/codegeneration/expressions.py
@@ -102,14 +102,13 @@ class ExpressionGenerator:
 
         tables = self.ir.unique_tables
 
-        alignas = self.ir.params["alignas"]
         padlen = self.ir.params["padlen"]
         table_names = sorted(tables)
 
         for name in table_names:
             table = tables[name]
             decl = L.ArrayDecl(
-                "static const ufc_scalar_t", name, table.shape, table, alignas=alignas, padlen=padlen)
+                "static const ufc_scalar_t", name, table.shape, table, padlen=padlen)
             parts += [decl]
 
         # Add leading comment if there are any tables
@@ -413,8 +412,7 @@ class ExpressionGenerator:
             parts += definitions
         if intermediates:
             if use_symbol_array:
-                alignas = self.ir.params["alignas"]
-                parts += [L.ArrayDecl("ufc_scalar_t", symbol, len(intermediates), alignas=alignas)]
+                parts += [L.ArrayDecl("ufc_scalar_t", symbol, len(intermediates))]
             parts += intermediates
         return parts
 

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -27,9 +27,6 @@ FFCX_PARAMETERS = {
         (1e-6, "Relative precision to use when comparing finite element table values for table reuse."),
     "table_atol":
         (1e-9, "Absolute precision to use when comparing finite element table values for reuse."),
-    "alignas":
-        (32, """Memory alignment (in bytes) of some temporary objects in tabulation kernel
-                (finite element tables, intermediate variables array)"""),
     "assume_aligned":
         (-1, """Assumes alignment (in bytes) of pointers to tabulated tensor, coefficients and constants array.
                This value must be compatible with alignment of data structures allocated outside FFC.


### PR DESCRIPTION
This is better chosen by a compiler. Compiler always knows how to align the locally allocated memory.