### PR TITLE
Remove malloc

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: michal/ffcx-remove-malloc
       - name: Clone and install DOLFINx
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -1341,7 +1341,7 @@ class ArrayDecl(CStatement):
                 formatter = format_int
             elif self.values.dtype == numpy.bool_:
                 def format_bool(x, precision=None):
-                    return "true" if x == True else "false"
+                    return "true" if x is True else "false"
                 formatter = format_bool
             else:
                 formatter = format_value

--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -1312,7 +1312,7 @@ class ArrayDecl(CStatement):
 
     def cs_format(self, precision=None):
         if not all(self.sizes):
-            raise RuntimeError("Detected an array dimension of zero. This is not valid in C.")
+            raise RuntimeError(f"Detected an array {self.symbol} dimension of zero. This is not valid in C.")
 
         # Pad innermost array dimension
         sizes = pad_innermost_dim(self.sizes, self.padlen)
@@ -1339,6 +1339,10 @@ class ArrayDecl(CStatement):
                 formatter = format_float
             elif self.values.dtype.kind == "i":
                 formatter = format_int
+            elif self.values.dtype == numpy.bool_:
+                def format_bool(x, precision=None):
+                    return "true" if x == True else "false"
+                formatter = format_bool
             else:
                 formatter = format_value
             initializer_lists = build_initializer_lists(

--- a/ffcx/codegeneration/coordinate_mapping.py
+++ b/ffcx/codegeneration/coordinate_mapping.py
@@ -7,6 +7,7 @@
 import logging
 
 import ffcx.codegeneration.coordinate_mapping_template as ufc_coordinate_mapping
+import ffcx.codegeneration.C.cnodes as L
 
 logger = logging.getLogger("ffcx")
 

--- a/ffcx/codegeneration/coordinate_mapping.py
+++ b/ffcx/codegeneration/coordinate_mapping.py
@@ -21,7 +21,7 @@ def generator(ir, parameters):
     logger.info(f"--- gdim: {ir.geometric_dimension}")
     logger.info(f"--- tdim: {ir.topological_dimension}")
     logger.info(f"--- name: {ir.name}")
-    logger.info(f"--- scalar dofmap name: {ir.scalar_dofmap_name}")
+    logger.info(f"--- scalar dofmap name: {ir.scalar_dofmap}")
 
     d = {}
 
@@ -33,7 +33,7 @@ def generator(ir, parameters):
     d["topological_dimension"] = ir.topological_dimension
     d["is_affine"] = 1 if ir.is_affine else 0
     d["cell_shape"] = ir.cell_shape
-    d["scalar_dofmap_name"] = ir.scalar_dofmap_name
+    d["scalar_dofmap"] = L.AddressOf(L.Symbol(ir.scalar_dofmap))
 
     d["needs_transformation_data"] = ir.needs_transformation_data
 

--- a/ffcx/codegeneration/coordinate_mapping_template.py
+++ b/ffcx/codegeneration/coordinate_mapping_template.py
@@ -4,18 +4,12 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2018
 
 declaration = """
-ufc_coordinate_mapping* create_{factory_name}(void);
+extern ufc_coordinate_mapping {factory_name};
 
 // Helper used to create coordinate map using name given to the
 // UFL file.
-// This helper is called in user c++ code.
-//
-ufc_coordinate_mapping* create_coordinate_map_{prefix}(void);
+extern ufc_coordinate_mapping* coordinate_mapping_{prefix};
 """
-
-# declaration = """
-# ufc_coordinate_mapping* create_{factory_name}(void);
-# """
 
 factory = """
 // Code for coordinate mapping {factory_name}
@@ -30,28 +24,22 @@ int unpermute_dofs_{factory_name}(int* dof_list, const uint32_t cell_permutation
   {unpermute_dofs}
 }}
 
-ufc_coordinate_mapping* create_{factory_name}(void)
+ufc_coordinate_mapping {factory_name} =
 {{
-  ufc_coordinate_mapping* cmap = (ufc_coordinate_mapping*)malloc(sizeof(*cmap));
-  cmap->signature = {signature};
-  cmap->element_family = {family};
-  cmap->element_degree = {degree};
-  cmap->create = create_{factory_name};
-  cmap->geometric_dimension = {geometric_dimension};
-  cmap->topological_dimension = {topological_dimension};
-  cmap->is_affine = {is_affine};
-  cmap->needs_transformation_data = {needs_transformation_data};
-  cmap->permute_dofs = permute_dofs_{factory_name};
-  cmap->unpermute_dofs = unpermute_dofs_{factory_name};
-  cmap->cell_shape = {cell_shape};
-  cmap->create_scalar_dofmap = create_{scalar_dofmap_name};
-  return cmap;
-}}
+  .signature = {signature},
+  .element_family = {family},
+  .element_degree = {degree},
+  .geometric_dimension = {geometric_dimension},
+  .topological_dimension = {topological_dimension},
+  .is_affine = {is_affine},
+  .needs_transformation_data = {needs_transformation_data},
+  .permute_dofs = permute_dofs_{factory_name},
+  .unpermute_dofs = unpermute_dofs_{factory_name},
+  .cell_shape = {cell_shape},
+  .scalar_dofmap = {scalar_dofmap}
+}};
 
-ufc_coordinate_mapping* create_coordinate_map_{prefix}(void)
-{{
-  return create_{factory_name}();
-}}
+ufc_coordinate_mapping* coordinate_mapping_{prefix} = &{factory_name};
 
 // End of code for coordinate mapping {factory_name}
 """

--- a/ffcx/codegeneration/coordinate_mapping_template.py
+++ b/ffcx/codegeneration/coordinate_mapping_template.py
@@ -14,16 +14,6 @@ extern ufc_coordinate_mapping* coordinate_mapping_{prefix};
 factory = """
 // Code for coordinate mapping {factory_name}
 
-int permute_dofs_{factory_name}(int* dof_list, const uint32_t cell_permutation)
-{{
-  {permute_dofs}
-}}
-
-int unpermute_dofs_{factory_name}(int* dof_list, const uint32_t cell_permutation)
-{{
-  {unpermute_dofs}
-}}
-
 ufc_coordinate_mapping {factory_name} =
 {{
   .signature = {signature},

--- a/ffcx/codegeneration/dofmap.py
+++ b/ffcx/codegeneration/dofmap.py
@@ -9,7 +9,6 @@
 
 import logging
 import ffcx.codegeneration.dofmap_template as ufc_dofmap
-from ffcx.codegeneration.utils import generate_return_new_switch
 
 logger = logging.getLogger("ffcx")
 
@@ -54,19 +53,6 @@ def tabulate_entity_dofs(L, ir):
         return L.NoOp()
 
 
-def create_sub_dofmap(L, ir):
-    classnames = ir.create_sub_dofmap
-    return generate_return_new_switch(L, "i", classnames)
-
-
-def sub_dofmap_declaration(L, ir):
-    classnames = set(ir.create_sub_dofmap)
-    code = ""
-    for name in classnames:
-        code += f"ufc_dofmap* create_{name}(void);\n"
-    return code
-
-
 def generator(ir, parameters):
     """Generate UFC code for a dofmap."""
 
@@ -89,8 +75,14 @@ def generator(ir, parameters):
 
     # Functions
     d["tabulate_entity_dofs"] = tabulate_entity_dofs(L, ir)
-    d["sub_dofmap_declaration"] = sub_dofmap_declaration(L, ir)
-    d["create_sub_dofmap"] = create_sub_dofmap(L, ir)
+
+    if len(ir.sub_dofmaps) > 0:
+        d["sub_dofmaps_initialization"] = L.ArrayDecl(
+            "ufc_dofmap*", f"sub_dofmaps_{ir.name}", values=[L.AddressOf(L.Symbol(dofmap)) for dofmap in ir.sub_dofmaps], sizes=len(ir.sub_dofmaps))
+        d["sub_dofmaps"] = f"sub_dofmaps_{ir.name}"
+    else:
+        d["sub_dofmaps_initialization"] = ""
+        d["sub_dofmaps"] = "NULL"
 
     # Check that no keys are redundant or have been missed
     from string import Formatter

--- a/ffcx/codegeneration/dofmap.py
+++ b/ffcx/codegeneration/dofmap.py
@@ -78,7 +78,8 @@ def generator(ir, parameters):
 
     if len(ir.sub_dofmaps) > 0:
         d["sub_dofmaps_initialization"] = L.ArrayDecl(
-            "ufc_dofmap*", f"sub_dofmaps_{ir.name}", values=[L.AddressOf(L.Symbol(dofmap)) for dofmap in ir.sub_dofmaps], sizes=len(ir.sub_dofmaps))
+            "ufc_dofmap*", f"sub_dofmaps_{ir.name}",
+            values=[L.AddressOf(L.Symbol(dofmap)) for dofmap in ir.sub_dofmaps], sizes=len(ir.sub_dofmaps))
         d["sub_dofmaps"] = f"sub_dofmaps_{ir.name}"
     else:
         d["sub_dofmaps_initialization"] = ""

--- a/ffcx/codegeneration/dofmap_template.py
+++ b/ffcx/codegeneration/dofmap_template.py
@@ -4,41 +4,33 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2018.
 
 declaration = """
-ufc_dofmap* create_{factory_name}(void);
+extern ufc_dofmap {factory_name};
 """
 
 factory = """
 // Code for dofmap {factory_name}
+
+{sub_dofmaps_initialization}
 
 void tabulate_entity_dofs_{factory_name}(int* restrict dofs, int d, int i)
 {{
 {tabulate_entity_dofs}
 }}
 
-{sub_dofmap_declaration}
-ufc_dofmap* create_sub_dofmap_{factory_name}(int i)
+ufc_dofmap {factory_name} =
 {{
-{create_sub_dofmap}
-}}
-
-ufc_dofmap* create_{factory_name}(void)
-{{
-  ufc_dofmap* dofmap = (ufc_dofmap*)malloc(sizeof(*dofmap));
-  dofmap->signature = {signature};
-  dofmap->block_size = {block_size};
-  dofmap->num_global_support_dofs = {num_global_support_dofs};
-  dofmap->num_element_support_dofs = {num_element_support_dofs};
-  dofmap->num_entity_dofs[0] = {num_entity_dofs[0]};
-  dofmap->num_entity_dofs[1] = {num_entity_dofs[1]};
-  dofmap->num_entity_dofs[2] = {num_entity_dofs[2]};
-  dofmap->num_entity_dofs[3] = {num_entity_dofs[3]};
-  dofmap->tabulate_entity_dofs = tabulate_entity_dofs_{factory_name};
-  dofmap->num_sub_dofmaps = {num_sub_dofmaps};
-  dofmap->create_sub_dofmap = create_sub_dofmap_{factory_name};
-  dofmap->create = create_{factory_name};
-
-  return dofmap;
-}}
+  .signature = {signature},
+  .block_size = {block_size},
+  .num_global_support_dofs = {num_global_support_dofs},
+  .num_element_support_dofs = {num_element_support_dofs},
+  .num_entity_dofs[0] = {num_entity_dofs[0]},
+  .num_entity_dofs[1] = {num_entity_dofs[1]},
+  .num_entity_dofs[2] = {num_entity_dofs[2]},
+  .num_entity_dofs[3] = {num_entity_dofs[3]},
+  .tabulate_entity_dofs = tabulate_entity_dofs_{factory_name},
+  .num_sub_dofmaps = {num_sub_dofmaps},
+  .sub_dofmaps = {sub_dofmaps}
+}};
 
 // End of code for dofmap {factory_name}
 """

--- a/ffcx/codegeneration/expressions_template.py
+++ b/ffcx/codegeneration/expressions_template.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 declaration = """
-ufc_expression* create_expression_{factory_name}(void);
+extern ufc_expression {factory_name};
 """
 
 factory = """
