### PR TITLE
Entity DOFs for quadrature element

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: mscrogs/entity_dofs
+          ref: mscroggs/get_entity_dofs_from_basix
       - name: Clone and install DOLFINx
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/ffcx/codegeneration/dofmap_template.py
+++ b/ffcx/codegeneration/dofmap_template.py
@@ -12,22 +12,12 @@ factory = """
 
 {sub_dofmaps_initialization}
 
-void tabulate_entity_dofs_{factory_name}(int* restrict dofs, int d, int i)
-{{
-{tabulate_entity_dofs}
-}}
-
 ufc_dofmap {factory_name} =
 {{
   .signature = {signature},
   .block_size = {block_size},
   .num_global_support_dofs = {num_global_support_dofs},
   .num_element_support_dofs = {num_element_support_dofs},
-  .num_entity_dofs[0] = {num_entity_dofs[0]},
-  .num_entity_dofs[1] = {num_entity_dofs[1]},
-  .num_entity_dofs[2] = {num_entity_dofs[2]},
-  .num_entity_dofs[3] = {num_entity_dofs[3]},
-  .tabulate_entity_dofs = tabulate_entity_dofs_{factory_name},
   .num_sub_dofmaps = {num_sub_dofmaps},
   .sub_dofmaps = {sub_dofmaps}
 }};

--- a/ffcx/codegeneration/finite_element.py
+++ b/ffcx/codegeneration/finite_element.py
@@ -17,6 +17,44 @@ logger = logging.getLogger("ffcx")
 index_type = "int"
 
 
+def tabulate_entity_dofs(L, entity_dofs, num_dofs_per_entity):
+    # Output argument array
+    dofs = L.Symbol("dofs")
+
+    # Input arguments
+    d = L.Symbol("d")
+    i = L.Symbol("i")
+
+    # TODO: Removed check for (d <= tdim + 1)
+    tdim = len(num_dofs_per_entity) - 1
+
+    # Generate cases for each dimension:
+    all_cases = []
+    for dim in range(tdim + 1):
+
+        # Ignore if no entities for this dimension
+        if num_dofs_per_entity[dim] == 0:
+            continue
+
+        # Generate cases for each mesh entity
+        cases = []
+        for entity in range(len(entity_dofs[dim])):
+            casebody = []
+            for (j, dof) in enumerate(entity_dofs[dim][entity]):
+                casebody += [L.Assign(dofs[j], dof)]
+            cases.append((entity, L.StatementList(casebody)))
+
+        # Generate inner switch
+        # TODO: Removed check for (i <= num_entities-1)
+        inner_switch = L.Switch(i, cases, autoscope=False)
+        all_cases.append((dim, inner_switch))
+
+    if all_cases:
+        return L.Switch(d, all_cases, autoscope=False)
+    else:
+        return L.NoOp()
+
+
 def generator(ir, parameters):
     """Generate UFC code for a finite element."""
     logger.info("Generating code for finite element:")
@@ -61,6 +99,17 @@ def generator(ir, parameters):
         d["reference_value_shape"] = "NULL"
         d["reference_value_shape_init"] = ""
 
+    if ir.tabulate_entity_dofs is None:
+        d["num_entity_dofs"] = [-1, -1, -1, -1]
+        d["tabulate_entity_dofs"] = L.NoOp()
+        d["num_entity_closure_dofs"] = [-1, -1, -1, -1]
+        d["tabulate_entity_closure_dofs"] = L.NoOp()
+    else:
+        d["num_entity_dofs"] = ir.num_entity_dofs + [0, 0, 0, 0]
+        d["tabulate_entity_dofs"] = tabulate_entity_dofs(L, *ir.tabulate_entity_dofs)
+        d["num_entity_closure_dofs"] = ir.num_entity_closure_dofs + [0, 0, 0, 0]
+        d["tabulate_entity_closure_dofs"] = tabulate_entity_dofs(L, *ir.tabulate_entity_closure_dofs)
+
     if len(ir.sub_elements) > 0:
         d["sub_elements"] = f"sub_elements_{ir.name}"
         d["sub_elements_init"] = L.ArrayDecl(
@@ -73,8 +122,9 @@ def generator(ir, parameters):
     # Check that no keys are redundant or have been missed
     from string import Formatter
     fieldnames = [
-        fname for _, fname, _, _ in Formatter().parse(ufc_finite_element.factory) if fname
+        fname.split("[")[0] for _, fname, _, _ in Formatter().parse(ufc_finite_element.factory) if fname
     ]
+
     assert set(fieldnames) == set(
         d.keys()), "Mismatch between keys in template and in formattting dict"
 

--- a/ffcx/codegeneration/finite_element_template.py
+++ b/ffcx/codegeneration/finite_element_template.py
@@ -14,6 +14,16 @@ factory = """
 {reference_value_shape_init}
 {sub_elements_init}
 
