### PR TITLE
Don't permute tables in interior facet integrals

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: main
+          ref: mscroggs/remove-exterior-facet-perms
       - name: Clone and install DOLFINx
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build -S dolfinx/cpp/

--- a/ffcx/codegeneration/ufc.h
+++ b/ffcx/codegeneration/ufc.h
@@ -208,10 +208,9 @@ extern "C"
   ///  facet
   ///  - N % 2 gives the number of reflections to apply to the facet
   ///
-  ///  For integrals not on facets, this argument has not effect and a
-  ///  null pointer can be passed. For interior facets the array will
-  ///  have size 2 (one permutation for each cell adjacent to the
-  ///  facet). For exterior facets, this will have size 1.
+  /// For integrals not on interior facets, this argument has no effect and a
+  /// null pointer can be passed. For interior facets the array will have size 2
+  /// (one permutation for each cell adjacent to the facet).
   typedef void(ufc_tabulate_tensor_float32)(
       float* restrict A, const float* restrict w,
       const float* restrict c, const double* restrict coordinate_dofs,

--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -307,7 +307,8 @@ def build_optimized_tables(quadrature_rule, cell, integral_type, entitytype,
         # the dofmap offset may differ due to restriction.
 
         tdim = cell.topological_dimension()
-        if entitytype == "facet":
+
+        if integral_type == "interior_facet":
             if tdim == 1:
                 t = get_ffcx_table_values(quadrature_rule.points, cell,
                                           integral_type, element, avg, entitytype,


### PR DESCRIPTION
Fixes #426.

This is coupled with https://github.com/FEniCS/dolfinx/pull/1837