@@ -19,25 +19,21 @@ void tabulate_expression_{factory_name}(ufc_scalar_t* restrict A,
 {tabulate_expression}
 }}
 
-ufc_expression* create_{factory_name}(void)
+{points_init}
+{value_shape_init}
+{original_coefficient_positions_init}
+
+ufc_expression {factory_name} =
 {{
-
-  ufc_expression* expression = (ufc_expression*)malloc(sizeof(*expression));
-
-  {original_coefficient_positions}
-  {points}
-  {value_shape}
-
-  expression->tabulate_expression = tabulate_expression_{factory_name};
-  expression->num_coefficients = {num_coefficients};
-  expression->num_points = {num_points};
-  expression->topological_dimension = {topological_dimension};
-  expression->points = *points;
-  expression->value_shape = value_shape;
-  expression->num_components = {num_components};
-
-  return expression;
-}}
+  .tabulate_expression = tabulate_expression_{factory_name},
+  .num_coefficients = {num_coefficients},
+  .num_points = {num_points},
+  .topological_dimension = {topological_dimension},
+  .points = {points},
+  .value_shape = {value_shape},
+  .num_components = {num_components},
+  .original_coefficient_positions = {original_coefficient_positions}
+}};
 
 // End of code for expression {factory_name}
 """

--- a/ffcx/codegeneration/finite_element.py
+++ b/ffcx/codegeneration/finite_element.py
@@ -13,9 +13,7 @@ import logging
 import numpy
 import ffcx.codegeneration.finite_element_template as ufc_finite_element
 import ufl
-from ffcx.codegeneration.utils import (generate_return_int_switch,
-                                       generate_return_new_switch,
-                                       apply_transformations_to_data)
+from ffcx.codegeneration.utils import (apply_transformations_to_data)
 
 logger = logging.getLogger("ffcx")
 index_type = "int"
@@ -49,25 +47,8 @@ def _generate_combinations(L, tdim, max_degree, order, num_derivatives, suffix="
     return code, combinations
 
 
-def value_dimension(L, value_shape):
-    return generate_return_int_switch(L, "i", value_shape, 1)
-
-
 def reference_value_dimension(L, reference_value_shape):
     return generate_return_int_switch(L, "i", reference_value_shape, 1)
-
-
-def sub_element_declaration(L, ir):
-    classnames = set(ir.create_sub_element)
-    code = ""
-    for name in classnames:
-        code += f"ufc_finite_element* create_{name}(void);\n"
-    return code
-
-
-def create_sub_element(L, ir):
-    classnames = ir.create_sub_element
-    return generate_return_new_switch(L, "i", classnames)
 
 
 def apply_dof_transformation(L, ir, parameters, inverse=False, transpose=False, dtype="double"):
@@ -112,8 +93,21 @@ def generator(ir, parameters):
 
     import ffcx.codegeneration.C.cnodes as L
 
-    d["value_dimension"] = value_dimension(L, ir.value_shape)
-    d["reference_value_dimension"] = reference_value_dimension(L, ir.reference_value_shape)
+    if len(ir.value_shape) > 0:
+        d["value_shape"] = f"value_shape_{ir.name}"
+        d["value_shape_init"] = L.ArrayDecl(
+            "int", f"value_shape_{ir.name}", values=ir.value_shape, sizes=len(ir.value_shape))
+    else:
+        d["value_shape"] = "NULL"
+        d["value_shape_init"] = ""
+
+    if len(ir.value_shape) > 0:
+        d["reference_value_shape"] = f"reference_value_shape_{ir.name}"
+        d["reference_value_shape_init"] = L.ArrayDecl(
+            "int", f"reference_value_shape_{ir.name}", values=ir.reference_value_shape, sizes=len(ir.reference_value_shape))
+    else:
+        d["reference_value_shape"] = "NULL"
+        d["reference_value_shape_init"] = ""
 
     d["apply_dof_transformation"] = L.StatementList(
         apply_dof_transformation(L, ir, parameters))
@@ -124,9 +118,13 @@ def generator(ir, parameters):
     d["apply_inverse_transpose_dof_transformation_to_scalar"] = L.StatementList(
         apply_dof_transformation(L, ir, parameters, dtype="ufc_scalar_t", inverse=True, transpose=True))
 
-    statements = create_sub_element(L, ir)
-    d["sub_element_declaration"] = sub_element_declaration(L, ir)
-    d["create_sub_element"] = statements
+    if len(ir.sub_elements) > 0:
+        d["sub_elements"] = f"sub_elements_{ir.name}"
+        d["sub_elements_init"] = L.ArrayDecl(
+            "ufc_finite_element*", f"sub_elements_{ir.name}", values=[L.AddressOf(L.Symbol(el)) for el in ir.sub_elements], sizes=len(ir.sub_elements))
+    else:
+        d["sub_elements"] = "NULL"
+        d["sub_elements_init"] = ""
 
     # Check that no keys are redundant or have been missed
     from string import Formatter

--- a/ffcx/codegeneration/finite_element.py
+++ b/ffcx/codegeneration/finite_element.py
@@ -47,10 +47,6 @@ def _generate_combinations(L, tdim, max_degree, order, num_derivatives, suffix="
     return code, combinations
 
 
-def reference_value_dimension(L, reference_value_shape):
-    return generate_return_int_switch(L, "i", reference_value_shape, 1)
-
-
 def apply_dof_transformation(L, ir, parameters, inverse=False, transpose=False, dtype="double"):
     """Write function that applies the DOF transformations to some data."""
     data = L.Symbol("data")
@@ -104,7 +100,8 @@ def generator(ir, parameters):
     if len(ir.value_shape) > 0:
         d["reference_value_shape"] = f"reference_value_shape_{ir.name}"
         d["reference_value_shape_init"] = L.ArrayDecl(
-            "int", f"reference_value_shape_{ir.name}", values=ir.reference_value_shape, sizes=len(ir.reference_value_shape))
+            "int", f"reference_value_shape_{ir.name}",
+            values=ir.reference_value_shape, sizes=len(ir.reference_value_shape))
     else:
         d["reference_value_shape"] = "NULL"
         d["reference_value_shape_init"] = ""
@@ -121,7 +118,8 @@ def generator(ir, parameters):
     if len(ir.sub_elements) > 0:
         d["sub_elements"] = f"sub_elements_{ir.name}"
         d["sub_elements_init"] = L.ArrayDecl(
-            "ufc_finite_element*", f"sub_elements_{ir.name}", values=[L.AddressOf(L.Symbol(el)) for el in ir.sub_elements], sizes=len(ir.sub_elements))
+            "ufc_finite_element*", f"sub_elements_{ir.name}",
+            values=[L.AddressOf(L.Symbol(el)) for el in ir.sub_elements], sizes=len(ir.sub_elements))
     else:
         d["sub_elements"] = "NULL"
         d["sub_elements_init"] = ""

--- a/ffcx/codegeneration/finite_element_template.py
+++ b/ffcx/codegeneration/finite_element_template.py
@@ -4,21 +4,15 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2018.
 
 declaration = """
-ufc_finite_element* create_{factory_name}(void);
+extern ufc_finite_element {factory_name};
 """
 
 factory = """
 // Code for element {factory_name}
 
-int value_dimension_{factory_name}(int i)
-{{
-  {value_dimension}
-}}
-
-int reference_value_dimension_{factory_name}(int i)
-{{
-  {reference_value_dimension}
-}}
+{value_shape_init}
+{reference_value_shape_init}
+{sub_elements_init}
 
 int apply_dof_transformation_{factory_name}(
      double* restrict data, uint32_t cell_permutation, int dim)
