### PR TITLE
Continue on coveralls upload error

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -71,6 +71,7 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           coveralls
+        continue-on-error: true
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@main


### PR DESCRIPTION
Coveralls has been down for ~4 days now, so perhaps the CI should still pass when the upload fails.