### PR TITLE
Remove permute_dofs and unpermute_dofs functions from FFCx

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: ./basix
           repository: FEniCS/basix
-          ref: mscroggs/dof-permutations
+          ref: main
 
       - name: Install Basix
         run: |

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           path: ./basix
           repository: FEniCS/basix
-          ref: main
+          ref: mscroggs/dof-permutations
 
       - name: Install Basix
         run: |
@@ -55,7 +55,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: mscroggs/dof-permutations
       - name: Clone and install DOLFINx
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path: ./basix
           repository: FEniCS/basix
-          ref: mscroggs/dof-permutations
+          ref: main
 
       - name: Install dependencies (non-Python, Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path: ./basix
           repository: FEniCS/basix
-          ref: main
+          ref: mscroggs/dof-permutations
 
       - name: Install dependencies (non-Python, Linux)
         if: runner.os == 'Linux'

--- a/ffcx/codegeneration/coordinate_mapping.py
+++ b/ffcx/codegeneration/coordinate_mapping.py
@@ -7,8 +7,6 @@
 import logging
 
 import ffcx.codegeneration.coordinate_mapping_template as ufc_coordinate_mapping
-from ffcx.codegeneration.utils import apply_transformations_to_data
-import ffcx.codegeneration.C.cnodes as L
 
 logger = logging.getLogger("ffcx")
 

--- a/ffcx/codegeneration/coordinate_mapping.py
+++ b/ffcx/codegeneration/coordinate_mapping.py
@@ -35,14 +35,6 @@ def generator(ir, parameters):
     d["cell_shape"] = ir.cell_shape
     d["scalar_dofmap_name"] = ir.scalar_dofmap_name
 
-    d["needs_transformation_data"] = ir.needs_transformation_data
-
-    statements = permute_dofs(L, ir.base_transformations, ir.cell_shape)
-    d["permute_dofs"] = L.StatementList(statements)
-
-    statements = unpermute_dofs(L, ir.base_transformations, ir.cell_shape)
-    d["unpermute_dofs"] = L.StatementList(statements)
-
     d["family"] = f"\"{ir.coordinate_element_family}\""
     d["degree"] = ir.coordinate_element_degree
 
@@ -61,15 +53,3 @@ def generator(ir, parameters):
     declaration = ufc_coordinate_mapping.declaration.format(factory_name=ir.name, prefix=ir.prefix)
 
     return declaration, implementation
-
-
-def permute_dofs(L, base_transformations, cell_shape):
-    data = L.Symbol("dof_list")
-    return apply_transformations_to_data(L, base_transformations, cell_shape, data,
-                                         dtype="int") + [L.Return(0)]
-
-
-def unpermute_dofs(L, base_transformations, cell_shape):
-    data = L.Symbol("dof_list")
-    return apply_transformations_to_data(L, base_transformations, cell_shape, data,
-                                         inverse=True, dtype="int") + [L.Return(0)]

--- a/ffcx/codegeneration/coordinate_mapping_template.py
+++ b/ffcx/codegeneration/coordinate_mapping_template.py
@@ -20,16 +20,6 @@ ufc_coordinate_mapping* create_coordinate_map_{prefix}(void);
 factory = """
 // Code for coordinate mapping {factory_name}
 
-int permute_dofs_{factory_name}(int* dof_list, const uint32_t cell_permutation)
-{{
-  {permute_dofs}
-}}
-
-int unpermute_dofs_{factory_name}(int* dof_list, const uint32_t cell_permutation)
-{{
-  {unpermute_dofs}
-}}
-
 ufc_coordinate_mapping* create_{factory_name}(void)
 {{
   ufc_coordinate_mapping* cmap = (ufc_coordinate_mapping*)malloc(sizeof(*cmap));
@@ -40,9 +30,6 @@ ufc_coordinate_mapping* create_{factory_name}(void)
   cmap->geometric_dimension = {geometric_dimension};
   cmap->topological_dimension = {topological_dimension};
   cmap->is_affine = {is_affine};
-  cmap->needs_transformation_data = {needs_transformation_data};
-  cmap->permute_dofs = permute_dofs_{factory_name};
-  cmap->unpermute_dofs = unpermute_dofs_{factory_name};
   cmap->cell_shape = {cell_shape};
   cmap->create_scalar_dofmap = create_{scalar_dofmap_name};
   return cmap;

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -228,22 +228,6 @@ extern "C"
     /// Boolean flag for affine
     int is_affine;
 
-    /// Indicates whether transformation data needs to be passed into various
-    /// functions
-    bool needs_transformation_data;
-
-    /// Permutes a list of DOF numbers
-    /// As a coordinate mapping is always Lagrange or Q, the DOF transformation
-    /// will always be a rearrangement of DOF points, so this is valid in this
-    /// case.
-    int (*permute_dofs)(int* dof_list, uint32_t cell_permutation);
-
-    /// Reverses a permutation of a list of DOF numbers
-    /// As a coordinate mapping is always Lagrange or Q, the DOF transformation
-    /// will always be a rearrangement of DOF points, so this is valid in this
-    /// case.
-    int (*unpermute_dofs)(int* dof_list, uint32_t cell_permutation);
-
     /// Return cell shape of the coordinate_mapping
     ufc_shape cell_shape;
 


### PR DESCRIPTION
Added permute_dofs and unpermute_dofs functions to Basix, so these can be removed from the generated code.

This PR is coupled with FEniCS/basix#187 and FEniCS/dolfinx#1471.