### PR TITLE
Move warning to quadrature creation

### DIFF
--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -13,7 +13,6 @@ representation type.
 
 import logging
 import typing
-import warnings
 from collections import namedtuple
 
 import numpy
@@ -203,16 +202,6 @@ def _analyze_form(form: ufl.form.Form, parameters: typing.Dict) -> ufl.algorithm
                 qd = qd_metadata
             else:
                 qd = pd_estimated
-
-                # The quadrature degree from UFL can be very high for some
-                # integrals.  Print warning if number of quadrature points
-                # exceeds 100.
-                tdim = integral_data.domain.topological_dimension()
-                num_points = ((qd + 1 + 1) // 2)**tdim
-                if num_points >= 100:
-                    warnings.warn(
-                        f"Number of integration points per cell is: {num_points}. Consider using 'quadrature_degree' "
-                        "to reduce number.")
 
             # Extract quadrature rule
             qr = integral.metadata().get("quadrature_rule", qr_default)

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -1,6 +1,7 @@
 import numpy
 import ufl
 import basix
+import warnings
 
 
 def create_element(ufl_element):
@@ -45,7 +46,19 @@ def create_quadrature(cellname, degree, rule):
     """Create a quadrature rule."""
     if cellname == "vertex":
         return [[]], [1]
-    return basix.make_quadrature(rule, basix.cell.string_to_type(cellname), degree)
+
+    quadrature = basix.make_quadrature(rule, basix.cell.string_to_type(cellname), degree)
+
+    # The quadrature degree from UFL can be very high for some
+    # integrals.  Print warning if number of quadrature points
+    # exceeds 100.
+    num_points = quadrature[1].size
+    if num_points >= 100:
+        warnings.warn(
+            f"Number of integration points per cell is: {num_points}. Consider using 'quadrature_degree' "
+            "to reduce number.")
+
+    return quadrature
 
 
 def reference_cell_vertices(cellname):


### PR DESCRIPTION
Currently we issue this warning even if the number of quadrature points `p < 100`.

Example:
```
element = FiniteElement("N1curl", tetrahedron, 4)
mesh = Mesh(VectorElement("Lagrange", tetrahedron, 1))
V = FunctionSpace(mesh, element)
u = TrialFunction(V)
v = TestFunction(V)
a = inner(curl(u), curl(v))*dx + inner(u, v)*dx
```
Warning:
```
Number of integration points per cell is: 125. Consider using 'quadrature_degree' to reduce number.
```

Actual number of quadrature points is 45 (new quadrature rules added to basix in https://github.com/FEniCS/basix/pull/178).