+void tabulate_entity_dofs_{factory_name}(int* restrict dofs, int d, int i)
+{{
+{tabulate_entity_dofs}
+}}
+
+void tabulate_entity_closure_dofs_{factory_name}(int* restrict dofs, int d, int i)
+{{
+{tabulate_entity_closure_dofs}
+}}
+
 ufc_finite_element {factory_name} =
 {{
   .signature = {signature},
@@ -31,7 +41,16 @@ ufc_finite_element {factory_name} =
   .degree = {degree},
   .family = {family},
   .block_size = {block_size},
-
+  .tabulate_entity_dofs = tabulate_entity_dofs_{factory_name},
+  .num_entity_dofs[0] = {num_entity_dofs[0]},
+  .num_entity_dofs[1] = {num_entity_dofs[1]},
+  .num_entity_dofs[2] = {num_entity_dofs[2]},
+  .num_entity_dofs[3] = {num_entity_dofs[3]},
+  .tabulate_entity_closure_dofs = tabulate_entity_closure_dofs_{factory_name},
+  .num_entity_closure_dofs[0] = {num_entity_closure_dofs[0]},
+  .num_entity_closure_dofs[1] = {num_entity_closure_dofs[1]},
+  .num_entity_closure_dofs[2] = {num_entity_closure_dofs[2]},
+  .num_entity_closure_dofs[3] = {num_entity_closure_dofs[3]},
   .num_sub_elements = {num_sub_elements},
   .sub_elements = {sub_elements}
 }};

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -126,6 +126,22 @@ extern "C"
     /// Return the number of sub elements (for a mixed element)
     int num_sub_elements;
 
+    /// Number of dofs associated with each cell entity of dimension d.
+    /// This will only be set for quadrature elements and custom elements.
+    int num_entity_dofs[4];
+
+    /// Tabulate the local-to-local mapping of dofs on entity (d, i).
+    /// This will only be set for quadrature elements and custom elements.
+    void (*tabulate_entity_dofs)(int* restrict dofs, int d, int i);
+
+    /// Number of dofs associated with the closure of each cell entity of dimension d.
+    /// This will only be set for quadrature elements and custom elements.
+    int num_entity_closure_dofs[4];
+
+    /// Tabulate the local-to-local mapping of dofs on the closure of entity (d, i).
+    /// This will only be set for quadrature elements and custom elements.
+    void (*tabulate_entity_closure_dofs)(int* restrict dofs, int d, int i);
+
     /// Get a finite element for sub element i (for a mixed
     /// element).
     ufc_finite_element** sub_elements;
