### PR TITLE
Improvements in code generation for Vector Elements

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -3,9 +3,9 @@
 name: DOLFINx integration
 
 on:
-  push:
+  pull_request:
     branches:
-      - "**"
+      - main
 
 jobs:
   build:

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -3,9 +3,9 @@
 name: DOLFINx integration
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
+      - "**"
 
 jobs:
   build:

--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -383,6 +383,9 @@ class Symbol(CExprTerminal):
     def __eq__(self, other):
         return isinstance(other, Symbol) and self.name == other.name
 
+    def __hash__(self):
+        return hash(self.ce_format())
+
 
 # CExprOperator base classes
 
@@ -452,6 +455,9 @@ class BinOp(CExprOperator):
 
     def __eq__(self, other):
         return (isinstance(other, type(self)) and self.lhs == other.lhs and self.rhs == other.rhs)
+
+    def __hash__(self):
+        return hash(self.ce_format())
 
 
 class NaryOp(CExprOperator):

--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -67,7 +67,9 @@ class FFCXBackendAccess(object):
         ttype = tabledata.ttype
         assert ttype != "zeros"
 
-        begin, end = tabledata.dofrange
+        num_dofs = tabledata.values.shape[3]
+        begin = tabledata.offset
+        end = begin + tabledata.block_size * (num_dofs - 1) + 1
 
         if ttype == "ones" and (end - begin) == 1:
             # f = 1.0 * f_{begin}, just return direct reference to dof

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -76,7 +76,7 @@ class FFCXBackendDefinitions(object):
             return []
 
         # For a constant coefficient we reference the dofs directly, so no definition needed
-        if ttype == "ones" and (end - begin == 1):
+        if ttype == "ones" and end - begin == 1:
             return []
 
         assert begin < end

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -87,9 +87,9 @@ class FFCXBackendDefinitions(object):
         ic = self.symbols.coefficient_dof_sum_index()
         dof_access = self.symbols.coefficient_dof_access(mt.terminal, ic * bs + begin)
         code = []
-        
+
         body = [L.AssignAdd(access, dof_access * FE[ic])]
-        
+
         code += [L.VariableDecl("ufc_scalar_t", access, 0.0)]
         code += [L.ForRange(ic, 0, num_dofs, body)]
 

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -117,19 +117,17 @@ class FFCXBackendDefinitions(object):
         # Find table name
         ttype = tabledata.ttype
 
-        # assert len(tabledata.dofmap) <= num_scalar_dofs
         assert ttype != "zeros"
         assert ttype != "ones"
 
         begin = tabledata.offset
         num_dofs = tabledata.values.shape[3]
-        dofmap = tuple(begin + i * tabledata.block_size for i in range(num_dofs))
-
-        FE = self.symbols.element_table(tabledata, self.entitytype, mt.restriction)
+        bs = tabledata.block_size
 
         # Inlined version (we know this is bounded by a small number)
+        FE = self.symbols.element_table(tabledata, self.entitytype, mt.restriction)
         dof_access = self.symbols.domain_dofs_access(gdim, num_scalar_dofs, mt.restriction)
-        value = L.Sum([dof_access[idof] * FE[i] for i, idof in enumerate(dofmap)])
+        value = L.Sum([dof_access[begin + i * bs] * FE[i] for i in range(num_dofs)])
         code = [L.VariableDecl("const double", access, value)]
 
         return code

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -570,8 +570,6 @@ class IntegralGenerator(object):
                 weight = weights[iq]
 
             # Define fw = f * weight
-            assert not blockdata.transposed, "Not handled yet"
-
             fw_rhs = L.float_product([f, weight])
             if not isinstance(fw_rhs, L.Product):
                 fw = fw_rhs
@@ -582,7 +580,7 @@ class IntegralGenerator(object):
                 if not defined:
                     quadparts.append(L.VariableDecl("const ufc_scalar_t", fw, fw_rhs))
 
-            assert not blockdata.transposed
+            assert not blockdata.transposed, "Not handled yet"
             A_shape = self.ir.tensor_shape
 
             Asym = self.backend.symbols.element_tensor()
@@ -594,14 +592,14 @@ class IntegralGenerator(object):
             B_rhs = L.float_product([fw] + arg_factors)
 
             A_indices = []
-            for bm, index in zip(blockmap, arg_indices):
-                offset = blockdata.ma_data[0].tabledata.offset
-                if len(bm) == 1:
+            for i in range(block_rank):
+                offset = blockdata.ma_data[i].tabledata.offset
+                index = arg_indices[i]
+                if len(blockmap[i]) == 1:
                     A_indices.append(index + offset)
                 else:
-                    block_size = blockdata.ma_data[0].tabledata.block_size
+                    block_size = blockdata.ma_data[i].tabledata.block_size
                     A_indices.append(block_size * index + offset)
-
             rhs_expressions[tuple(A_indices)].append(B_rhs)
 
         # List of statements to keep in the inner loop

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -656,8 +656,8 @@ class IntegralGenerator(object):
 
         body = []
 
