### PR TITLE
Write ufl family, not Basix family

### DIFF
--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -136,7 +136,7 @@ def _compute_element_ir(ufl_element, element_numbers, finite_element_names):
     ir["basix_cell"] = basix_element.cell_type
     ir["discontinuous"] = basix_element.discontinuous
     ir["degree"] = ufl_element.degree()
-    ir["family"] = basix_element.family_name
+    ir["family"] = ufl_element.family()
     ir["value_shape"] = ufl_element.value_shape()
     ir["reference_value_shape"] = ufl_element.reference_value_shape()
 


### PR DESCRIPTION
`family` in `ufc_element` should tell us what string can be used to recreate the ufl element instead of the Basix element