@@ -44,46 +38,35 @@ int apply_inverse_transpose_dof_transformation_to_scalar_{factory_name}(
   {apply_inverse_transpose_dof_transformation_to_scalar}
 }}
 
-{sub_element_declaration}
-ufc_finite_element* create_sub_element_{factory_name}(int i)
+ufc_finite_element {factory_name} = 
 {{
-  {create_sub_element}
-}}
+  .signature = {signature},
+  .cell_shape = {cell_shape},
+  .topological_dimension = {topological_dimension},
+  .geometric_dimension = {geometric_dimension},
+  .space_dimension = {space_dimension},
+  .value_rank = {value_rank},
+  .value_shape = {value_shape},
+  .value_size = {value_size},
+  .reference_value_rank = {reference_value_rank},
+  .reference_value_shape = {reference_value_shape},
+  .reference_value_size = {reference_value_size},
+  .degree = {degree},
+  .family = {family},
+  .block_size = {block_size},
 
-ufc_finite_element* create_{factory_name}(void)
-{{
-  ufc_finite_element* element = (ufc_finite_element*)malloc(sizeof(*element));
+  .needs_transformation_data = {needs_transformation_data},
+  .interpolation_is_identity = {interpolation_is_identity},
 
-  element->signature = {signature};
-  element->cell_shape = {cell_shape};
-  element->topological_dimension = {topological_dimension};
-  element->geometric_dimension = {geometric_dimension};
-  element->space_dimension = {space_dimension};
-  element->value_rank = {value_rank};
-  element->value_dimension = value_dimension_{factory_name};
-  element->value_size = {value_size};
-  element->reference_value_rank = {reference_value_rank};
-  element->reference_value_dimension = reference_value_dimension_{factory_name};
-  element->reference_value_size = {reference_value_size};
-  element->degree = {degree};
-  element->family = {family};
-  element->block_size = {block_size};
-
-  element->needs_transformation_data = {needs_transformation_data};
-  element->interpolation_is_identity = {interpolation_is_identity};
-
-  element->apply_dof_transformation = apply_dof_transformation_{factory_name};
-  element->apply_dof_transformation_to_scalar = apply_dof_transformation_to_scalar_{factory_name};
-  element->apply_inverse_transpose_dof_transformation
-      = apply_inverse_transpose_dof_transformation_{factory_name};
-  element->apply_inverse_transpose_dof_transformation_to_scalar
-      = apply_inverse_transpose_dof_transformation_to_scalar_{factory_name};
-  element->num_sub_elements = {num_sub_elements};
-  element->create_sub_element = create_sub_element_{factory_name};
-  element->create = create_{factory_name};
-
-  return element;
-}}
+  .apply_dof_transformation = apply_dof_transformation_{factory_name},
+  .apply_dof_transformation_to_scalar = apply_dof_transformation_to_scalar_{factory_name},
+  .apply_inverse_transpose_dof_transformation
+      = apply_inverse_transpose_dof_transformation_{factory_name},
+  .apply_inverse_transpose_dof_transformation_to_scalar
+      = apply_inverse_transpose_dof_transformation_to_scalar_{factory_name},
+  .num_sub_elements = {num_sub_elements},
+  .sub_elements = {sub_elements}
+}};
 
 // End of code for element {factory_name}
 """

--- a/ffcx/codegeneration/finite_element_template.py
+++ b/ffcx/codegeneration/finite_element_template.py
@@ -38,7 +38,7 @@ int apply_inverse_transpose_dof_transformation_to_scalar_{factory_name}(
   {apply_inverse_transpose_dof_transformation_to_scalar}
 }}
 
-ufc_finite_element {factory_name} = 
+ufc_finite_element {factory_name} =
 {{
   .signature = {signature},
   .cell_shape = {cell_shape},

--- a/ffcx/codegeneration/form.py
+++ b/ffcx/codegeneration/form.py
@@ -112,7 +112,6 @@ def generator(ir, parameters):
 
     # FIXME: Should be handled differently, revise how ufc_function_space is
     # generated
-    i = 0
     for (name, (element, dofmap, cmap)) in ir.function_spaces.items():
         code += [f"static ufc_function_space functionspace_{name} ="]
         code += ["{"]
@@ -121,14 +120,12 @@ def generator(ir, parameters):
         code += [f".coordinate_mapping = &{cmap}"]
         code += ["};"]
 
-    for (name, (element, dofmap, cmap)) in ir.function_spaces.items():
+    for i, (name, (element, dofmap, cmap)) in enumerate(ir.function_spaces.items()):
         condition = L.EQ(L.Call("strcmp", (function_name, L.LiteralString(name))), 0)
         if i == 0:
             code += [L.If(condition, L.Return(L.Symbol(f"&functionspace_{name}")))]
         else:
             code += [L.ElseIf(condition, L.Return(L.Symbol(f"&functionspace_{name}")))]
-
-        i += 1
 
     code += ["return NULL;\n"]
 

--- a/ffcx/codegeneration/form.py
+++ b/ffcx/codegeneration/form.py
@@ -8,181 +8,9 @@
 # old implementation in FFC
 import logging
 
-from ffcx.codegeneration import form_template as ufc_form
-from ffcx.codegeneration.utils import (generate_return_new,
-                                       generate_return_new_switch)
-from ffcx.ir.representation import ufc_integral_types
-
-# These are the method names in ufc_form that are specialized for each
-# integral type
-integral_name_templates = ("get_{}_integral_ids", "create_{}_integral")
+from ffcx.codegeneration import form_template
 
 logger = logging.getLogger("ffcx")
-
-
-def create_delegate(integral_type, declname, impl):
-    def _delegate(self, L, ir, parameters):
-        return impl(self, L, ir, parameters, integral_type, declname)
-
-    _delegate.__doc__ = impl.__doc__ % {"declname": declname, "integral_type": integral_type}
-    return _delegate
-
-
-def add_ufc_form_integral_methods(cls):
-    """Generate methods on the class decorated by this function.
-    One for each integral name template and for each integral type.
-
-    This allows implementing e.g. create_###_integrals once in the
-    decorated class as '_create_foo_integrals', and this function will
-    expand that implementation into 'create_cell_integrals',
-    'create_exterior_facet_integrals', etc.
-
-    Name templates are taken from 'integral_name_templates' and
-    'ufc_integral_types'.
-
-    """
-    # The dummy name "foo" is chosen for familiarity for ffcx developers
-    dummy_integral_type = "foo"
-
-    for template in integral_name_templates:
-        implname = "_" + (template.format(dummy_integral_type))
-        impl = getattr(cls, implname)
-        for integral_type in ufc_integral_types:
-            declname = template.format(integral_type)
-            _delegate = create_delegate(integral_type, declname, impl)
-            setattr(cls, declname, _delegate)
-    return cls
-
-
-@add_ufc_form_integral_methods
-class UFCForm:
-    """Each function maps to a keyword in the template.
-
-    The exceptions are functions on the form
-
-        def _*_foo_*(self, L, ir, parameters, integral_type, declname)
-
-    which add_ufc_form_integral_methods will duplicate for foo = each integral type.
-    """
-
-    def original_coefficient_position(self, L, ir):
-        i = L.Symbol("i")
-        positions = ir.original_coefficient_position
-
-        # Check argument
-        msg = "Invalid original coefficient index."
-        if positions:
-            code = [L.If(L.GE(i, len(positions)), [L.Comment(msg), L.Return(-1)])]
-            position = L.Symbol("position")
-            code += [
-                L.ArrayDecl("static const int", position, len(positions), positions),
-                L.Return(position[i]),
-            ]
-            return code
-        else:
-            code = [L.Comment(msg), L.Return(-1)]
-        return code
-
-    def generate_coefficient_position_to_name_map(self, L, ir):
-        """Generate code that maps name to number."""
-        cnames = ir.coefficient_names
-        assert ir.num_coefficients == len(cnames)
-        names = L.Symbol("names")
-        if (len(cnames) == 0):
-            code = [L.Return(L.Null())]
-        else:
-            code = [L.ArrayDecl("static const char*", names, len(cnames), cnames)]
-            code += [L.Return(names)]
-        return L.StatementList(code)
-
-    def generate_constant_original_position_to_name_map(self, L, ir):
-        """Generate code that maps original position of a constant to its name."""
-        cnames = ir.constant_names
-        names = L.Symbol("names")
-        if (len(cnames) == 0):
-            code = [L.Return(L.Null())]
-        else:
-            code = [L.ArrayDecl("static const char*", names, len(cnames), cnames)]
-            code += [L.Return(names)]
-        return L.StatementList(code)
-
-    def create_coordinate_mapping(self, L, ir):
-        classnames = ir.create_coordinate_mapping
-        # list of length 1 until we support multiple domains
-        assert len(classnames) == 1
-        return generate_return_new(L, classnames[0])
-
-    def coordinate_mapping_declaration(self, L, ir):
-        classname = ir.create_coordinate_mapping
-        code = f"ufc_coordinate_mapping* create_{classname[0]}(void);\n"
-        return code
-
-    def create_finite_element(self, L, ir):
-        i = L.Symbol("i")
-        classnames = ir.create_finite_element
-        return generate_return_new_switch(L, i, classnames)
-
-    def finite_element_declaration(self, L, ir):
-        classnames = set(ir.create_finite_element)
-        code = ""
-        for name in classnames:
-            code += f"ufc_finite_element* create_{name}(void);\n"
-        return code
-
-    def create_dofmap(self, L, ir):
-        i = L.Symbol("i")
-        classnames = ir.create_dofmap
-        return generate_return_new_switch(L, i, classnames)
-
-    def dofmap_declaration(self, L, ir):
-        classnames = set(ir.create_dofmap)
-        code = ""
-        for name in classnames:
-            code += f"ufc_dofmap* create_{name}(void);\n"
-        return code
-
-    def create_functionspace(self, L, ir):
-        code = []
-        function_name = L.Symbol("function_name")
-
-        i = 0
-        for (name, (element, dofmap, cmap)) in ir.function_spaces.items():
-            body = "ufc_function_space* space = (ufc_function_space*)malloc(sizeof(*space));\n"
-            body += f"space->create_element = create_{element};\n"
-            body += f"space->create_dofmap = create_{dofmap};\n"
-            body += f"space->create_coordinate_mapping = create_{cmap};\n"
-            body += "return space;"
-
-            condition = L.EQ(L.Call("strcmp", (function_name, L.LiteralString(name))), 0)
-            if i == 0:
-                code += [L.If(condition, body)]
-            else:
-                code += [L.ElseIf(condition, body)]
-
-            i += 1
-
-        code += ["return NULL;\n"]
-
-        return L.StatementList(code)
-
-    # This group of functions are repeated for each foo_integral by
-    # add_ufc_form_integral_methods:
-
-    def _get_foo_integral_ids(self, L, ir, parameters, integral_type, declname):
-        """Return implementation of ufc::form::%(declname)s()."""
-        code = []
-        ids = L.Symbol("ids")
-        for i, v in enumerate(getattr(ir, declname)[0]):
-            code += [L.Assign(ids[i], v)]
-        code += [L.Return()]
-        return L.StatementList(code)
-
-    def _create_foo_integral(self, L, ir, parameters, integral_type, declname):
-        """Return implementation of ufc::form::%(declname)s()."""
-        # e.g. subdomain_ids, classnames = ir.create_cell_integral
-        subdomain_ids, classnames = getattr(ir, declname)
-        subdomain_id = L.Symbol("subdomain_id")
-        return generate_return_new_switch(L, subdomain_id, classnames, subdomain_ids)
 
 
 def generator(ir, parameters):
@@ -192,6 +20,8 @@ def generator(ir, parameters):
     logger.info(f"--- rank: {ir.rank}")
     logger.info(f"--- name: {ir.name}")
 
+    import ffcx.codegeneration.C.cnodes as L
+
     d = {}
     d["factory_name"] = ir.name
     d["name_from_uflfile"] = ir.name_from_uflfile
@@ -200,54 +30,118 @@ def generator(ir, parameters):
     d["num_coefficients"] = ir.num_coefficients
     d["num_constants"] = ir.num_constants
 
-    d["num_cell_integrals"] = len(ir.create_cell_integral[0])
-    d["num_exterior_facet_integrals"] = len(ir.create_exterior_facet_integral[0])
-    d["num_interior_facet_integrals"] = len(ir.create_interior_facet_integral[0])
-    d["num_vertex_integrals"] = len(ir.create_vertex_integral[0])
-    d["num_custom_integrals"] = len(ir.create_custom_integral[0])
+    code = []
+    cases = []
+    for itg_type in ("cell", "interior_facet", "exterior_facet"):
+        cases += [(L.Symbol(itg_type), L.Return(len(ir.subdomain_ids[itg_type])))]
+    code += [L.Switch("integral_type", cases, default=L.Return(0))]
+    d["num_integrals"] = L.StatementList(code)
 
-    import ffcx.codegeneration.C.cnodes as L
-    generator = UFCForm()
+    if len(ir.original_coefficient_position) > 0:
+        d["original_coefficient_position_init"] = L.ArrayDecl(
+            "int", f"original_coefficient_position_{ir.name}",
+            values=ir.original_coefficient_position, sizes=len(ir.original_coefficient_position))
+        d["original_coefficient_position"] = f"original_coefficient_position_{ir.name}"
+    else:
+        d["original_coefficient_position_init"] = ""
+        d["original_coefficient_position"] = L.Null()
 
-    statements = generator.original_coefficient_position(L, ir)
-    d["original_coefficient_position"] = L.StatementList(statements)
+    cnames = ir.coefficient_names
+    assert ir.num_coefficients == len(cnames)
+    names = L.Symbol("names")
+    if (len(cnames) == 0):
+        code = [L.Return(L.Null())]
+    else:
+        code = [L.ArrayDecl("static const char*", names, len(cnames), cnames)]
+        code += [L.Return(names)]
+    d["coefficient_name_map"] = L.StatementList(code)
 
-    d["coefficient_name_map"] = generator.generate_coefficient_position_to_name_map(L, ir)
-    d["constant_name_map"] = generator.generate_constant_original_position_to_name_map(L, ir)
+    cstnames = ir.constant_names
+    names = L.Symbol("names")
+    if len(cstnames) == 0:
+        code = [L.Return(L.Null())]
+    else:
+        code = [L.ArrayDecl("static const char*", names, len(cstnames), cstnames)]
+        code += [L.Return(names)]
+    d["constant_name_map"] = L.StatementList(code)
 
-    d["create_coordinate_mapping"] = generator.create_coordinate_mapping(L, ir)
-    d["coordinate_mapping_declaration"] = generator.coordinate_mapping_declaration(L, ir)
-    d["create_finite_element"] = generator.create_finite_element(L, ir)
-    d["finite_element_declaration"] = generator.finite_element_declaration(L, ir)
-    d["create_dofmap"] = generator.create_dofmap(L, ir)
-    d["dofmap_declaration"] = generator.dofmap_declaration(L, ir)
+    d["coordinate_mapping"] = L.AddressOf(L.Symbol(ir.coordinate_mappings[0]))
 
-    d["create_functionspace"] = generator.create_functionspace(L, ir)
+    if len(ir.finite_elements) > 0:
+        d["finite_elements"] = f"finite_elements_{ir.name}"
+        d["finite_elements_init"] = L.ArrayDecl("ufc_finite_element*", f"finite_elements_{ir.name}", values=[
+                                                L.AddressOf(L.Symbol(el)) for el in ir.finite_elements], sizes=len(ir.finite_elements))
+    else:
+        d["finite_elements"] = L.Null()
+        d["finite_elements_init"] = ""
 
-    d["get_cell_integral_ids"] = generator.get_cell_integral_ids(L, ir, parameters)
-    d["get_exterior_facet_integral_ids"] = generator.get_exterior_facet_integral_ids(L, ir, parameters)
-    d["get_interior_facet_integral_ids"] = generator.get_interior_facet_integral_ids(L, ir, parameters)
-    d["get_vertex_integral_ids"] = generator.get_vertex_integral_ids(L, ir, parameters)
-    d["get_custom_integral_ids"] = generator.get_custom_integral_ids(L, ir, parameters)
+    if len(ir.dofmaps) > 0:
+        d["dofmaps"] = f"dofmaps_{ir.name}"
+        d["dofmaps_init"] = L.ArrayDecl("ufc_dofmap*", f"dofmaps_{ir.name}", values=[
+            L.AddressOf(L.Symbol(dofmap)) for dofmap in ir.dofmaps], sizes=len(ir.dofmaps))
+    else:
+        d["dofmaps"] = L.Null()
+        d["dofmaps_init"] = ""
 
-    d["create_cell_integral"] = generator.create_cell_integral(L, ir, parameters)
-    d["create_interior_facet_integral"] = generator.create_interior_facet_integral(
-        L, ir, parameters)
-    d["create_exterior_facet_integral"] = generator.create_exterior_facet_integral(
-        L, ir, parameters)
-    d["create_vertex_integral"] = generator.create_vertex_integral(L, ir, parameters)
-    d["create_custom_integral"] = generator.create_custom_integral(L, ir, parameters)
+    code = []
+    cases = []
+    code_ids = []
+    cases_ids = []
+    for itg_type in ("cell", "interior_facet", "exterior_facet"):
+        if len(ir.classnames[itg_type]) > 0:
+            code += [L.ArrayDecl(
+                "static ufc_integral*", f"integrals_{itg_type}_{ir.name}",
+                values=[L.AddressOf(L.Symbol(itg)) for itg in ir.classnames[itg_type]], sizes=len(ir.classnames[itg_type]))]
+            cases.append((L.Symbol(itg_type), L.Return(L.Symbol(f"integrals_{itg_type}_{ir.name}"))))
+
+            code_ids += [L.ArrayDecl(
+                "static int", f"integral_ids_{itg_type}_{ir.name}",
+                values=ir.subdomain_ids[itg_type], sizes=len(ir.subdomain_ids[itg_type]))]
+            cases_ids.append((L.Symbol(itg_type), L.Return(L.Symbol(f"integral_ids_{itg_type}_{ir.name}"))))
+
+    code += [L.Switch("integral_type", cases, default=L.Return(L.Null()))]
+    code_ids += [L.Switch("integral_type", cases_ids, default=L.Return(L.Null()))]
+    d["integrals"] = L.StatementList(code)
+
+    d["integral_ids"] = L.StatementList(code_ids)
+
+    code = []
+    function_name = L.Symbol("function_name")
+
+    # FIXME: Should be handled differently, revise how ufc_function_space is
+    # generated
+    i = 0
+    for (name, (element, dofmap, cmap)) in ir.function_spaces.items():
+        code += [f"static ufc_function_space functionspace_{name} ="]
+        code += ["{"]
+        code += [f".finite_element = &{element},"]
+        code += [f".dofmap = &{dofmap},"]
+        code += [f".coordinate_mapping = &{cmap}"]
+        code += ["};"]
+
+    for (name, (element, dofmap, cmap)) in ir.function_spaces.items():
+        condition = L.EQ(L.Call("strcmp", (function_name, L.LiteralString(name))), 0)
+        if i == 0:
+            code += [L.If(condition, L.Return(L.Symbol(f"&functionspace_{name}")))]
+        else:
+            code += [L.ElseIf(condition, L.Return(L.Symbol(f"&functionspace_{name}")))]
+
+        i += 1
+
+    code += ["return NULL;\n"]
+
+    d["functionspace"] = L.StatementList(code)
 
     # Check that no keys are redundant or have been missed
     from string import Formatter
-    fields = [fname for _, fname, _, _ in Formatter().parse(ufc_form.factory) if fname]
+    fields = [fname for _, fname, _, _ in Formatter().parse(form_template.factory) if fname]
     assert set(fields) == set(d.keys()), "Mismatch between keys in template and in formattting dict"
 
     # Format implementation code
-    implementation = ufc_form.factory.format_map(d)
+    implementation = form_template.factory.format_map(d)
 
     # Format declaration
-    declaration = ufc_form.declaration.format(factory_name=d["factory_name"],
-                                              name_from_uflfile=d["name_from_uflfile"])
+    declaration = form_template.declaration.format(factory_name=d["factory_name"],
+                                                   name_from_uflfile=d["name_from_uflfile"])
 
     return declaration, implementation

--- a/ffcx/codegeneration/form.py
+++ b/ffcx/codegeneration/form.py
@@ -70,7 +70,8 @@ def generator(ir, parameters):
     if len(ir.finite_elements) > 0:
         d["finite_elements"] = f"finite_elements_{ir.name}"
         d["finite_elements_init"] = L.ArrayDecl("ufc_finite_element*", f"finite_elements_{ir.name}", values=[
-                                                L.AddressOf(L.Symbol(el)) for el in ir.finite_elements], sizes=len(ir.finite_elements))
+                                                L.AddressOf(L.Symbol(el)) for el in ir.finite_elements],
+                                                sizes=len(ir.finite_elements))
     else:
         d["finite_elements"] = L.Null()
         d["finite_elements_init"] = ""
@@ -91,7 +92,8 @@ def generator(ir, parameters):
         if len(ir.classnames[itg_type]) > 0:
             code += [L.ArrayDecl(
                 "static ufc_integral*", f"integrals_{itg_type}_{ir.name}",
-                values=[L.AddressOf(L.Symbol(itg)) for itg in ir.classnames[itg_type]], sizes=len(ir.classnames[itg_type]))]
+                values=[L.AddressOf(L.Symbol(itg)) for itg in ir.classnames[itg_type]],
+                sizes=len(ir.classnames[itg_type]))]
             cases.append((L.Symbol(itg_type), L.Return(L.Symbol(f"integrals_{itg_type}_{ir.name}"))))
 
             code_ids += [L.ArrayDecl(

--- a/ffcx/codegeneration/form_template.py
+++ b/ffcx/codegeneration/form_template.py
@@ -4,31 +4,26 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2020.
 
 declaration = """
