### PR TITLE
Do not create temporaries for non-varying partition

### DIFF
--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -88,7 +88,7 @@ class FFCXBackendDefinitions(object):
         code = []
         pre_code = []
 
-        if bs > 1:
+        if bs > 1 and not tabledata.is_piecewise:
             # For bs > 1, the coefficient access has a stride of bs. e.g.: XYZXYZXYZ
             # When memory access patterns are non-sequential, the number of cache misses increases.
             # In turn, it results in noticeably reduced performance.


### PR DESCRIPTION
Since the data is only used outside the quadrature loop, the "unit stride map" is not helpful, and it avoids creating extra variables that might clash with the varying partition.