### PR TITLE
Revert changes that have broken mixed spaces

### DIFF
--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -257,13 +257,7 @@ def get_ffcx_table_values(points, cell, integral_type, ufl_element, avg, entityt
             padded_shape = (basix_element.dim,) + basix_element.value_shape + (len(entity_points), )
             padded_tbl = numpy.zeros(padded_shape, dtype=tbl.dtype)
 
-            if basix_element.family_name == "mixed element":
-                tab = numpy.zeros_like(tbl.reshape(slice_size(ir), slice_size(cr), -1))
-                for basis_i in range(tab.shape[0]):
-                    for value_i in range(tab.shape[1]):
-                        tab[basis_i, value_i] = tbl[value_i * tab.shape[0] + basis_i]
-            else:
-                tab = tbl.reshape(slice_size(ir), slice_size(cr), -1)
+            tab = tbl.reshape(slice_size(ir), slice_size(cr), -1)
 
             padded_tbl[slice(*ir), slice(*cr)] = tab
 


### PR DESCRIPTION
This change seems to have caused dolfinx tests to fail.

Currently looking into what should be done instead, but this should be merged for now to fix dolfin