### PR TITLE
Fix geometry array width at 3 in generated code

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: geometry-3d
       - name: Clone and install DOLFINx
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -69,13 +69,6 @@ class FFCXBackendSymbols(object):
 
         self.original_constant_offsets = original_constant_offsets
 
-        # Used for padding variable names based on restriction
-#        self.restriction_postfix = {r: ufc_restriction_postfix(r) for r in ("+", "-", None)}
-
-        # TODO: Make this configurable for easy experimentation with dolfinx!
-        # Coordinate dofs for each component are interleaved? Must match dolfinx.
-        # True = XYZXYZXYZXYZ, False = XXXXYYYYZZZZ
-        self.interleaved_components = True
 
     def element_tensor(self):
         """Symbol for the element tensor itself."""
@@ -144,10 +137,7 @@ class FFCXBackendSymbols(object):
         if restriction == "-":
             offset = num_scalar_dofs * 3
         vc = self.S("coordinate_dofs")
-        if self.interleaved_components:
-            return vc[3 * dof + component + offset]
-        else:
-            return vc[num_scalar_dofs * component + dof + offset]
+        return vc[3 * dof + component + offset]
 
     def domain_dofs_access(self, gdim, num_scalar_dofs, restriction):
         # FIXME: Add domain number or offset!

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -142,10 +142,10 @@ class FFCXBackendSymbols(object):
         # FIXME: Add domain number or offset!
         offset = 0
         if restriction == "-":
-            offset = num_scalar_dofs * gdim
+            offset = num_scalar_dofs * 3
         vc = self.S("coordinate_dofs")
         if self.interleaved_components:
-            return vc[gdim * dof + component + offset]
+            return vc[3 * dof + component + offset]
         else:
             return vc[num_scalar_dofs * component + dof + offset]
 

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -102,8 +102,8 @@ extern "C"
     /// function space
     int degree;
 
-    /// Return the block size for a VectorElement.
-    /// For a TensorElement, this is the product of the tensor's dimensions
+    /// Return the block size for a VectorElement. For a TensorElement,
+    /// this is the product of the tensor's dimensions
     int block_size;
 
     /// Return the family of the finite element function space
@@ -112,8 +112,8 @@ extern "C"
     /// Return the number of sub elements (for a mixed element)
     int num_sub_elements;
 
-    /// Indicates whether transformation data needs to be passed into various
-    /// functions
+    /// Indicates whether transformation data needs to be passed into
+    /// various functions
     bool needs_transformation_data;
 
     /// Get a finite element for sub element i (for a mixed
@@ -131,15 +131,14 @@ extern "C"
     /// Number of dofs with global support (i.e. global constants)
     int num_global_support_dofs;
 
-    /// Dimension of the local finite element function space
-    /// for a cell (not including global support dofs)
+    /// Dimension of the local finite element function space for a cell
+    /// (not including global support dofs)
     int num_element_support_dofs;
 
     /// Return the block size for a VectorElement or TensorElement
     int block_size;
 
-    /// Number of dofs associated with each cell entity of
-    /// dimension d
+    /// Number of dofs associated with each cell entity of dimension d
     int num_entity_dofs[4];
 
     /// Tabulate the local-to-local mapping of dofs on entity (d, i)
@@ -148,8 +147,7 @@ extern "C"
     /// Return the number of sub dofmaps (for a mixed element)
     int num_sub_dofmaps;
 
-    /// Get a dofmap for sub dofmap i (for a mixed
-    /// element).
+    /// Get a dofmap for sub dofmap i (for a mixed element)
     ufc_dofmap** sub_dofmaps;
 
   } ufc_dofmap;
@@ -158,48 +156,43 @@ extern "C"
   ///
   /// @param[out] A
   /// @param[in] w Coefficients attached to the form to which the
-  ///         tabulated integral belongs.
+  /// tabulated integral belongs.
   ///
-  ///         Dimensions: w[coefficient][restriction][dof].
+  /// Dimensions: w[coefficient][restriction][dof].
   ///
-  ///         Restriction dimension
-  ///         applies to interior facet integrals, where coefficients
-  ///         restricted to both cells sharing the facet must be
-  ///         provided.
+  /// Restriction dimension
+  /// applies to interior facet integrals, where coefficients restricted
+  /// to both cells sharing the facet must be provided.
   /// @param[in] c Constants attached to the form to which the tabulated
