### PR TITLE
Parse env parameters

### DIFF
--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -166,7 +166,7 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
         do_append_everywhere_integrals=False,  # do not add dx integrals to dx(i) in UFL
         complex_mode=complex_mode)
 
-    parameters = default_parameters()
+    parameters_default = default_parameters()
 
     # Determine unique quadrature degree, quadrature scheme and
     # precision per each integral data
@@ -185,7 +185,7 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
         #
         # 1. parameters["precision"]
         # 2. specified in metadata of integral
-        p_default = parameters["precision"]
+        p_default = parameters_default["precision"]
         precisions = set([integral.metadata().get("precision", p_default)
                           for integral in integral_data.integrals])
         precisions.discard(p_default)
@@ -203,8 +203,8 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
 
         integral_data.metadata["precision"] = p
 
-        qd_default = parameters["quadrature_degree"]
-        qr_default = parameters["quadrature_rule"]
+        qd_default = parameters_default["quadrature_degree"]
+        qr_default = parameters_default["quadrature_rule"]
 
         for i, integral in enumerate(integral_data.integrals):
             # ----- Extract quadrature degree

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -95,6 +95,8 @@ def compile_elements(elements, parameters=None, cache_dir=None, timeout=10, cffi
     if parameters is not None:
         p.update(parameters)
 
+    p.update(ffcx.parameters.env_parameters())
+
     # Get a signature for these elements
     module_name = 'libffcx_elements_' + \
         ffcx.naming.compute_signature(elements, _compute_parameter_signature(p)
@@ -147,6 +149,8 @@ def compile_forms(forms, parameters=None, cache_dir=None, timeout=10, cffi_extra
     if parameters is not None:
         p.update(parameters)
 
+    p.update(ffcx.parameters.env_parameters())
+
     # Get a signature for these forms
     module_name = 'libffcx_forms_' + \
         ffcx.naming.compute_signature(forms, _compute_parameter_signature(p)
@@ -197,6 +201,8 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
     if parameters is not None:
         p.update(parameters)
 
+    p.update(ffcx.parameters.env_parameters())
+
     # Get a signature for these forms
     module_name = 'libffcx_expressions_' + ffcx.naming.compute_signature(expressions, '', p)
 
@@ -238,6 +244,8 @@ def compile_coordinate_maps(meshes, parameters=None, cache_dir=None, timeout=10,
     p = ffcx.parameters.default_parameters()
     if parameters is not None:
         p.update(parameters)
+
+    p.update(ffcx.parameters.env_parameters())
 
     # Get a signature for these cmaps
     module_name = 'libffcx_cmaps_' + \

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -96,6 +96,7 @@ def compile_elements(elements, parameters=None, cache_dir=None, timeout=10, cffi
         p.update(parameters)
 
     p.update(ffcx.parameters.env_parameters())
+    logger.setLevel(p["verbosity"])
 
     # Get a signature for these elements
     module_name = 'libffcx_elements_' + \
@@ -150,6 +151,7 @@ def compile_forms(forms, parameters=None, cache_dir=None, timeout=10, cffi_extra
         p.update(parameters)
 
     p.update(ffcx.parameters.env_parameters())
+    logger.setLevel(p["verbosity"])
 
     # Get a signature for these forms
     module_name = 'libffcx_forms_' + \
@@ -202,6 +204,7 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
         p.update(parameters)
 
     p.update(ffcx.parameters.env_parameters())
+    logger.setLevel(p["verbosity"])
 
     # Get a signature for these forms
     module_name = 'libffcx_expressions_' + ffcx.naming.compute_signature(expressions, '', p)
@@ -246,6 +249,7 @@ def compile_coordinate_maps(meshes, parameters=None, cache_dir=None, timeout=10,
         p.update(parameters)
 
     p.update(ffcx.parameters.env_parameters())
+    logger.setLevel(p["verbosity"])
 
     # Get a signature for these cmaps
     module_name = 'libffcx_cmaps_' + \

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -26,7 +26,6 @@ parser = argparse.ArgumentParser(
     description="FEniCS Form Compiler (FFCX, https://fenicsproject.org)")
 parser.add_argument(
     "--version", action='version', version="%(prog)s " + ("(version {})".format(FFCX_VERSION)))
-parser.add_argument("-v", "--verbosity", action="count", help="verbose output (-vv for more verbosity)")
 parser.add_argument("-o", "--output-directory", type=str, default=".", help="output directory")
 parser.add_argument("--visualise", action="store_true", help="visualise the IR graph")
 parser.add_argument("-p", "--profile", action='store_true', help="enable profiling")
@@ -42,18 +41,15 @@ parser.add_argument("ufl_file", nargs='+', help="UFL file(s) to be compiled")
 def main(args=None):
     xargs = parser.parse_args(args)
 
-    ffcx_logger = logging.getLogger("ffcx")
-    if xargs.verbosity == 1:
-        ffcx_logger.setLevel(logging.INFO)
-    if xargs.verbosity == 2:
-        ffcx_logger.setLevel(logging.DEBUG)
-
     # Parse all other parameters
     parameters = default_parameters()
     for param_name, param_val in parameters.items():
         parameters[param_name] = xargs.__dict__.get(param_name)
 
     parameters.update(env_parameters())
+
+    ffcx_logger = logging.getLogger("ffcx")
+    ffcx_logger.setLevel(parameters["verbosity"])
 
     # Call parser and compiler for each file
     for filename in xargs.ufl_file:

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -18,7 +18,7 @@ import string
 import ufl
 from ffcx import __version__ as FFCX_VERSION
 from ffcx import compiler, formatting
-from ffcx.parameters import FFCX_PARAMETERS, default_parameters
+from ffcx.parameters import FFCX_PARAMETERS, default_parameters, env_parameters
 
 logger = logging.getLogger("ffcx")
 
@@ -52,6 +52,8 @@ def main(args=None):
     parameters = default_parameters()
     for param_name, param_val in parameters.items():
         parameters[param_name] = xargs.__dict__.get(param_name)
+
+    parameters.update(env_parameters())
 
     # Call parser and compiler for each file
     for filename in xargs.ufl_file:

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -33,7 +33,9 @@ FFCX_PARAMETERS = {
                This value must be compatible with alignment of data structures allocated outside FFC.
                (-1 means no alignment assumed, safe option)"""),
     "padlen":
-        (1, "Pads every declared array in tabulation kernel such that its last dimension is divisible by given value.")
+        (1, "Pads every declared array in tabulation kernel such that its last dimension is divisible by given value."),
+    "verbosity":
+        (30, "Logger verbosity. Follows standard logging library levels, i.e. INFO=20, DEBUG=10, etc.")
 }
 
 

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 import logging
+import os
 
 logger = logging.getLogger("ffcx")
 
@@ -44,3 +45,19 @@ def default_parameters():
         parameters[param] = value
 
     return parameters
+
+
+def env_parameters():
+    """Returns parameters set in environmental variables"""
+
+    keys = os.environ.keys()
+    params = {}
+    for name, value in FFCX_PARAMETERS.items():
+        param_name = "FFCX_" + name.upper()
+        param_type = type(value[0])
+
+        if param_name in keys:
+            params[name] = param_type(os.environ[param_name])
+            logger.info("Parameter {} forced to {} from environmental variable.".format(name, params[name]))
+
+    return params

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -48,7 +48,7 @@ def default_parameters():
 
 
 def env_parameters():
-    """Returns parameters set in environmental variables"""
+    """Returns parameters set in environmental variables."""
 
     keys = os.environ.keys()
     params = {}

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -11,7 +11,6 @@ import subprocess
 
 def test_cmdline_simple():
     os.chdir(os.path.dirname(__file__))
-    subprocess.run(["ffcx", "-v", "Poisson.ufl"])
     subprocess.run(["ffcx", "Poisson.ufl"])
 
 


### PR DESCRIPTION
Adds the possibility to force any parameter with env variable. Especially useful for `export FFCX_ASSUME_ALIGNED=...`. Env forced parameters have the highest priority.

In addition, `verbosity` is added as a new FFCx parameter, which means it could be now easily controlled either via API or the above-mentioned env vars. One can do `export FFCX_VERBOSITY=10`.
It solves the issue of controlling FFCx verbosity from dolfinx, `dolfinx.Form(form, ffcx_parameters={"verbosity": 10})`.