### PR TITLE
Replace int num_entity_dofs[4] with int *num_entity_dofs

### DIFF
--- a/ffcx/codegeneration/dofmap.py
+++ b/ffcx/codegeneration/dofmap.py
@@ -67,7 +67,15 @@ def generator(ir, parameters):
     d["num_global_support_dofs"] = ir.num_global_support_dofs
     d["num_element_support_dofs"] = ir.num_element_support_dofs
     d["num_sub_dofmaps"] = ir.num_sub_dofmaps
-    d["num_entity_dofs"] = ir.num_entity_dofs + [0, 0, 0, 0]
+
+    import ffcx.codegeneration.C.cnodes as L
+
+    num_entity_dofs = ir.num_entity_dofs + [0, 0, 0, 0]
+    num_entity_dofs = num_entity_dofs[:4]
+    d["num_entity_dofs"] = f"num_entity_dofs_{ir.name}"
+    d["num_entity_dofs_init"] = L.ArrayDecl("int", f"num_entity_dofs_{ir.name}",
+                                            values=num_entity_dofs, sizes=4)
+
     d["block_size"] = ir.block_size
 
     import ffcx.codegeneration.C.cnodes as L

--- a/ffcx/codegeneration/dofmap.py
+++ b/ffcx/codegeneration/dofmap.py
@@ -78,8 +78,6 @@ def generator(ir, parameters):
 
     d["block_size"] = ir.block_size
 
-    import ffcx.codegeneration.C.cnodes as L
-
     # Functions
     d["tabulate_entity_dofs"] = tabulate_entity_dofs(L, ir)
 

--- a/ffcx/codegeneration/dofmap_template.py
+++ b/ffcx/codegeneration/dofmap_template.py
@@ -17,16 +17,15 @@ void tabulate_entity_dofs_{factory_name}(int* restrict dofs, int d, int i)
 {tabulate_entity_dofs}
 }}
 
+{num_entity_dofs_init}
+
 ufc_dofmap {factory_name} =
 {{
   .signature = {signature},
   .num_global_support_dofs = {num_global_support_dofs},
   .num_element_support_dofs = {num_element_support_dofs},
   .block_size = {block_size},
-  .num_entity_dofs[0] = {num_entity_dofs[0]},
-  .num_entity_dofs[1] = {num_entity_dofs[1]},
-  .num_entity_dofs[2] = {num_entity_dofs[2]},
-  .num_entity_dofs[3] = {num_entity_dofs[3]},
+  .num_entity_dofs = {num_entity_dofs},
   .tabulate_entity_dofs = tabulate_entity_dofs_{factory_name},
   .num_sub_dofmaps = {num_sub_dofmaps},
   .sub_dofmaps = {sub_dofmaps}

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -149,7 +149,7 @@ extern "C"
     int block_size;
 
     /// Number of dofs associated with each cell entity of dimension d
-    int num_entity_dofs[4];
+    int *num_entity_dofs;
 
     /// Tabulate the local-to-local mapping of dofs on entity (d, i)
     void (*tabulate_entity_dofs)(int* restrict dofs, int d, int i);


### PR DESCRIPTION
This is a more consistent way of creating static arrays (existing code triggers a warning with clang++)
