### PR TITLE
Configuration files for FFCX

### DIFF
--- a/ffcx/__init__.py
+++ b/ffcx/__init__.py
@@ -15,7 +15,7 @@ import logging
 import pkg_resources
 
 # Import default parameters
-from ffcx.parameters import default_parameters  # noqa: F401
+from ffcx.parameters import get_parameters  # noqa: F401
 
 __version__ = pkg_resources.get_distribution("fenics-ffcx").version
 

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -19,7 +19,6 @@ from collections import namedtuple
 import numpy
 
 import ufl
-from ffcx.parameters import get_parameters
 
 logger = logging.getLogger("ffcx")
 
@@ -166,8 +165,6 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
         do_append_everywhere_integrals=False,  # do not add dx integrals to dx(i) in UFL
         complex_mode=complex_mode)
 
-    parameters = get_parameters()
-
     # Determine unique quadrature degree, quadrature scheme and
     # precision per each integral data
     for id, integral_data in enumerate(form_data.integral_data):
@@ -179,47 +176,31 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
         # all integrals in this integral data group, i.e. must be the
         # same for for the same (domain, itype, subdomain_id)
 
-        # ----- Extract precision
-        #
-        # The priority of precision determination is following
-        #
-        # 1. parameters["precision"]
-        # 2. specified in metadata of integral
-        p_default = parameters["precision"]
+        # Extract precision
+        p_default = -1
         precisions = set([integral.metadata().get("precision", p_default)
                           for integral in integral_data.integrals])
         precisions.discard(p_default)
 
-        if parameters["precision"] != p_default:
-            p = parameters["precision"]
-        elif len(precisions) == 1:
+        if len(precisions) == 1:
             p = precisions.pop()
         elif len(precisions) == 0:
+            # Default precision
             p = numpy.finfo("double").precision + 1  # == 16
-        elif len(precisions) > 1:
-            raise RuntimeError("Only one precision allowed within integrals grouped by subdomain.")
         else:
-            raise RuntimeError("Unable to determine quadrature degree.")
+            raise RuntimeError("Only one precision allowed within integrals grouped by subdomain.")
 
         integral_data.metadata["precision"] = p
 
-        qd_default = parameters["quadrature_degree"]
-        qr_default = parameters["quadrature_rule"]
+        qd_default = -1
+        qr_default = "default"
 
         for i, integral in enumerate(integral_data.integrals):
-            # ----- Extract quadrature degree
-            #
-            # The priority of quadrature degree determination is following
-            #
-            # 1. Parameters["quadrature_degree"]
-            # 2. Specified in metadata of integral
-            # 3. Estimated by UFL
+            # Extract quadrature degree
             qd_metadata = integral.metadata().get("quadrature_degree", qd_default)
             qd_estimated = numpy.max(integral.metadata()["estimated_polynomial_degree"])
 
-            if parameters["quadrature_degree"] != qd_default:
-                qd = parameters["quadrature_degree"]
-            elif qd_metadata != qd_default:
+            if qd_metadata != qd_default:
                 qd = qd_metadata
             else:
                 qd = qd_estimated
@@ -234,19 +215,8 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
                         "Number of integration points per cell is: {}. Consider using 'quadrature_degree' "
                         "to reduce number.".format(num_points))
 
