### PR TITLE
Pad loops, not only tables

### DIFF
--- a/demo/Poisson.ufl
+++ b/demo/Poisson.ufl
@@ -20,7 +20,7 @@
 #
 # Compile this form with FFCx: ffcx Poisson.ufl
 
-element = FiniteElement("Lagrange", triangle, 1)
+element = FiniteElement("Lagrange", tetrahedron, 4)
 
 u = TrialFunction(element)
 v = TestFunction(element)

--- a/demo/Poisson.ufl
+++ b/demo/Poisson.ufl
@@ -20,7 +20,7 @@
 #
 # Compile this form with FFCx: ffcx Poisson.ufl
 
-element = FiniteElement("Lagrange", tetrahedron, 4)
+element = FiniteElement("Lagrange", tetrahedron, 1)
 
 u = TrialFunction(element)
 v = TestFunction(element)

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -135,7 +135,7 @@ class FFCXBackendDefinitions(object):
         dof_access = self.symbols.domain_dofs_access(gdim, num_scalar_dofs, mt.restriction)
 
         if tabledata.is_piecewise:
-            terms = []       
+            terms = []
             for i, idof in enumerate(tabledata.dofmap):
                 basis_value = tabledata.values[0][0][0][i]
                 if basis_value:

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -138,15 +138,7 @@ class FFCXBackendDefinitions(object):
         # Inlined version (we know this is bounded by a small number)
         dof_access = self.symbols.domain_dofs_access(gdim, num_scalar_dofs, mt.restriction)
 
-        if tabledata.is_piecewise:
-            terms = []
-            for i, idof in enumerate(tabledata.dofmap):
-                basis_value = tabledata.values[0][0][0][i]
-                if basis_value:
-                    terms.append(dof_access[idof] * basis_value)
-            value = L.Sum(terms)
-        else:
-            value = L.Sum([dof_access[idof] * FE[i] for i, idof in enumerate(tabledata.dofmap)])
+        value = L.Sum([dof_access[idof] * FE[i] for i, idof in enumerate(tabledata.dofmap)])
         code = [L.VariableDecl("const double", access, value)]
 
         return code

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -133,7 +133,16 @@ class FFCXBackendDefinitions(object):
 
         # Inlined version (we know this is bounded by a small number)
         dof_access = self.symbols.domain_dofs_access(gdim, num_scalar_dofs, mt.restriction)
-        value = L.Sum([dof_access[idof] * FE[i] for i, idof in enumerate(tabledata.dofmap)])
+
+        if tabledata.is_piecewise:
+            terms = []       
+            for i, idof in enumerate(tabledata.dofmap):
+                basis_value = tabledata.values[0][0][0][i]
+                if basis_value:
+                    terms.append(dof_access[idof] * basis_value)
+            value = L.Sum(terms)
+        else:
+            value = L.Sum([dof_access[idof] * FE[i] for i, idof in enumerate(tabledata.dofmap)])
         code = [L.VariableDecl("const double", access, value)]
 
         return code

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -508,7 +508,8 @@ class IntegralGenerator(object):
             arg_factors.append(arg_factor)
         return arg_factors
 
-    def generate_block_parts(self, quadrature_rule: QuadratureRule, blockmap: Tuple, blocklist: List[block_data_t], padlen: int):
+    def generate_block_parts(self, quadrature_rule: QuadratureRule, blockmap: Tuple,
+                             blocklist: List[block_data_t], padlen: int):
         """Generate and return code parts for a given block.
 
         Returns parts occuring before, inside, and after the quadrature loop identified by the quadrature rule.

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -314,13 +314,13 @@ class IntegralGenerator(object):
     def generate_quadrature_loop(self, quadrature_rule: QuadratureRule):
         """Generate quadrature loop with for this quadrature_rule."""
         L = self.backend.language
+        padlen = self.ir.params["padlen"]
 
         # Generate varying partition
         body = self.generate_varying_partition(quadrature_rule)
+
         body = L.commented_code_list(
             body, f"Quadrature loop body setup for quadrature rule {quadrature_rule.id()}")
-
-        padlen = self.ir.params["padlen"]
 
         # Generate dofblock parts, some of this will be placed before or
         # after quadloop
@@ -367,12 +367,12 @@ class IntegralGenerator(object):
 
     def generate_partition(self, symbol, F, mode, quadrature_rule):
         L = self.backend.language
+        padlen = self.ir.params["padlen"]
 
         definitions = dict()
         intermediates = []
 
         use_symbol_array = True
-
         for i, attr in F.nodes.items():
             if attr['status'] != mode:
                 continue
@@ -393,7 +393,6 @@ class IntegralGenerator(object):
                     # Backend specific modified terminal translation
                     vaccess = self.backend.access.get(mt.terminal, mt, tabledata, quadrature_rule)
                     vdef = self.backend.definitions.get(mt.terminal, mt, tabledata, quadrature_rule, vaccess)
-
                     # Store definitions of terminals in list
                     assert isinstance(vdef, list)
                     definitions[str(vaccess)] = vdef
@@ -451,9 +450,9 @@ class IntegralGenerator(object):
                 parts += definition
         if intermediates:
             if use_symbol_array:
-                padlen = self.ir.params["padlen"]
                 parts += [L.ArrayDecl("ufc_scalar_t", symbol, len(intermediates), padlen=padlen)]
             parts += intermediates
+
         return parts
 
     def generate_dofblock_partition(self, quadrature_rule: QuadratureRule, padlen: int):

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -525,7 +525,7 @@ class IntegralGenerator(object):
         blockdims = list(len(dofmap) for dofmap in blockmap)
 
         for i in range(len(blockdims)):
-            blockdims[i] =  blockdims[i] + blockdims[i] % padlen
+            blockdims[i] = blockdims[i] + (padlen - blockdims[i] % padlen) % padlen
 
         iq = self.backend.symbols.quadrature_loop_index()
 

--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -357,6 +357,7 @@ def build_optimized_tables(quadrature_rule,
         # Clean up table
         tbl = clamp_table_small_numbers(t['array'], rtol=rtol, atol=atol)
         tabletype = analyse_table_type(tbl)
+
         if tabletype in piecewise_ttypes:
             # Reduce table to dimension 1 along num_points axis in generated code
             tbl = tbl[:, :, :1, :]
@@ -465,4 +466,5 @@ def analyse_table_type(table, rtol=default_rtol, atol=default_atol):
         else:
             # Varying over points and entities
             ttype = "varying"
+
     return ttype


### PR DESCRIPTION
We have the option of padding arrays:
```
--padlen PADLEN       Pads every declared array in tabulation kernel such that its last dimension is divisible by given value. (default=1)
```

But in general that's not really helpful if we don't adjuts the loop bounds.
The idea of this PR is to adjust these bounds, in special inner loops that can be vectorized.

For two dimensional structures [m*n] pad only the  leading dimension: 
```
p = m + (padlen - m%padlen)%padlen
A[n*(m+p)]
```