-  ///         integral belongs. Dimensions: c[constant][dim].
+  /// integral belongs. Dimensions: c[constant][dim].
   /// @param[in] coordinate_dofs Values of degrees of freedom of
-  ///         coordinate element. Defines the geometry of the cell.
-  ///         Dimensions: coordinate_dofs[restriction][num_dofs][gdim].
-  ///         Restriction dimension applies to interior facet integrals,
-  ///         where cell geometries for both cells sharing the facet
-  ///         must be provided.
+  /// coordinate element. Defines the geometry of the cell. Dimensions:
+  /// coordinate_dofs[restriction][num_dofs][3]. Restriction
+  /// dimension applies to interior facet integrals, where cell
+  /// geometries for both cells sharing the facet must be provided.
   /// @param[in] entity_local_index Local index of mesh entity on which
-  ///         to tabulate. This applies to facet integrals.
+  /// to tabulate. This applies to facet integrals.
   /// @param[in] quadrature_permutation For facet integrals, numbers to
-  ///         indicate the permutation to be applied to each side of the
-  ///         facet to make the orientations of the faces matched up
-  ///         should be passed in. If an integer of value N is passed
-  ///         in, then:
+  /// indicate the permutation to be applied to each side of the facet
+  /// to make the orientations of the faces matched up should be passed
+  /// in. If an integer of value N is passed in, then:
   ///
-  ///          - floor(N / 2) gives the number of rotations to apply to the
-  ///          facet
-  ///          - N % 2 gives the number of reflections to apply to the facet
+  ///  - floor(N / 2) gives the number of rotations to apply to the
+  ///  facet
+  ///  - N % 2 gives the number of reflections to apply to the facet
   ///
-  ///         For integrals not on facets, this argument has not effect
-  ///         and a null pointer can be passed. For
-  ///         interior facets the array will have size 2 (one permutation
-  ///         for each cell adjacent to the facet). For exterior facets,
-  ///         this will have size 1.
-  /// @param[in] cell_permutations An integer that says how each entity of the
-  ///         cell of dimension < tdim has been permuted relative to a
-  ///         low-to-high ordering of the cell. This bits of this integer
-  ///         represent (from least to most significant bits):
+  ///  For integrals not on facets, this argument has not effect and a
+  ///  null pointer can be passed. For interior facets the array will
+  ///  have size 2 (one permutation for each cell adjacent to the
+  ///  facet). For exterior facets, this will have size 1.
+  ///  @param[in] cell_permutations An integer that says how each entity
+  ///  of the cell of dimension < tdim has been permuted relative to a
+  ///  low-to-high ordering of the cell. This bits of this integer
+  ///  represent (from least to most significant bits):
   ///