-ufc_form* create_{factory_name}(void);
+extern ufc_form {factory_name};
 
 // Helper used to create form using name which was given to the
 // form in the UFL file.
 // This helper is called in user c++ code.
 //
-ufc_form* create_{name_from_uflfile}(void);
+extern ufc_form* {name_from_uflfile};
 
-// Helper used to create function space using its name, as given in
-// the UFL file.
-// Note: There are in general more function spaces associated to the form,
-//       which is the reason why the helpers takes name as argument.
-// This helper is called in user c++ code.
+// Helper used to create function space using function name
+// i.e. name of the Python variable.
 //
-ufc_function_space* create_functionspace_{name_from_uflfile}(const char* fs_name);
-
+ufc_function_space* functionspace_{name_from_uflfile}(const char* function_name);
 """
 
 factory = """
 // Code for form {factory_name}
 
-int original_coefficient_position_{factory_name}(int i)
-{{
-{original_coefficient_position}
-}}
+{original_coefficient_position_init}
+{dofmaps_init}
+{finite_elements_init}
 
 // Return a list of the coefficient names.
 const char** coefficient_name_{factory_name}(void)
@@ -42,120 +37,49 @@ const char** constant_name_{factory_name}(void)
 {constant_name_map}
 }}
 
-{coordinate_mapping_declaration}
-ufc_coordinate_mapping* create_coordinate_mapping_{factory_name}(void)
+int* integral_ids_{factory_name}(ufc_integral_type integral_type)
 {{
-{create_coordinate_mapping}
+{integral_ids}
 }}
 