@@ -134,9 +150,11 @@ extern "C"
 
   typedef struct ufc_dofmap
   {
-
     /// Return a string identifying the dofmap
     const char* signature;
+
+    /// Return the block size for a VectorElement or TensorElement
+    int block_size;
 
     /// Number of dofs with global support (i.e. global constants)
     int num_global_support_dofs;
@@ -144,15 +162,6 @@ extern "C"
     /// Dimension of the local finite element function space for a cell
     /// (not including global support dofs)
     int num_element_support_dofs;
-
-    /// Return the block size for a VectorElement or TensorElement
-    int block_size;
-
-    /// Number of dofs associated with each cell entity of dimension d
-    int num_entity_dofs[4];
-
-    /// Tabulate the local-to-local mapping of dofs on entity (d, i)
-    void (*tabulate_entity_dofs)(int* restrict dofs, int d, int i);
 
     /// Return the number of sub dofmaps (for a mixed element)
     int num_sub_dofmaps;

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -41,7 +41,8 @@ ir_form = namedtuple('ir_form', [
 ir_element = namedtuple('ir_element', [
     'id', 'name', 'signature', 'cell_shape', 'topological_dimension',
     'geometric_dimension', 'space_dimension', 'value_shape', 'reference_value_shape', 'degree',
-    'family', 'num_sub_elements', 'block_size', 'sub_elements', 'element_type', 'entity_dofs'])
+    'family', 'num_sub_elements', 'block_size', 'sub_elements', 'element_type', 'entity_dofs',
+    'tabulate_entity_dofs', 'num_entity_dofs', 'tabulate_entity_closure_dofs', 'num_entity_closure_dofs'])
 ir_dofmap = namedtuple('ir_dofmap', [
     'id', 'name', 'signature', 'num_global_support_dofs', 'num_element_support_dofs', 'num_entity_dofs',
     'tabulate_entity_dofs', 'num_sub_dofmaps', 'sub_dofmaps', 'block_size'])
@@ -135,6 +136,19 @@ def _compute_element_ir(ufl_element, element_numbers, finite_element_names):
 
     ir["num_sub_elements"] = ufl_element.num_sub_elements()
     ir["sub_elements"] = [finite_element_names[e] for e in ufl_element.sub_elements()]
+
+    if basix_element.element_type == "ufc_quadrature_element":
+        num_dofs_per_entity = [i[0] for i in basix_element.num_entity_dofs]
+        ir["num_entity_dofs"] = num_dofs_per_entity
+        ir["tabulate_entity_dofs"] = (basix_element.entity_dofs, num_dofs_per_entity)
+        num_dofs_per_entity_closure = [i[0] for i in basix_element.num_entity_closure_dofs]
+        ir["num_entity_closure_dofs"] = num_dofs_per_entity_closure
+        ir["tabulate_entity_closure_dofs"] = (basix_element.entity_closure_dofs, num_dofs_per_entity_closure)
+    else:
+        ir["num_entity_dofs"] = None
+        ir["tabulate_entity_dofs"] = None
+        ir["num_entity_closure_dofs"] = None
+        ir["tabulate_entity_closure_dofs"] = None
 
     if hasattr(basix_element, "block_size"):
         ir["block_size"] = basix_element.block_size

--- a/test/test_blocked_elements.py
+++ b/test/test_blocked_elements.py
@@ -31,15 +31,6 @@ def test_finite_element(compile_args):
     assert ufc_dofmap.num_global_support_dofs == 0
     assert ufc_dofmap.num_global_support_dofs == 0
     assert ufc_dofmap.num_element_support_dofs == 3
-    assert ufc_dofmap.num_entity_dofs[0] == 1
-    assert ufc_dofmap.num_entity_dofs[1] == 0
-    assert ufc_dofmap.num_entity_dofs[2] == 0
-    assert ufc_dofmap.num_entity_dofs[3] == 0
-    for v in range(3):
-        vals = np.zeros(1, dtype=np.int32)
-        vals_ptr = module.ffi.cast("int *", module.ffi.from_buffer(vals))
-        ufc_dofmap.tabulate_entity_dofs(vals_ptr, 0, v)
-        assert vals[0] == v
     assert ufc_dofmap.num_sub_dofmaps == 0
 
 
@@ -65,15 +56,6 @@ def test_vector_element(compile_args):
     assert ufc_dofmap.num_global_support_dofs == 0
     assert ufc_dofmap.num_global_support_dofs == 0
     assert ufc_dofmap.num_element_support_dofs == 3
-    assert ufc_dofmap.num_entity_dofs[0] == 1
-    assert ufc_dofmap.num_entity_dofs[1] == 0
-    assert ufc_dofmap.num_entity_dofs[2] == 0
-    assert ufc_dofmap.num_entity_dofs[3] == 0
-    for v in range(3):
-        vals = np.zeros(1, dtype=np.int32)
-        vals_ptr = module.ffi.cast("int *", module.ffi.from_buffer(vals))
-        ufc_dofmap.tabulate_entity_dofs(vals_ptr, 0, v)
-        assert vals[0] == v
     assert ufc_dofmap.num_sub_dofmaps == 2
 
 
@@ -101,13 +83,4 @@ def test_tensor_element(compile_args):
     assert ufc_dofmap.num_global_support_dofs == 0
     assert ufc_dofmap.num_global_support_dofs == 0
     assert ufc_dofmap.num_element_support_dofs == 3
-    assert ufc_dofmap.num_entity_dofs[0] == 1
-    assert ufc_dofmap.num_entity_dofs[1] == 0
-    assert ufc_dofmap.num_entity_dofs[2] == 0
-    assert ufc_dofmap.num_entity_dofs[3] == 0
-    for v in range(3):
-        vals = np.zeros(1, dtype=np.int32)
-        vals_ptr = module.ffi.cast("int *", module.ffi.from_buffer(vals))
-        ufc_dofmap.tabulate_entity_dofs(vals_ptr, 0, v)
-        assert vals[0] == v
     assert ufc_dofmap.num_sub_dofmaps == 4


### PR DESCRIPTION
These changes follow on from #365, but I'm less sure about these.

These changes add entity dofs and entity closure dofs to `ufc_finite_element` (for quadrature elements only).

This allows FEniCS/dolfinx#1585 to be done.

This PR is into my other PR so we can either merge this with those changes, or merge that and rework this afterwards.