-  ///          - Faces (3 bits each). Reflections are least significant bit,
-  ///          then next two bits give number of rotations.
-  ///          - Edges (1 bit each). The bit is 1 if the edge is reflected.
-  ///
+  ///  - Faces (3 bits each). Reflections are least significant bit,
+  ///  then next two bits give number of rotations.
+  ///  - Edges (1 bit each). The bit is 1 if the edge is reflected.
   typedef void(ufc_tabulate_tensor)(
       ufc_scalar_t* restrict A, const ufc_scalar_t* restrict w,
       const ufc_scalar_t* restrict c, const double* restrict coordinate_dofs,
@@ -235,20 +228,17 @@ extern "C"
   typedef struct ufc_expression
   {
 
-    /// Evaluate expression into tensor A with compiled evaluation points
+    /// Evaluate expression into tensor A with compiled evaluation
+    /// points
     ///
     /// @param[out] A
-    /// @param[in] w
-    ///         Coefficients attached to the expression.
-    ///         Dimensions: w[coefficient][dof].
-    /// @param[in] c
-    ///         Constants attached to the expression.
-    ///         Dimensions: c[constant][dim].
-    /// @param[in] coordinate_dofs
-    ///         Values of degrees of freedom of coordinate element.
-    ///         Defines the geometry of the cell.
-    ///         Dimensions: coordinate_dofs[num_dofs][gdim].
-    ///
+    /// @param[in] w Coefficients attached to the expression.
+    /// Dimensions: w[coefficient][dof].
+    /// @param[in] c Constants attached to the expression. Dimensions:
+    /// c[constant][dim].
+    /// @param[in] coordinate_dofs Values of degrees of freedom of
+    /// coordinate element. Defines the geometry of the cell.
+    /// Dimensions: coordinate_dofs[num_dofs][3].
     void (*tabulate_expression)(ufc_scalar_t* restrict A,
                                 const ufc_scalar_t* restrict w,
                                 const ufc_scalar_t* restrict c,
@@ -267,12 +257,12 @@ extern "C"
     /// reference cell
     int topological_dimension;
 
-    /// Coordinates of evaluations points.
-    /// Dimensions: points[num_points][topological_dimension].
+    /// Coordinates of evaluations points. Dimensions:
+    /// points[num_points][topological_dimension]
     const double* points;
 
-    /// Return shape of expression
-    /// Dimension: value_shape[num_components].
+    /// Return shape of expression. Dimension:
+    /// value_shape[num_components]
     const int* value_shape;
 
     /// Number of components of return_shape
@@ -316,22 +306,19 @@ extern "C"
     /// Return list of names of constants
     const char** (*constant_name_map)(void);
 
-    /// Get a finite element for the i-th argument function,
-    /// where 0 <= i < r+n.
+    /// Get a finite element for the i-th argument function, where 0 <=
+    /// i < r + n.
     ///
-    /// @param i
-    ///        Argument number if 0 <= i < r
-    ///        Coefficient number j=i-r if r+j <= i < r+n
-    ///
+    /// @param i Argument number if 0 <= i < r Coefficient number j = i
+    /// - r if r + j <= i < r + n
     ufc_finite_element** finite_elements;
 
-    /// Get a dofmap for the i-th argument function, where 0 <=
-    /// i < r+n.
+    /// Get a dofmap for the i-th argument function, where 0 <= i < r +
+    /// n.
     ///
     /// @param i
     ///        Argument number if 0 <= i < r
     ///        Coefficient number j=i-r if r+j <= i < r+n
-    ///
     ufc_dofmap** dofmaps;
 
     /// All ids for integrals
@@ -340,12 +327,12 @@ extern "C"
     /// Number of integrals
     int (*num_integrals)(ufc_integral_type);
 
-    /// Get an integral on sub domain subdomain_id.
+    /// Get an integral on sub domain subdomain_id
     ufc_integral** (*integrals)(ufc_integral_type);
 
   } ufc_form;
 
-  // FIXME: Formalise a UFC 'function space'.
+  // FIXME: Formalise a UFC 'function space'
   typedef struct ufc_function_space
   {
     ufc_finite_element* finite_element;

--- a/test/test_add_mode.py
+++ b/test/test_add_mode.py
@@ -57,7 +57,9 @@ def test_additive_facet_integral(mode, compile_args):
     facets = np.array([0], dtype=np.int32)
     perm = np.array([0], dtype=np.uint8)
 
-    coords = np.array([0.0, 2.0, np.sqrt(3.0), -1.0, -np.sqrt(3.0), -1.0], dtype=np.float64)
+    coords = np.array([0.0, 2.0, 0.0,
+                       np.sqrt(3.0), -1.0, 0.0,
+                       -np.sqrt(3.0), -1.0, 0.0], dtype=np.float64)
 
     for i in range(3):
         facets[0] = i

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -60,7 +60,6 @@ def test_matvec(compile_args):
     w = np.array(f_mat.T.flatten(), dtype=np_type)
     c = np.array([0.5], dtype=np_type)
 
-
     # Coords storage XYZXYZXYZ
     coords = np.array([[0.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0],

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -60,8 +60,8 @@ def test_matvec(compile_args):
     w = np.array(f_mat.T.flatten(), dtype=np_type)
     c = np.array([0.5], dtype=np_type)
 
-    # Coords storage XYXYXY
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    # Coords storage XYZXYZXYZ
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64)
     expression.tabulate_expression(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
@@ -115,8 +115,9 @@ def test_rank1(compile_args):
     w = np.array([0.0], dtype=np_type)
     c = np.array([0.0], dtype=np_type)
 
-    # Coords storage XYXYXY
-    coords = np.array(points.flatten(), dtype=np.float64)
+    # Coords storage XYZXYZXYZ
+    coords = np.zeros((points.shape[0], 3), dtype=np.float64)
+    coords[:, :2] = points
     expression.tabulate_expression(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -101,7 +101,7 @@ def test_rank1(compile_args):
 
     expr = ufl.as_vector([u[1], u[0]]) + ufl.grad(u[0])
 
-    points = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    points = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
     obj, module = ffcx.codegeneration.jit.compile_expressions([(expr, points)], cffi_extra_compile_args=compile_args)
 
     ffi = cffi.FFI()

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -67,7 +67,6 @@ def test_laplace_bilinear_form_2d(mode, expected_result, compile_args):
     kappa_value = np.array([[1.0, 2.0], [3.0, 4.0]])
     c = np.array(kappa_value.flatten(), dtype=np_type)
 
-
     coords = np.array([[0.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0],
                        [0.0, 1.0, 0.0]], dtype=np.float64)
@@ -513,7 +512,6 @@ def test_lagrange_triangle(compile_args, order, mode, sym_fun, ufl_fun):
     c_type, np_type = float_to_type(mode)
     b = np.zeros((order + 2) * (order + 1) // 2, dtype=np_type)
     w = np.array([], dtype=np_type)
-
 
     coords = np.array([[1.0, 0.0, 0.0],
                        [2.0, 0.0, 0.0],

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -67,7 +67,7 @@ def test_laplace_bilinear_form_2d(mode, expected_result, compile_args):
     kappa_value = np.array([[1.0, 2.0], [3.0, 4.0]])
     c = np.array(kappa_value.flatten(), dtype=np_type)
 
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64)
     default_integral.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
@@ -126,7 +126,7 @@ def test_mass_bilinear_form_2d(mode, expected_result, compile_args):
     c = np.array([], dtype=np_type)
 
     ffi = cffi.FFI()
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64)
     form0.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
@@ -178,7 +178,7 @@ def test_helmholtz_form_2d(mode, expected_result, compile_args):
     c = np.array([], dtype=np_type)
 
     ffi = cffi.FFI()
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64)
     form0.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
@@ -253,7 +253,7 @@ def test_form_coefficient(compile_args):
     perm = np.array([0], dtype=np.uint8)
 
     ffi = cffi.FFI()
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64)
     form0.tabulate_tensor(
         ffi.cast('double  *', A.ctypes.data),
         ffi.cast('double  *', w.ctypes.data),
@@ -329,8 +329,8 @@ def test_interior_facet_integral(mode, compile_args):
     facets = np.array([0, 2], dtype=np.intc)
     perms = np.array([0, 1], dtype=np.uint8)
 
-    coords = np.array([[0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
-                       [1.0, 0.0, 0.0, 1.0, 1.0, 1.0]], dtype=np.float64)
+    coords = np.array([[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+                       [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0]], dtype=np.float64)
 
     integral0.tabulate_tensor(
         ffi.cast('{}  *'.format(c_type), A.ctypes.data),
@@ -370,7 +370,7 @@ def test_conditional(mode, compile_args):
     w1 = np.array([1.0, 1.0, 1.0], dtype=np_type)
     c = np.array([], dtype=np.float64)
 
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64)
 
     form0.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A1.ctypes.data),
@@ -383,7 +383,6 @@ def test_conditional(mode, compile_args):
 
     A2 = np.zeros(3, dtype=np_type)
     w2 = np.array([1.0, 1.0, 1.0], dtype=np_type)
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
 
     form1.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), A2.ctypes.data),
@@ -419,7 +418,7 @@ def test_custom_quadrature(compile_args):
     w = np.array([], dtype=np.float64)
     c = np.array([], dtype=np.float64)
 
-    coords = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    coords = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64)
     default_integral.tabulate_tensor(
         ffi.cast("double *", A.ctypes.data),
         ffi.cast("double *", w.ctypes.data),
@@ -499,7 +498,7 @@ def test_lagrange_triangle(compile_args, order, mode, sym_fun, ufl_fun):
     b = np.zeros((order + 2) * (order + 1) // 2, dtype=np_type)
     w = np.array([], dtype=np_type)
 
-    coords = np.array([1.0, 0.0, 2.0, 0.0, 0.0, 1.0], dtype=np.float64)
+    coords = np.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64)
     default_integral.tabulate_tensor(
         ffi.cast('{type} *'.format(type=c_type), b.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),


### PR DESCRIPTION
This permits a number of optimisation on the DOLFINx side when copying mesh geometry data.

Fixes #152.