-{finite_element_declaration}
-ufc_finite_element* create_finite_element_{factory_name}(int i)
+int num_integrals_{factory_name}(ufc_integral_type integral_type)
 {{
-{create_finite_element}
+{num_integrals}
 }}
 
-{dofmap_declaration}
-ufc_dofmap* create_dofmap_{factory_name}(int i)
+ufc_integral** integrals_{factory_name}(ufc_integral_type integral_type)
 {{
-{create_dofmap}
+{integrals}
 }}
 
-ufc_integral* create_cell_integral_{factory_name}(int subdomain_id)
+ufc_form {factory_name} =
 {{
-  {create_cell_integral}
-}}
 
-void get_cell_integral_ids_{factory_name}(int *ids)
+  .signature = {signature},
+  .rank = {rank},
+  .num_coefficients = {num_coefficients},
+  .num_constants = {num_constants},
+  .original_coefficient_position = {original_coefficient_position},
+
+  .coefficient_name_map = coefficient_name_{factory_name},
+  .constant_name_map = constant_name_{factory_name},
+
+  .coordinate_mapping = {coordinate_mapping},
+  .finite_elements = {finite_elements},
+  .dofmaps = {dofmaps},
+
+  .integral_ids = integral_ids_{factory_name},
+  .num_integrals = num_integrals_{factory_name},
+
+  .integrals = integrals_{factory_name}
+}};
+
+// Alias name
+ufc_form* {name_from_uflfile} = &{factory_name};
+
+ufc_function_space* functionspace_{name_from_uflfile}(const char* function_name)
 {{
-  {get_cell_integral_ids}
-}}
-
-ufc_integral* create_exterior_facet_integral_{factory_name}(int subdomain_id)
-{{
-  {create_exterior_facet_integral}
-}}
-
-void get_exterior_facet_integral_ids_{factory_name}(int *ids)
-{{
-  {get_exterior_facet_integral_ids}
-}}
-
-ufc_integral* create_interior_facet_integral_{factory_name}(int subdomain_id)
-{{
-{create_interior_facet_integral}
-}}
-
-void get_interior_facet_integral_ids_{factory_name}(int *ids)
-{{
-  {get_interior_facet_integral_ids}
-}}
-
-ufc_integral* create_vertex_integral_{factory_name}(int subdomain_id)
-{{
-{create_vertex_integral}
-}}
-
-void get_vertex_integral_ids_{factory_name}(int *ids)
-{{
-  {get_vertex_integral_ids}
-}}
-
-ufc_custom_integral* create_custom_integral_{factory_name}(int subdomain_id)
-{{
-{create_custom_integral}
-}}
-
-void get_custom_integral_ids_{factory_name}(int *ids)
-{{
-  {get_custom_integral_ids}
-}}
-
-ufc_form* create_{factory_name}(void)
-{{
-  ufc_form* form = (ufc_form*)malloc(sizeof(*form));
-
-  form->signature = {signature};
-  form->rank = {rank};
-  form->num_coefficients = {num_coefficients};
-  form->num_constants = {num_constants};
-  form->original_coefficient_position = original_coefficient_position_{factory_name};
-
-  form->coefficient_name_map = coefficient_name_{factory_name};
-  form->constant_name_map = constant_name_{factory_name};
-
-  form->create_coordinate_mapping = create_coordinate_mapping_{factory_name};
-  form->create_finite_element = create_finite_element_{factory_name};
-  form->create_dofmap = create_dofmap_{factory_name};
-
-  form->get_cell_integral_ids = get_cell_integral_ids_{factory_name};
-  form->get_exterior_facet_integral_ids = get_exterior_facet_integral_ids_{factory_name};
-  form->get_interior_facet_integral_ids = get_interior_facet_integral_ids_{factory_name};
-  form->get_vertex_integral_ids = get_vertex_integral_ids_{factory_name};
-  form->get_custom_integral_ids = get_custom_integral_ids_{factory_name};
-
-  form->num_cell_integrals = {num_cell_integrals};
-  form->num_exterior_facet_integrals = {num_exterior_facet_integrals};
-  form->num_interior_facet_integrals = {num_interior_facet_integrals};
-  form->num_vertex_integrals = {num_vertex_integrals};
-  form->num_custom_integrals = {num_custom_integrals};
-
-  form->create_cell_integral = create_cell_integral_{factory_name};
-  form->create_exterior_facet_integral = create_exterior_facet_integral_{factory_name};
-  form->create_interior_facet_integral = create_interior_facet_integral_{factory_name};
-  form->create_vertex_integral = create_vertex_integral_{factory_name};
-  form->create_custom_integral = create_custom_integral_{factory_name};
-
-  return form;
-}}
-
-ufc_form* create_{name_from_uflfile}(void)
-{{
-  return create_{factory_name}();
-}}
-
-ufc_function_space* create_functionspace_{name_from_uflfile}(const char* function_name)
-{{
-  {create_functionspace}
+{functionspace}
 }}
 
 // End of code for form {factory_name}

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -58,7 +58,8 @@ def generator(ir, parameters):
     L = backend.language
     if len(ir.enabled_coefficients) > 0:
         code["enabled_coefficients_init"] = L.ArrayDecl(
-            "bool", f"enabled_coefficients_{ir.name}", values=ir.enabled_coefficients, sizes=len(ir.enabled_coefficients))
+            "bool", f"enabled_coefficients_{ir.name}",
+            values=ir.enabled_coefficients, sizes=len(ir.enabled_coefficients))
         code["enabled_coefficients"] = f"enabled_coefficients_{ir.name}"
     else:
         code["enabled_coefficients_init"] = ""

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -55,40 +55,28 @@ def generator(ir, parameters):
     code["initializer_list"] = ""
     code["destructor"] = ""
 
