### PR TITLE
No statement for invariant only blocks

### DIFF
--- a/demo/MassDG0.ufl
+++ b/demo/MassDG0.ufl
@@ -1,0 +1,27 @@
+# Copyright (C) 2021 Igor Baratta
+#
+# This file is part of FFCx.
+#
+# FFCx is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# FFCx is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with FFCx. If not, see <http://www.gnu.org/licenses/>.
+#
+# The bilinear form for a mass matrix.
+#
+# Compile this form with FFCx: ffcx MassDG0.ufl
+
+element = FiniteElement("DG", tetrahedron, 0)
+
+v = TestFunction(element)
+u = TrialFunction(element)
+
+a = inner(u, v)*dx

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -669,7 +669,7 @@ class IntegralGenerator(object):
                 if len(rhs.args) <= 2:
                     keep.append(rhs)
                 else:
-                    varying = next(x for x in rhs.args if hasattr(x, 'indices') and (ind in x.indices))
+                    varying = next((x for x in rhs.args if hasattr(x, 'indices') and (ind in x.indices)), None)
                     invariant = [x for x in rhs.args if x is not varying]
                     hoist_rhs[varying].append(invariant)
 
@@ -683,7 +683,11 @@ class IntegralGenerator(object):
                     sum.append(L.float_product(rhs))
                 sum = L.Sum(sum)
                 hoist.append(L.Assign(t[B_indices[i - 1]], sum))
-                keep.append(L.float_product([statement, t[B_indices[0]]]))
+                if statement is None:
+                    # If there is no "varying" statement then accumulate temporary directly
+                    keep.append(t[B_indices[0]])
+                else:
+                    keep.append(L.float_product([statement, t[B_indices[0]]]))
 
             hoist = L.ForRange(B_indices[0], 0, blockdims[0], body=[hoist]) if hoist else []
             rhs_list = keep


### PR DESCRIPTION
Blocks with invariant only statements produced `StopIteration` exception due to #348 , because `next()` was applied on an empty iterator.