### PR TITLE
Prevent global Jacobian derivatives being interpreted as local derivatives

### DIFF
--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -160,7 +160,6 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
         do_apply_function_pullbacks=True,
         do_apply_integral_scaling=True,
         do_apply_geometry_lowering=True,
-        preserve_geometry_types=(ufl.classes.Jacobian, ),
         do_apply_restrictions=True,
         do_append_everywhere_integrals=False,  # do not add dx integrals to dx(i) in UFL
         complex_mode=complex_mode)

--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -201,13 +201,13 @@ def get_modified_terminal_element(mt):
     elif isinstance(mt.terminal, ufl.classes.Jacobian):
         if mt.reference_value:
             raise RuntimeError("Not expecting reference value of J.")
-
+        if gd:
+            raise RuntimeError("Not expecting global derivatives of J.")
         element = mt.terminal.ufl_domain().ufl_coordinate_element()
         assert len(mt.component) == 2
         # Translate component J[i,d] to x element context rgrad(x[i])[d]
         fc, d = mt.component  # x-component, derivative
 
-        # Grad(Jacobian(...)) should be a local derivative
         ld = tuple(sorted((d, ) + gd + ld))
     else:
         return None


### PR DESCRIPTION
This PR stops global Jacobian derivatives being interpreted as local derivatives and fixes https://github.com/FEniCS/ffcx/issues/373. An alternative approach to removing  `preserve_geometry_types=(ufl.classes.Jacobian, ),` would be to modify UFL such that `preprocessed_form` contains local Jacobian derivatives instead of global derivatives, as described here https://github.com/FEniCS/ufl/issues/62.