-    # TODO: I don't know how to implement this using the format dict,
-    # this will do for now:
-    initializer_list = ", ".join("true" if enabled else "false" for enabled in ir.enabled_coefficients)
-    if ir.enabled_coefficients:
-        enabled_coeffs_code = f"[{len(ir.enabled_coefficients)}] = {{ {initializer_list} }};"
+    L = backend.language
+    if len(ir.enabled_coefficients) > 0:
+        code["enabled_coefficients_init"] = L.ArrayDecl(
+            "bool", f"enabled_coefficients_{ir.name}", values=ir.enabled_coefficients, sizes=len(ir.enabled_coefficients))
+        code["enabled_coefficients"] = f"enabled_coefficients_{ir.name}"
     else:
-        enabled_coeffs_code = "[1] = {false};  /* No coefficients, but C does not permit zero-sized arrays */"
+        code["enabled_coefficients_init"] = ""
+        code["enabled_coefficients"] = L.Null()
 
-    code["enabled_coefficients"] = enabled_coeffs_code
     code["additional_includes_set"] = set()  # FIXME: Get this out of code[]
     code["tabulate_tensor"] = body
 
     if parameters["tabulate_tensor_void"]:
         code["tabulate_tensor"] = ""
 
-    # Format tabulate tensor body
-    tabulate_tensor_declaration = ufc_integrals.tabulate_implementation[
-        integral_type]
-    tabulate_tensor_fn = tabulate_tensor_declaration.format(
-        factory_name=factory_name, tabulate_tensor=code["tabulate_tensor"])
+    implementation = ufc_integrals.factory.format(
+        factory_name=factory_name,
+        enabled_coefficients=code["enabled_coefficients"],
+        enabled_coefficients_init=code["enabled_coefficients_init"],
+        tabulate_tensor=code["tabulate_tensor"],
+        needs_transformation_data=ir.needs_transformation_data)
 
-    # Format implementation code
-    if integral_type == "custom":
-        implementation = ufc_integrals.custom_factory.format(
-            factory_name=factory_name,
-            enabled_coefficients=code["enabled_coefficients"],
-            tabulate_tensor=tabulate_tensor_fn,
-            needs_transformation_data=ir.needs_transformation_data)
-    else:
-        implementation = ufc_integrals.factory.format(
-            factory_name=factory_name,
-            enabled_coefficients=code["enabled_coefficients"],
-            tabulate_tensor=tabulate_tensor_fn,
-            needs_transformation_data=ir.needs_transformation_data)
     return declaration, implementation
 
 

--- a/ffcx/codegeneration/integrals_template.py
+++ b/ffcx/codegeneration/integrals_template.py
@@ -4,114 +4,31 @@
 # The FEniCS Project (http://www.fenicsproject.org/) 2018
 
 declaration = """
-ufc_integral* create_{factory_name}(void);
+extern ufc_integral {factory_name};
 """
-
-custom_declaration = """
-ufc_custom_integral* create_{factory_name}(void);
-"""
-
-tabulate_implementation = {
-    "cell":
-    """
-void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
-                                    const ufc_scalar_t* restrict w,
-                                    const ufc_scalar_t* restrict c,
-                                    const double* restrict coordinate_dofs,
-                                    const int* restrict unused_local_index,
-                                    const uint8_t* restrict quadrature_permutation,
-                                    const uint32_t cell_permutation)
-{{
-{tabulate_tensor}
-}}
-""",
-    "exterior_facet":
-    """
-void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
-                                    const ufc_scalar_t* restrict w,
-                                    const ufc_scalar_t* restrict c,
-                                    const double* restrict coordinate_dofs,
-                                    const int* restrict facet,
-                                    const uint8_t* restrict quadrature_permutation,
-                                    const uint32_t cell_permutation)
-{{
-{tabulate_tensor}
-}}
-""",
-    "interior_facet":
-    """
-void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
-                                    const ufc_scalar_t* restrict w,
-                                    const ufc_scalar_t* restrict c,
-                                    const double* restrict coordinate_dofs,
-                                    const int* restrict facet,
-                                    const uint8_t* restrict quadrature_permutation,
-                                    const uint32_t cell_permutation)
-{{
-{tabulate_tensor}
-}}
-""",
-    "vertex":
-    """
-void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
-                                    const ufc_scalar_t* restrict w,
-                                    const ufc_scalar_t* restrict c,
-                                    const double* restrict coordinate_dofs,
-                                    const int* restrict vertex,
-                                    const uint8_t* restrict quadrature_permutation,
-                                    const uint32_t cell_permutation)
-{{
-{tabulate_tensor}
-}}
-""",
-    "custom":
-    """
-void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
-                                    const ufc_scalar_t* restrict w,
-                                    const ufc_scalar_t* restrict c,
-                                    const double* restrict coordinate_dofs,
-                                    int num_quadrature_points,
-                                    const double* restrict quadrature_points,
-                                    const double* restrict quadrature_weights,
-                                    const double* restrict facet_normals)
-{{
-{tabulate_tensor}
-}}
-"""
-}
 
 factory = """
 // Code for integral {factory_name}
 
-{tabulate_tensor}
-
-ufc_integral* create_{factory_name}(void)
+void tabulate_tensor_{factory_name}(ufc_scalar_t* restrict A,
+                                    const ufc_scalar_t* restrict w,
+                                    const ufc_scalar_t* restrict c,
+                                    const double* restrict coordinate_dofs,
+                                    const int* restrict entity_local_index,
+                                    const uint8_t* restrict quadrature_permutation,
+                                    const uint32_t cell_permutation)
 {{
-  static const bool enabled{enabled_coefficients}
-  ufc_integral* integral = (ufc_integral*)malloc(sizeof(*integral));
-  integral->enabled_coefficients = enabled;
-  integral->tabulate_tensor = tabulate_tensor_{factory_name};
-  integral->needs_transformation_data = {needs_transformation_data};
-  return integral;
+{tabulate_tensor}
 }}
+
+{enabled_coefficients_init}
+
+ufc_integral {factory_name} =
+{{
+  .enabled_coefficients = {enabled_coefficients},
+  .tabulate_tensor = tabulate_tensor_{factory_name},
+  .needs_transformation_data = {needs_transformation_data}
+}};
 
 // End of code for integral {factory_name}
-"""
-
-custom_factory = """
-// Code for custom integral {factory_name}
-
-{tabulate_tensor}
-
-ufc_custom_integral* create_{factory_name}(void)
-{{
-  static const bool enabled{enabled_coefficients}
-  ufc_custom_integral* integral = (ufc_custom_integral*)malloc(sizeof(*integral));
-  integral->enabled_coefficients = enabled;
-  integral->tabulate_tensor = tabulate_tensor_{factory_name};
-  integral->needs_transformation_data = {needs_transformation_data};
-  return integral;
-}}
-
-// End of code for custom integral {factory_name}
 """

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -325,7 +325,6 @@ def _load_objects(cache_dir, module_name, object_names):
 
     compiled_objects = []
     for name in object_names:
-        # Call UFC factory to create object data struct (calls malloc)
         obj = getattr(compiled_module.lib, name)
         compiled_objects.append(obj)
 

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -86,9 +86,9 @@ class FFCXBackendSymbols(object):
             postfix = "[0]"
             if restriction == "-":
                 postfix = "[1]"
-            return self.S("facet" + postfix)
+            return self.S("entity_local_index" + postfix)
         elif entitytype == "vertex":
-            return self.S("vertex[0]")
+            return self.S("entity_local_index[0]")
         else:
             logging.exception(f"Unknown entitytype {entitytype}")
 

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -51,6 +51,13 @@ extern "C"
     vertex = 60,
   } ufc_shape;
 
+  typedef enum
+  {
+    cell = 0,
+    exterior_facet = 1,
+    interior_facet = 2
+  } ufc_integral_type;
+
   /// Forward declarations
   typedef struct ufc_coordinate_mapping ufc_coordinate_mapping;
   typedef struct ufc_finite_element ufc_finite_element;
@@ -79,7 +86,7 @@ extern "C"
     int value_rank;
 
     /// Return the dimension of the value space for axis i
-    int (*value_dimension)(int i);
+    int* value_shape;
 
     /// Return the number of components of the value space
     int value_size;
@@ -88,7 +95,7 @@ extern "C"
     int reference_value_rank;
 
     /// Return the dimension of the reference value space for axis i
-    int (*reference_value_dimension)(int i);
+    int* reference_value_shape;
 
     /// Return the number of components of the reference value space
     int reference_value_size;
@@ -152,15 +159,10 @@ extern "C"
     /// points are the DOF coordinates.
     bool interpolation_is_identity;
 
-    /// Create a new finite element for sub element i (for a mixed
-    /// element). Memory for the new object is obtained with malloc(),
-    /// and the caller is reponsible for freeing it by calling free().
-    ufc_finite_element* (*create_sub_element)(int i);
+    /// Get a finite element for sub element i (for a mixed
+    /// element).
+    ufc_finite_element** sub_elements;
 
