### PR TITLE
Loop transformations

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -2,7 +2,10 @@
 
 name: DOLFINx integration
 
-on: push
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -2,10 +2,7 @@
 
 name: DOLFINx integration
 
-on:
-  pull_request:
-    branches:
-      - main
+on: push
 
 jobs:
   build:

--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -819,6 +819,9 @@ class ArrayAccess(CExprOperator):
         return (isinstance(other, type(self)) and self.array == other.array
                 and self.indices == other.indices)
 
+    def __hash__(self):
+        return hash(self.ce_format())
+
 
 class Conditional(CExprOperator):
     __slots__ = ("condition", "true", "false")

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -699,6 +699,8 @@ class IntegralGenerator(object):
         for i in reversed(range(block_rank)):
             body = L.ForRange(B_indices[i], 0, blockdims[i], body=body)
 
+        # TODO: Check if compiler can optimize out the allocation of temporaies
+        #  arrays in pre_loop
         quadparts += [pre_loop, hoist, body]
 
         return preparts, quadparts

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -653,12 +653,15 @@ class IntegralGenerator(object):
                 A_indices.append(block_size * index + offset)
 
         hoist_rhs = collections.defaultdict(list)
+        # List of statements to keep in the inner loop
         keep = []
         # List of temporary array declarations
         pre_loop = []
         # List of loop invariant expressions to hoist
         hoist = []
 
+        # Hoist loop invariant code and group array access (each table should only be read one
+        # time in the inner loop).
         if block_rank == 2:
             ind = B_indices[-1]
             # Indetify loop invariant code to hoist

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -654,7 +654,7 @@ class IntegralGenerator(object):
                 block_size = bm[1] - bm[0]
                 A_indices.append(block_size * index + offset)
 
-        # Create temporary accumulator variable if the number of statements in 
+        # Create temporary accumulator variable if the number of statements in
         # the loop is greater than 1.
         if len(rhs_list) == 1:
             body.append(L.AssignAdd(A[A_indices], rhs_list[0]))
@@ -664,7 +664,7 @@ class IntegralGenerator(object):
             for rhs in rhs_list:
                 body.append(L.AssignAdd(acc, B_rhs))
             body.append(L.AssignAdd(A[A_indices], acc))
-        
+
         for i in reversed(range(block_rank)):
             body = L.ForRange(B_indices[i], 0, blockdims[i], body=body)
         quadparts += [body]

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -664,7 +664,7 @@ class IntegralGenerator(object):
         # time in the inner loop).
         if block_rank == 2:
             ind = B_indices[-1]
-            # Indetify loop invariant code to hoist
+            # Identify loop invariant code to hoist
             for rhs in rhs_list:
                 if len(rhs.args) <= 2:
                     keep.append(rhs)

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -670,8 +670,6 @@ class IntegralGenerator(object):
                     invariant = [x for x in rhs.args if x is not varying]
                     hoist_rhs[varying].append(invariant)
 
-
-
             # Perform algebraic manipulations to reduce number of floating point
             # operations (factorize expressions by grouping)
             for statement in hoist_rhs:

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -702,7 +702,7 @@ class IntegralGenerator(object):
         for i in reversed(range(block_rank)):
             body = L.ForRange(B_indices[i], 0, blockdims[i], body=body)
 
-        # TODO: Check if compiler can optimize out the allocation of temporaies
+        # TODO: Check if the compiler can optimize out the allocation of temporaries
         #  arrays in pre_loop
         quadparts += [pre_loop, hoist, body]
 

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -662,7 +662,7 @@ class IntegralGenerator(object):
             acc = self.new_temp_symbol("acc")
             body.append(L.VariableDecl("ufc_scalar_t", acc, 0))
             for rhs in rhs_list:
-                body.append(L.AssignAdd(acc, B_rhs))
+                body.append(L.AssignAdd(acc, rhs))
             body.append(L.AssignAdd(A[A_indices], acc))
 
         for i in reversed(range(block_rank)):

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -660,7 +660,4 @@ class IntegralGenerator(object):
             body = L.ForRange(B_indices[i], 0, blockdims[i], body=body)
         quadparts += [body]
 
-        for i in quadparts:
-            print(i)
-
         return preparts, quadparts

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -658,7 +658,7 @@ class IntegralGenerator(object):
         body.append(L.AssignAdd(A[A_indices], acc))
         for i in reversed(range(block_rank)):
             body = L.ForRange(B_indices[i], 0, blockdims[i], body=body)
-        quadparts+=[body]
+        quadparts += [body]
 
         for i in quadparts:
             print(i)


### PR DESCRIPTION
Adjusts the generated code quadrature inner loops, by:

* Using full tables (including zeros, which can be optimised out by compiler)
* Fusing loops - when all tables are the same size, this can result in huge performance gains at higher order
* Hoisting inner loop invariant float multiplications

Extensive testing has shown that all compilers perform better with these optimisations under `-Ofast -march=native`