-            # ----- Extract quadrature rule
-            #
-            # The priority of quadrature rule determination is following
-            #
-            # 1. parameters["quadrature_rule"]
-            # 2. specified in metadata of integral
-            qr_metadata = integral.metadata().get("quadrature_rule", qr_default)
-            if parameters["quadrature_rule"] != qr_default:
-                qr = parameters["quadrature_rule"]
-            elif qr_metadata != qr_default:
-                qr = qr_metadata
-            else:
-                qr = qr_default
+            # Extract quadrature rule
+            qr = integral.metadata().get("quadrature_rule", qr_default)
 
             logger.info("Integral {}, integral group {}:".format(i, id))
             logger.info("--- quadrature rule: {}".format(qr))

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -36,6 +36,7 @@ def analyze_ufl_objects(ufl_objects: typing.Union[typing.List[ufl.form.Form], ty
     ----------
     ufl_objects
     parameters
+      FFCX parameters. These parameters take priority over all other set parameters.
 
     Returns
     -------

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 import numpy
 
 import ufl
-from ffcx.parameters import default_parameters
+from ffcx.parameters import get_parameters
 
 logger = logging.getLogger("ffcx")
 
@@ -166,7 +166,7 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
         do_append_everywhere_integrals=False,  # do not add dx integrals to dx(i) in UFL
         complex_mode=complex_mode)
 
-    parameters = default_parameters()
+    parameters = get_parameters()
 
     # Determine unique quadrature degree, quadrature scheme and
     # precision per each integral data

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -91,11 +91,7 @@ def get_cached_module(module_name, object_names, cache_dir, timeout):
 def compile_elements(elements, parameters=None, cache_dir=None, timeout=10, cffi_extra_compile_args=None,
                      cffi_verbose=False, cffi_debug=None, cffi_libraries=None):
     """Compile a list of UFL elements and dofmaps into Python objects."""
-    p = ffcx.parameters.get_parameters()
-    if parameters is not None:
-        p.update(parameters)
-
-    logger.setLevel(p["verbosity"])
+    p = ffcx.parameters.get_parameters(parameters)
 
     # Get a signature for these elements
     module_name = 'libffcx_elements_' + \
@@ -145,11 +141,7 @@ def compile_elements(elements, parameters=None, cache_dir=None, timeout=10, cffi
 def compile_forms(forms, parameters=None, cache_dir=None, timeout=10, cffi_extra_compile_args=None,
                   cffi_verbose=False, cffi_debug=None, cffi_libraries=None):
     """Compile a list of UFL forms into UFC Python objects."""
-    p = ffcx.parameters.get_parameters()
-    if parameters is not None:
-        p.update(parameters)
-
-    logger.setLevel(p["verbosity"])
+    p = ffcx.parameters.get_parameters(parameters)
 
     # Get a signature for these forms
     module_name = 'libffcx_forms_' + \
@@ -197,11 +189,7 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
         List of (UFL expression, evaluation points).
 
     """
-    p = ffcx.parameters.get_parameters()
-    if parameters is not None:
-        p.update(parameters)
-
-    logger.setLevel(p["verbosity"])
+    p = ffcx.parameters.get_parameters(parameters)
 
     # Get a signature for these forms
     module_name = 'libffcx_expressions_' + ffcx.naming.compute_signature(expressions, '', p)
@@ -241,11 +229,7 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
 def compile_coordinate_maps(meshes, parameters=None, cache_dir=None, timeout=10, cffi_extra_compile_args=None,
                             cffi_verbose=False, cffi_debug=None, cffi_libraries=None):
     """Compile a list of UFL coordinate mappings into UFC Python objects."""
-    p = ffcx.parameters.get_parameters()
-    if parameters is not None:
-        p.update(parameters)
-
-    logger.setLevel(p["verbosity"])
+    p = ffcx.parameters.get_parameters(parameters)
 
     # Get a signature for these cmaps
     module_name = 'libffcx_cmaps_' + \

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -95,6 +95,8 @@ def compile_elements(elements, parameters=None, cache_dir=None, timeout=10, cffi
     if parameters is not None:
         p.update(parameters)
 
+    logger.setLevel(p["verbosity"])
+
     # Get a signature for these elements
     module_name = 'libffcx_elements_' + \
         ffcx.naming.compute_signature(elements, _compute_parameter_signature(p)
@@ -147,6 +149,8 @@ def compile_forms(forms, parameters=None, cache_dir=None, timeout=10, cffi_extra
     if parameters is not None:
         p.update(parameters)
 
+    logger.setLevel(p["verbosity"])
+
     # Get a signature for these forms
     module_name = 'libffcx_forms_' + \
         ffcx.naming.compute_signature(forms, _compute_parameter_signature(p)
@@ -197,6 +201,8 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
     if parameters is not None:
         p.update(parameters)
 
+    logger.setLevel(p["verbosity"])
+
     # Get a signature for these forms
     module_name = 'libffcx_expressions_' + ffcx.naming.compute_signature(expressions, '', p)
 
@@ -238,6 +244,8 @@ def compile_coordinate_maps(meshes, parameters=None, cache_dir=None, timeout=10,
     p = ffcx.parameters.get_parameters()
     if parameters is not None:
         p.update(parameters)
+
+    logger.setLevel(p["verbosity"])
 
     # Get a signature for these cmaps
     module_name = 'libffcx_cmaps_' + \

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -91,7 +91,7 @@ def get_cached_module(module_name, object_names, cache_dir, timeout):
 def compile_elements(elements, parameters=None, cache_dir=None, timeout=10, cffi_extra_compile_args=None,
                      cffi_verbose=False, cffi_debug=None, cffi_libraries=None):
     """Compile a list of UFL elements and dofmaps into Python objects."""
-    p = ffcx.parameters.default_parameters()
+    p = ffcx.parameters.get_parameters()
     if parameters is not None:
         p.update(parameters)
 
@@ -143,7 +143,7 @@ def compile_elements(elements, parameters=None, cache_dir=None, timeout=10, cffi
 def compile_forms(forms, parameters=None, cache_dir=None, timeout=10, cffi_extra_compile_args=None,
                   cffi_verbose=False, cffi_debug=None, cffi_libraries=None):
     """Compile a list of UFL forms into UFC Python objects."""
-    p = ffcx.parameters.default_parameters()
+    p = ffcx.parameters.get_parameters()
     if parameters is not None:
         p.update(parameters)
 
@@ -193,7 +193,7 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
         List of (UFL expression, evaluation points).
 
     """
-    p = ffcx.parameters.default_parameters()
+    p = ffcx.parameters.get_parameters()
     if parameters is not None:
         p.update(parameters)
 
@@ -235,7 +235,7 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
 def compile_coordinate_maps(meshes, parameters=None, cache_dir=None, timeout=10, cffi_extra_compile_args=None,
                             cffi_verbose=False, cffi_debug=None, cffi_libraries=None):
     """Compile a list of UFL coordinate mappings into UFC Python objects."""
-    p = ffcx.parameters.default_parameters()
+    p = ffcx.parameters.get_parameters()
     if parameters is not None:
         p.update(parameters)
 

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -32,7 +32,7 @@ parser.add_argument("-p", "--profile", action='store_true', help="enable profili
 
 # Add all parameters from FFC parameter system
 for param_name, (param_val, param_desc) in FFCX_DEFAULT_PARAMETERS.items():
-    parser.add_argument("--{}".format(param_name), default=param_val,
+    parser.add_argument("--{}".format(param_name),
                         type=type(param_val), help="{} (default={})".format(param_desc, param_val))
 
 parser.add_argument("ufl_file", nargs='+', help="UFL file(s) to be compiled")
@@ -42,12 +42,8 @@ def main(args=None):
     xargs = parser.parse_args(args)
 
     # Parse all other parameters
-    parameters = get_parameters()
-    for param_name, param_val in parameters.items():
-        parameters[param_name] = xargs.__dict__.get(param_name)
-
-    ffcx_logger = logging.getLogger("ffcx")
-    ffcx_logger.setLevel(parameters["verbosity"])
+    priority_parameters = {k: v for k, v in xargs.__dict__.items() if v is not None}
+    parameters = get_parameters(priority_parameters)
 
     # Call parser and compiler for each file
     for filename in xargs.ufl_file:

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -46,8 +46,6 @@ def main(args=None):
     for param_name, param_val in parameters.items():
         parameters[param_name] = xargs.__dict__.get(param_name)
 
-    parameters.update(env_parameters())
-
     ffcx_logger = logging.getLogger("ffcx")
     ffcx_logger.setLevel(parameters["verbosity"])
 

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -26,7 +26,6 @@ parser = argparse.ArgumentParser(
     description="FEniCS Form Compiler (FFCX, https://fenicsproject.org)")
 parser.add_argument(
     "--version", action='version', version="%(prog)s " + ("(version {})".format(FFCX_VERSION)))
-parser.add_argument("-v", "--verbosity", action="count", help="verbose output (-vv for more verbosity)")
 parser.add_argument("-o", "--output-directory", type=str, default=".", help="output directory")
 parser.add_argument("--visualise", action="store_true", help="visualise the IR graph")
 parser.add_argument("-p", "--profile", action='store_true', help="enable profiling")
@@ -42,16 +41,15 @@ parser.add_argument("ufl_file", nargs='+', help="UFL file(s) to be compiled")
 def main(args=None):
     xargs = parser.parse_args(args)
 
-    ffcx_logger = logging.getLogger("ffcx")
-    if xargs.verbosity == 1:
-        ffcx_logger.setLevel(logging.INFO)
-    if xargs.verbosity == 2:
-        ffcx_logger.setLevel(logging.DEBUG)
-
     # Parse all other parameters
     parameters = get_parameters()
     for param_name, param_val in parameters.items():
         parameters[param_name] = xargs.__dict__.get(param_name)
+
+    parameters.update(env_parameters())
+
+    ffcx_logger = logging.getLogger("ffcx")
+    ffcx_logger.setLevel(parameters["verbosity"])
 
     # Call parser and compiler for each file
     for filename in xargs.ufl_file:

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -18,7 +18,7 @@ import string
 import ufl
 from ffcx import __version__ as FFCX_VERSION
 from ffcx import compiler, formatting
-from ffcx.parameters import FFCX_PARAMETERS, default_parameters
+from ffcx.parameters import FFCX_DEFAULT_PARAMETERS, get_parameters
 
 logger = logging.getLogger("ffcx")
 
@@ -32,7 +32,7 @@ parser.add_argument("--visualise", action="store_true", help="visualise the IR g
 parser.add_argument("-p", "--profile", action='store_true', help="enable profiling")
 
 # Add all parameters from FFC parameter system
-for param_name, (param_val, param_desc) in FFCX_PARAMETERS.items():
+for param_name, (param_val, param_desc) in FFCX_DEFAULT_PARAMETERS.items():
     parser.add_argument("--{}".format(param_name), default=param_val,
                         type=type(param_val), help="{} (default={})".format(param_desc, param_val))
 
@@ -49,7 +49,7 @@ def main(args=None):
         ffcx_logger.setLevel(logging.DEBUG)
 
     # Parse all other parameters
-    parameters = default_parameters()
+    parameters = get_parameters()
     for param_name, param_val in parameters.items():
         parameters[param_name] = xargs.__dict__.get(param_name)
 

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -39,7 +39,7 @@ FFCX_DEFAULT_PARAMETERS = {
 
 @functools.lru_cache
 def _load_parameters():
-    """Loads parameters from JSON files"""
+    """Loads parameters from JSON files."""
     user_config_file = os.path.join(pathlib.Path.home(), ".config", "ffcx", "ffcx_parameters.json")
     try:
         with open(user_config_file) as f:
@@ -93,6 +93,7 @@ def get_parameters(priority_parameters: Optional[dict] = None) -> dict:
     for param, (value, desc) in FFCX_DEFAULT_PARAMETERS.items():
         parameters[param] = value
 
+    # NOTE: _load_parameters uses functools.lru_cache
     user_parameters, pwd_parameters = _load_parameters()
 
     parameters.update(user_parameters)

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -50,7 +50,6 @@ def get_parameters(priority_parameters: Optional[dict] = None) -> dict:
 
     Notes
     -----
-
     This function sets the log level from the merged parameter values prior to
     returning.
 

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -80,7 +80,7 @@ def get_parameters(priority_parameters: Optional[dict] = None) -> dict:
     Priority ordering of parameters from highest to lowest is:
       priority_parameters (API and command line parameters)
       $(pwd)/ffcx_parameters.json (local parameters)
-      ~/.config/ffcx/ffcx_paramters.json (user parameters)
+      ~/.config/ffcx/ffcx_parameters.json (user parameters)
       FFCX_DEFAULT_PARAMETERS in ffcx.parameters
 
     Example ffcx_parameters.json file:

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -71,7 +71,6 @@ def get_parameters():
     except FileNotFoundError:
         pwd_parameters = {}
 
-
     keys = os.environ.keys()
     env_parameters = {}
     for name, value in FFCX_DEFAULT_PARAMETERS.items():
@@ -79,8 +78,8 @@ def get_parameters():
         param_type = type(value[0])
 
         if param_name in keys:
-            env_paramaters[name] = param_type(os.environ[param_name])
-            logger.info("Parameter {} forced to {} from environmental variable.".format(name, params[name]))
+            env_parameters[name] = param_type(os.environ[param_name])
+            logger.info("Parameter {} forced to {} from environmental variable.".format(name, env_parameters[name]))
 
     parameters.update(user_parameters)
     parameters.update(pwd_parameters)

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -37,7 +37,7 @@ FFCX_DEFAULT_PARAMETERS = {
 }
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=None)
 def _load_parameters():
     """Loads parameters from JSON files."""
     user_config_file = os.path.join(pathlib.Path.home(), ".config", "ffcx", "ffcx_parameters.json")

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -13,14 +13,6 @@ import pathlib
 logger = logging.getLogger("ffcx")
 
 FFCX_DEFAULT_PARAMETERS = {
-    "quadrature_rule":
-        ("default", "Quadrature rule used for integration of element tensors."),
-    "quadrature_degree":
-        (-1, """Quadrature degree used for approximating integrals.
-                (-1 means automatically determined from integrand polynomial degree)"""),
-    "precision":
-        (-1, """Precision used when writing numbers (-1 for max precision).
-                Represents maximum number of digits after decimal point."""),
     "epsilon":
         (1e-14, "Machine precision, used for dropping zero terms in tables"),
     "scalar_type":
@@ -56,7 +48,7 @@ def get_parameters():
     for param, (value, desc) in FFCX_DEFAULT_PARAMETERS.items():
         parameters[param] = value
 
-    user_config_file = os.path.join(pathlib.Path.home(), ".config", "ffcx", "parameters.json")
+    user_config_file = os.path.join(pathlib.Path.home(), ".config", "ffcx", ".ffcx_parameters.json")
     pwd_config_file = os.path.join(os.getcwd(), ".ffcx_parameters.json")
 
     try:
@@ -71,21 +63,10 @@ def get_parameters():
     except FileNotFoundError:
         pwd_parameters = {}
 
-    keys = os.environ.keys()
-    env_parameters = {}
-    for name, value in FFCX_DEFAULT_PARAMETERS.items():
-        param_name = "FFCX_" + name.upper()
-        param_type = type(value[0])
-
-        if param_name in keys:
-            env_parameters[name] = param_type(os.environ[param_name])
-            logger.info("Parameter {} forced to {} from environmental variable.".format(name, env_parameters[name]))
-
     parameters.update(user_parameters)
     parameters.update(pwd_parameters)
-    parameters.update(env_parameters)
 
-    logging.debug("Final parameter settings")
-    logging.debug(parameters)
+    logging.info("Final parameter settings")
+    logging.info(parameters)
 
     return parameters

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -38,8 +38,7 @@ def get_parameters():
     """Return (a copy of) the parameter values for FFCX.
 
     Priority order is:
-      environment variables (to discuss)
-      ~/.config/ffcx/paramters.json (user parameters)
+      ~/.config/ffcx/.ffcx_paramters.json (user parameters)
       $(pwd)/.ffcx_parameters.json (local parameters)
       FFCX_DEFAULT_PARAMETERS
     """

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -65,7 +65,7 @@ def get_parameters():
     parameters.update(user_parameters)
     parameters.update(pwd_parameters)
 
-    logging.info("Final parameter settings")
-    logging.info(parameters)
+    logger.info("Final parameter settings")
+    logger.info(parameters)
 
     return parameters

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -41,7 +41,7 @@ def get_parameters(priority_parameters: Optional[dict] = None) -> dict:
 
     Parameters
     ----------
-      priority_parameters: 
+      priority_parameters:
         take priority over all other parameter values (see notes)
 
     Returns

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -53,17 +53,17 @@ def get_parameters():
     for param, (value, desc) in FFCX_DEFAULT_PARAMETERS.items():
         parameters[param] = value
 
-    USER_CONFIG_FILE = os.path.join(pathlib.Path.home(), ".config", "ffcx", "parameters.json")
-    PWD_CONFIG_FILE = os.path.join(os.getcwd(), ".ffcx_parameters.json")
+    user_config_file = os.path.join(pathlib.Path.home(), ".config", "ffcx", "parameters.json")
+    pwd_config_file = os.path.join(os.getcwd(), ".ffcx_parameters.json")
 
     try:
-        with open(USER_CONFIG_FILE) as f:
+        with open(user_config_file) as f:
             user_parameters = json.load(f)
     except FileNotFoundError:
         user_parameters = {}
 
     try:
-        with open(PWD_CONFIG_FILE) as f:
+        with open(pwd_config_file) as f:
             pwd_parameters = json.load(f)
     except FileNotFoundError:
         pwd_parameters = {}

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -77,7 +77,7 @@ def get_parameters(priority_parameters: Optional[dict] = None) -> dict:
     The ffcx_parameters.json files are cached on the first call. Subsequent
     calls to this function use this cache.
 
-    Priority ordering of parameters is:
+    Priority ordering of parameters from highest to lowest is:
       priority_parameters (API and command line parameters)
       $(pwd)/ffcx_parameters.json (local parameters)
       ~/.config/ffcx/ffcx_paramters.json (user parameters)

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -41,7 +41,6 @@ FFCX_DEFAULT_PARAMETERS = {
 def _load_parameters():
     """Loads parameters from JSON files"""
     user_config_file = os.path.join(pathlib.Path.home(), ".config", "ffcx", "ffcx_parameters.json")
-
     try:
         with open(user_config_file) as f:
             user_parameters = json.load(f)

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+import os
 import os.path
 import pathlib
 
@@ -35,7 +36,9 @@ FFCX_DEFAULT_PARAMETERS = {
                This value must be compatible with alignment of data structures allocated outside FFC.
                (-1 means no alignment assumed, safe option)"""),
     "padlen":
-        (1, "Pads every declared array in tabulation kernel such that its last dimension is divisible by given value.")
+        (1, "Pads every declared array in tabulation kernel such that its last dimension is divisible by given value."),
+    "verbosity":
+        (30, "Logger verbosity. Follows standard logging library levels, i.e. INFO=20, DEBUG=10, etc.")
 }
 
 
@@ -68,8 +71,20 @@ def get_parameters():
     except FileNotFoundError:
         pwd_parameters = {}
 
+
+    keys = os.environ.keys()
+    env_parameters = {}
+    for name, value in FFCX_DEFAULT_PARAMETERS.items():
+        param_name = "FFCX_" + name.upper()
+        param_type = type(value[0])
+
+        if param_name in keys:
+            env_paramaters[name] = param_type(os.environ[param_name])
+            logger.info("Parameter {} forced to {} from environmental variable.".format(name, params[name]))
+
     parameters.update(user_parameters)
     parameters.update(pwd_parameters)
+    parameters.update(env_parameters)
 
     logging.debug("Final parameter settings")
     logging.debug(parameters)

--- a/ffcx/parameters.py
+++ b/ffcx/parameters.py
@@ -87,7 +87,8 @@ def get_parameters(priority_parameters: Optional[dict] = None) -> dict:
 
     parameters.update(user_parameters)
     parameters.update(pwd_parameters)
-    parameters.update(priority_parameters)
+    if priority_parameters is not None:
+        parameters.update(priority_parameters)
 
     logger.setLevel(parameters["verbosity"])
 

--- a/test/test_cmdline.py
+++ b/test/test_cmdline.py
@@ -11,7 +11,6 @@ import subprocess
 
 def test_cmdline_simple():
     os.chdir(os.path.dirname(__file__))
-    subprocess.run(["ffcx", "-v", "Poisson.ufl"])
     subprocess.run(["ffcx", "Poisson.ufl"])
 
 


### PR DESCRIPTION
This PR greatly simplifies parameter handling in FFCX. It supersedes PR #285.

* passed parameters (command line, API) *always* take precedent over parameters set elsewhere.
* `quadrature_rule`, `quadrature_degree` and `precision` are no longer FFCX compiler parameters. they are exclusively set by the integral metadata (or otherwise set to internal defaults/calculated).
* setting log level is no longer responsibility of the caller, but is handled inside get_parameters immediately after final parameters are determined.
* final parameters are outputted at info log level.
* possibility to set 'global' parameters in a file `ffcx_parameters.json` in present working directory or `~/.config/ffcx`.
* the environment variable settings was removed.

This system can be added to DOLFINX for consistency once this PR is merged.