-    /// Create a new class instance. Memory for the new object is
-    /// obtained with malloc(), and the caller is reponsible for
-    /// freeing it by calling free().
-    ufc_finite_element* (*create)(void);
   } ufc_finite_element;
 
   typedef struct ufc_dofmap
@@ -189,15 +191,10 @@ extern "C"
     /// Return the number of sub dofmaps (for a mixed element)
     int num_sub_dofmaps;
 
-    /// Create a new dofmap for sub dofmap i (for a mixed
-    /// element). Memory for the new object is obtained with malloc(),
-    /// and the caller is reponsible for freeing it by calling free().
-    ufc_dofmap* (*create_sub_dofmap)(int i);
+    /// Get a dofmap for sub dofmap i (for a mixed
+    /// element).
+    ufc_dofmap** sub_dofmaps;
 
-    /// Create a new class instance. Memory for the new object is
-    /// obtained with malloc(), and the caller is reponsible for
-    /// freeing it by calling free().
-    ufc_dofmap* (*create)(void);
   } ufc_dofmap;
 
   /// A representation of a coordinate mapping parameterized by a local
@@ -213,11 +210,6 @@ extern "C"
 
     /// The finite element degree used in the mapping
     int element_degree;
-
-    /// Create object of the same type. Memory for the new object is
-    /// obtained with malloc(), and the caller is reponsible for
-    /// freeing it by calling free().
-    ufc_coordinate_mapping* (*create)(void);
 
     /// Return geometric dimension of the coordinate_mapping
     int geometric_dimension;
@@ -247,10 +239,8 @@ extern "C"
     /// Return cell shape of the coordinate_mapping
     ufc_shape cell_shape;
 
-    /// Create dofmap for the underlying scalar element. Memory for
-    /// the new object is obtained with malloc(), and the caller is
-    /// reponsible for freeing it by calling free().
-    ufc_dofmap* (*create_scalar_dofmap)(void);
+    /// Dofmap for the underlying scalar element.
+    ufc_dofmap* scalar_dofmap;
 
   } ufc_coordinate_mapping;
 
@@ -407,12 +397,8 @@ extern "C"
     /// Number of constants
     int num_constants;
 
-    /// Return original coefficient position for each coefficient
-    ///
-    /// @param i
-    ///        Coefficient number, 0 <= i < n
-    ///
-    int (*original_coefficient_position)(int i);
+    /// Original coefficient position for each coefficient
+    int* original_coefficient_position;
 
     /// Return list of names of coefficients
     const char** (*coefficient_name_map)(void);
@@ -420,113 +406,43 @@ extern "C"
     /// Return list of names of constants
     const char** (*constant_name_map)(void);
 
-    /// Create a new coordinate mapping. Memory for the new object is
-    /// obtained with malloc(), and the caller is reponsible for
-    /// freeing it by calling free().
-    ufc_coordinate_mapping* (*create_coordinate_mapping)(void);
+    ufc_coordinate_mapping* coordinate_mapping;
 
-    /// Create a new finite element for the i-th argument function,
-    /// where 0 <= i < r+n. Memory for the new object is obtained with
-    /// malloc(), and the caller is reponsible for freeing it by
-    /// calling free().
+    /// Get a finite element for the i-th argument function,
+    /// where 0 <= i < r+n.
     ///
     /// @param i
     ///        Argument number if 0 <= i < r
     ///        Coefficient number j=i-r if r+j <= i < r+n
     ///
-    ufc_finite_element* (*create_finite_element)(int i);
+    ufc_finite_element** finite_elements;
 
-    /// Create a new dofmap for the i-th argument function, where 0 <=
-    /// i < r+n.  Memory for the new object is obtained with malloc(),
-    /// and the caller is reponsible for freeing it by calling free().
+    /// Get a dofmap for the i-th argument function, where 0 <=
+    /// i < r+n.
     ///
     /// @param i
     ///        Argument number if 0 <= i < r
     ///        Coefficient number j=i-r if r+j <= i < r+n
     ///
-    ufc_dofmap* (*create_dofmap)(int i);
+    ufc_dofmap** dofmaps;
 
-    /// All ids for cell integrals
-    void (*get_cell_integral_ids)(int* ids);
+    /// All ids for integrals
+    int* (*integral_ids)(ufc_integral_type);
 
-    /// All ids for exterior facet integrals
-    void (*get_exterior_facet_integral_ids)(int* ids);
+    /// Number of integrals
+    int (*num_integrals)(ufc_integral_type);
 
-    /// All ids for interior facet integrals
-    void (*get_interior_facet_integral_ids)(int* ids);
-
-    /// All ids for vertex integrals
-    void (*get_vertex_integral_ids)(int* ids);
-
-    /// All ids for custom integrals
-    void (*get_custom_integral_ids)(int* ids);
-
-    /// Number of cell integrals
-    int num_cell_integrals;
-
-    /// Number of exterior facet integrals
-    int num_exterior_facet_integrals;
-
-    /// Number of interior facet integrals
-    int num_interior_facet_integrals;
-
-    /// Number of vertex integrals
-    int num_vertex_integrals;
-
-    /// Number of custom integrals
-    int num_custom_integrals;
-
-    /// Create a new cell integral on sub domain subdomain_id. Memory
-    /// for the new object is obtained with malloc(), and the caller
-    /// is reponsible for freeing it by calling free().
-    ufc_integral* (*create_cell_integral)(int subdomain_id);
-
-    /// Create a new exterior facet integral on sub domain
-    /// subdomain_id. Memory for the new object is obtained with
-    /// malloc(), and the caller is reponsible for freeing it by
-    /// calling free().
-    ufc_integral* (*create_exterior_facet_integral)(int subdomain_id);
-
-    /// Create a new interior facet integral on sub domain
-    /// subdomain_id. Memory for the new object is obtained with
-    /// malloc(), and the caller is reponsible for freeing it by
-    /// calling free().
-    ufc_integral* (*create_interior_facet_integral)(int subdomain_id);
-
-    /// Create a new vertex integral on sub domain
-    /// subdomain_id. Memory for the new object is obtained with
-    /// malloc(), and the caller is reponsible for freeing it by
-    /// calling free().
-    ufc_integral* (*create_vertex_integral)(int subdomain_id);
-
-    /// Create a new custom integral on sub domain
-    /// subdomain_id. Memory for the new object is obtained with
-    /// malloc(), and the caller is reponsible for freeing it by
-    /// calling free().
-    ufc_custom_integral* (*create_custom_integral)(int subdomain_id);
+    /// Get an integral on sub domain subdomain_id.
+    ufc_integral** (*integrals)(ufc_integral_type);
 
   } ufc_form;
 
   // FIXME: Formalise a UFC 'function space'.
   typedef struct ufc_function_space
   {
-    // Pointer to factory function that creates a new
-    // ufc_finite_element. Memory for the new object is obtained with
-    // malloc(), and the caller is reponsible for freeing it by
-    // calling free().
-    ufc_finite_element* (*create_element)(void);
-
-    // Pointer to factory function that creates a new
-    // ufc_dofmap. Memory for the new object is obtained with
-    // malloc(), and the caller is reponsible for freeing it by
-    // calling free().
-    ufc_dofmap* (*create_dofmap)(void);
-
-    // Pointer to factory function that creates a new
-    // ufc_coordinate_mapping. Memory for the new object is obtained
-    // with malloc(), and the caller is reponsible for freeing it by
-    // calling free().
-    ufc_coordinate_mapping* (*create_coordinate_mapping)(void);
+    ufc_finite_element* finite_element;
+    ufc_dofmap* dofmap;
+    ufc_coordinate_mapping* coordinate_mapping;
   } ufc_function_space;
 
 #ifdef __cplusplus

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -10,31 +10,6 @@ import numpy
 index_type = "int"
 
 