-        for indices in rhs_expressions:
-            sum = L.Sum(rhs_expressions[indices])
+        for indices in keep:
+            sum = L.Sum(keep[indices])
             body.append(L.AssignAdd(A[indices], sum))
 
         for i in reversed(range(block_rank)):

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -469,14 +469,14 @@ class IntegralGenerator(object):
         # Group loops by blockmap, in Vector elements each component has
         # a different blockmap
         for blockmap, blockdata in blocks:
-            new_blockmap = []
+            scalar_blockmap = []
             assert len(blockdata.ma_data) == len(blockmap)
             for i, b in enumerate(blockmap):
                 bs = blockdata.ma_data[i].tabledata.block_size
                 offset = blockdata.ma_data[i].tabledata.offset
                 b = tuple([(idx - offset) // bs for idx in b])
-                new_blockmap.append(b)
-            block_groups[tuple(new_blockmap)].append(blockdata)
+                scalar_blockmap.append(b)
+            block_groups[tuple(scalar_blockmap)].append(blockdata)
 
         for blockmap in block_groups:
             block_preparts, block_quadparts = \

--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -386,8 +386,6 @@ def build_optimized_tables(
             # offset = 0 or number of element dofs, if restricted to "-"
             cell_offset = basix_element.dim
 
-        # dofmap = tuple(offset + i * block_size for i in range(tbl.shape[3]))
-
         offset = cell_offset + t['offset']
         block_size = t['stride']
 

--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -28,8 +28,8 @@ uniform_ttypes = ("fixed", "ones", "zeros", "uniform")
 
 unique_table_reference_t = collections.namedtuple(
     "unique_table_reference",
-    ["name", "values", "dofrange", "dofmap", "ttype", "is_piecewise", "is_uniform",
-     "is_permuted"])
+    ["name", "values", "offset", "block_size", "ttype",
+     "is_piecewise", "is_uniform", "is_permuted"])
 
 
 def equal_tables(a, b, rtol=default_rtol, atol=default_atol):
@@ -386,12 +386,14 @@ def build_optimized_tables(
             # offset = 0 or number of element dofs, if restricted to "-"
             cell_offset = basix_element.dim
 
-        num_dofs = tbl.shape[3]
-        dofmap = tuple(cell_offset + t['offset'] + i * t['stride'] for i in range(num_dofs))
+        # dofmap = tuple(offset + i * block_size for i in range(tbl.shape[3]))
+
+        offset = cell_offset + t['offset']
+        block_size = t['stride']
 
         # tables is just np.arrays, mt_tables hold metadata too
         mt_tables[mt] = unique_table_reference_t(
-            name, tbl, tuple((dofmap[0], dofmap[-1] + 1)), dofmap, tabletype,
+            name, tbl, offset, block_size, tabletype,
             tabletype in piecewise_ttypes, tabletype in uniform_ttypes, is_permuted)
 
     return mt_tables

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -184,7 +184,6 @@ def compute_integral_ir(cell, integral_type, entitytype, integrands, argument_sh
             assert not any(tt == "zeros" for tt in ttypes)
 
             blockmap = []
-
             for tr in trs:
                 begin = tr.offset
                 num_dofs = tr.values.shape[3]

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -182,7 +182,15 @@ def compute_integral_ir(cell, integral_type, entitytype, integrands, argument_sh
             ttypes = tuple(tr.ttype for tr in trs)
             assert not any(tt == "zeros" for tt in ttypes)
 
-            blockmap = tuple(tr.dofmap for tr in trs)
+            blockmap = []
+
+            for tr in trs:
+                begin = tr.offset
+                num_dofs = tr.values.shape[3]
+                dofmap = tuple(begin + i * tr.block_size for i in range(num_dofs))
+                blockmap.append(dofmap)
+
+            blockmap = tuple(blockmap)
             block_is_uniform = all(tr.is_uniform for tr in trs)
 
             # Collect relevant restrictions to identify blocks correctly

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -25,6 +25,7 @@ from ufl.classes import QuadratureWeight
 
 logger = logging.getLogger("ffcx")
 
+# FIXME: What's ma?
 ma_data_t = collections.namedtuple("ma_data_t", ["ma_index", "tabledata"])
 
 block_data_t = collections.namedtuple("block_data_t",


### PR DESCRIPTION
First steps in optimizing the generated code for vector elements:
- Group expressions by "scalar dofmap" (same table, same blocksize, different offset).
- Identify "block" invariant code.


Limitations:
Array of Structures `XYZXYZXYZ` impairs vectorization efficiency. 

Example Elasticity.ufl (100'000 cells):

![elasticity2](https://user-images.githubusercontent.com/15614155/129531119-aaf3c7b3-10cf-45a2-a818-c09af6baacd6.png)
![elasticity3](https://user-images.githubusercontent.com/15614155/129531120-f9bfe769-d296-40ce-bbd1-438ecb445fd0.png)
![elasticity4](https://user-images.githubusercontent.com/15614155/129531122-7cddb6fd-ed2d-415d-be0d-4fa0bd8741a9.png)

No difference for degree 1.