-def generate_return_new(L, classname):
-    return L.Return(L.Call("create_" + classname))
-
-
-def generate_return_new_switch(L, i, classnames, args=None):
-
-    if isinstance(i, str):
-        i = L.Symbol(i)
-
-    def create(classname):
-        return L.Call("create_" + classname)
-
-    default = L.Return(L.Null())
-    if classnames:
-        cases = []
-        if args is None:
-            args = list(range(len(classnames)))
-        for j, classname in zip(args, classnames):
-            if classname:
-                cases.append((j, L.Return(create(classname))))
-        return L.Switch(i, cases, default=default)
-    else:
-        return default
-
-
 def generate_return_literal_switch(L,
                                    i,
                                    values,

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -571,8 +571,8 @@ def _compute_form_ir(form_data, form_id, prefix, element_numbers, finite_element
     ufc_integral_types = ("cell", "exterior_facet", "interior_facet")
     for integral_type in ufc_integral_types:
         subdomain_ids, classnames = _create_foo_integral(form_id, integral_type, form_data)
-        ir[f"classnames"][integral_type] = classnames
-        ir[f"subdomain_ids"][integral_type] = subdomain_ids
+        ir["classnames"][integral_type] = classnames
+        ir["subdomain_ids"][integral_type] = subdomain_ids
 
     return ir_form(**ir)
 

--- a/test/test_add_mode.py
+++ b/test/test_add_mode.py
@@ -42,14 +42,13 @@ def test_additive_facet_integral(mode, compile_args):
         assert compiled_f.rank == len(f.arguments())
 
     ffi = cffi.FFI()
-    form0 = compiled_forms[0][0]
+    form0 = compiled_forms[0]
 
-    assert form0.num_exterior_facet_integrals == 1
-    ids = np.zeros(form0.num_exterior_facet_integrals, dtype=np.int32)
-    form0.get_exterior_facet_integral_ids(ffi.cast('int *', ids.ctypes.data))
+    assert form0.num_integrals(module.lib.exterior_facet) == 1
+    ids = form0.integral_ids(module.lib.exterior_facet)
     assert ids[0] == -1
 
-    default_integral = form0.create_exterior_facet_integral(ids[0])
+    default_integral = form0.integrals(module.lib.exterior_facet)[0]
 
     c_type, np_type = float_to_type(mode)
     A = np.zeros((3, 3), dtype=np_type)
@@ -87,14 +86,13 @@ def test_additive_cell_integral(mode, compile_args):
         assert compiled_f.rank == len(f.arguments())
 
     ffi = cffi.FFI()
-    form0 = compiled_forms[0][0]
+    form0 = compiled_forms[0]
 
-    assert form0.num_cell_integrals == 1
-    ids = np.zeros(form0.num_cell_integrals, dtype=np.int32)
-    form0.get_cell_integral_ids(ffi.cast('int *', ids.ctypes.data))
+    assert form0.num_integrals(module.lib.cell) == 1
+    ids = form0.integral_ids(module.lib.cell)
     assert ids[0] == -1
 
-    default_integral = form0.create_cell_integral(ids[0])
+    default_integral = form0.integrals(0)[0]
 
     c_type, np_type = float_to_type(mode)
     A = np.zeros((3, 3), dtype=np_type)

--- a/test/test_blocked_elements.py
+++ b/test/test_blocked_elements.py
@@ -21,14 +21,8 @@ def test_finite_element(compile_args):
     assert ufc_element.geometric_dimension == 2
     assert ufc_element.space_dimension == 3
     assert ufc_element.value_rank == 0
-    assert ufc_element.value_dimension(0) == 1
-    assert ufc_element.value_dimension(1) == 1
-    assert ufc_element.value_dimension(2) == 1
     assert ufc_element.value_size == 1
     assert ufc_element.reference_value_rank == 0
-    assert ufc_element.reference_value_dimension(0) == 1
-    assert ufc_element.reference_value_dimension(1) == 1
-    assert ufc_element.reference_value_dimension(2) == 1
     assert ufc_element.reference_value_size == 1
     assert ufc_element.block_size == 1
     assert ufc_element.num_sub_elements == 0
@@ -59,14 +53,10 @@ def test_vector_element(compile_args):
     assert ufc_element.geometric_dimension == 2
     assert ufc_element.space_dimension == 6
     assert ufc_element.value_rank == 1
-    assert ufc_element.value_dimension(0) == 2
-    assert ufc_element.value_dimension(1) == 1
-    assert ufc_element.value_dimension(2) == 1
+    assert ufc_element.value_shape[0] == 2
     assert ufc_element.value_size == 2
     assert ufc_element.reference_value_rank == 1
-    assert ufc_element.reference_value_dimension(0) == 2
-    assert ufc_element.reference_value_dimension(1) == 1
-    assert ufc_element.reference_value_dimension(2) == 1
+    assert ufc_element.reference_value_shape[0] == 2
     assert ufc_element.reference_value_size == 2
     assert ufc_element.block_size == 2
     assert ufc_element.num_sub_elements == 2
@@ -97,14 +87,12 @@ def test_tensor_element(compile_args):
     assert ufc_element.geometric_dimension == 2
     assert ufc_element.space_dimension == 12
     assert ufc_element.value_rank == 2
-    assert ufc_element.value_dimension(0) == 2
-    assert ufc_element.value_dimension(1) == 2
-    assert ufc_element.value_dimension(2) == 1
+    assert ufc_element.value_shape[0] == 2
+    assert ufc_element.value_shape[1] == 2
     assert ufc_element.value_size == 4
     assert ufc_element.reference_value_rank == 2
-    assert ufc_element.reference_value_dimension(0) == 2
-    assert ufc_element.reference_value_dimension(1) == 2
-    assert ufc_element.reference_value_dimension(2) == 1
+    assert ufc_element.reference_value_shape[0] == 2
+    assert ufc_element.reference_value_shape[1] == 2
     assert ufc_element.reference_value_size == 4
     assert ufc_element.block_size == 4
     assert ufc_element.num_sub_elements == 4

--- a/test/test_jit_cmaps.py
+++ b/test/test_jit_cmaps.py
@@ -24,7 +24,7 @@ def test_cmap_triangle(degree, compile_args):
     assert compiled_cmap[0].geometric_dimension == 2
     assert compiled_cmap[0].topological_dimension == 2
 
-    num_entity_dofs = compiled_cmap[0].create_scalar_dofmap().num_entity_dofs
+    num_entity_dofs = compiled_cmap[0].scalar_dofmap.num_entity_dofs
 
     assert num_entity_dofs[0] == 1
     assert num_entity_dofs[2] == 0
@@ -50,7 +50,7 @@ def test_cmap_quads(degree, compile_args):
     assert compiled_cmap[0].geometric_dimension == 2
     assert compiled_cmap[0].topological_dimension == 2
 
-    num_entity_dofs = compiled_cmap[0].create_scalar_dofmap().num_entity_dofs
+    num_entity_dofs = compiled_cmap[0].scalar_dofmap.num_entity_dofs
 
     assert num_entity_dofs[0] == 1
     assert num_entity_dofs[3] == 0
@@ -77,7 +77,7 @@ def test_cmap_hex(degree, compile_args):
     assert compiled_cmap[0].geometric_dimension == 3
     assert compiled_cmap[0].topological_dimension == 3
 
-    num_entity_dofs = compiled_cmap[0].create_scalar_dofmap().num_entity_dofs
+    num_entity_dofs = compiled_cmap[0].scalar_dofmap.num_entity_dofs
 
     assert num_entity_dofs[0] == 1
 
@@ -105,7 +105,7 @@ def test_cmap_tet(degree, compile_args):
     assert compiled_cmap[0].geometric_dimension == 3
     assert compiled_cmap[0].topological_dimension == 3
 
-    num_entity_dofs = compiled_cmap[0].create_scalar_dofmap().num_entity_dofs
+    num_entity_dofs = compiled_cmap[0].scalar_dofmap.num_entity_dofs
 
     assert num_entity_dofs[0] == 1
     assert num_entity_dofs[2] == 0

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -49,7 +49,7 @@ def test_matvec(compile_args):
     obj, module = ffcx.codegeneration.jit.compile_expressions([(expr, points)], cffi_extra_compile_args=compile_args)
 
     ffi = cffi.FFI()
-    kernel = obj[0][0]
+    expression = obj[0]
 
     c_type, np_type = float_to_type("double")
 
@@ -62,7 +62,7 @@ def test_matvec(compile_args):
 
     # Coords storage XYXYXY
     coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
-    kernel.tabulate_expression(
+    expression.tabulate_expression(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
@@ -72,13 +72,13 @@ def test_matvec(compile_args):
     assert np.allclose(A, 0.5 * np.dot(a_mat, f_mat).T)
 
     # Prepare NumPy array of points attached to the expression
-    length = kernel.num_points * kernel.topological_dimension
-    points_kernel = np.frombuffer(ffi.buffer(kernel.points, length * ffi.sizeof("double")), np.double)
+    length = expression.num_points * expression.topological_dimension
+    points_kernel = np.frombuffer(ffi.buffer(expression.points, length * ffi.sizeof("double")), np.double)
     points_kernel = points_kernel.reshape(points.shape)
     assert np.allclose(points, points_kernel)
 
     # Check the value shape attached to the expression
-    value_shape = np.frombuffer(ffi.buffer(kernel.value_shape, kernel.num_components * ffi.sizeof("int")), np.intc)
+    value_shape = np.frombuffer(ffi.buffer(expression.value_shape, expression.num_components * ffi.sizeof("int")), np.intc)
     assert np.allclose(expr.ufl_shape, value_shape)
 
 
@@ -101,7 +101,7 @@ def test_rank1(compile_args):
     obj, module = ffcx.codegeneration.jit.compile_expressions([(expr, points)], cffi_extra_compile_args=compile_args)
 
     ffi = cffi.FFI()
-    kernel = obj[0][0]
+    expression = obj[0]
 
     c_type, np_type = float_to_type("double")
 
@@ -116,7 +116,7 @@ def test_rank1(compile_args):
 
     # Coords storage XYXYXY
     coords = np.array(points.flatten(), dtype=np.float64)
-    kernel.tabulate_expression(
+    expression.tabulate_expression(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -78,7 +78,8 @@ def test_matvec(compile_args):
     assert np.allclose(points, points_kernel)
 
     # Check the value shape attached to the expression
-    value_shape = np.frombuffer(ffi.buffer(expression.value_shape, expression.num_components * ffi.sizeof("int")), np.intc)
+    value_shape = np.frombuffer(ffi.buffer(expression.value_shape,
+                                           expression.num_components * ffi.sizeof("int")), np.intc)
     assert np.allclose(expr.ufl_shape, value_shape)
 
 

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -282,8 +282,6 @@ def test_subdomains(compile_args):
     for f, compiled_f in zip(forms, compiled_forms):
         assert compiled_f.rank == len(f.arguments())
 
-    ffi = cffi.FFI()
-
     form0 = compiled_forms[0]
     ids = form0.integral_ids(module.lib.cell)
     assert ids[0] == -1 and ids[1] == 2


### PR DESCRIPTION
Changes the allocation strategy for ufc structures. Removes the use of dynamic memory allocation.
Instead, all `struct ufc_foo` are now `extern`, i.e. have static storage duration and external linkage.

For structures containing structures, e.g. `ufc_form` holding `ufc_finite_element` for elements of functions in the form, `ufc_finite_element**` is used. Essentially, `ufc_finite_element*` are grouped into an array.