### PR TITLE
Throw error if creating a BlockedElement whose sub element is not scalar

### DIFF
--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -588,6 +588,12 @@ class BlockedElement(BaseElement):
 
     def __init__(self, sub_element, block_size, block_shape=None):
         assert block_size > 0
+
+        if sub_element.value_size != 1:
+            raise ValueError("Blocked elements (VectorElement and TensorElement) of "
+                             "non-scalar elements are not supported. Try using MixedElement "
+                             "instead.")
+
         self.sub_element = sub_element
         self.block_size = block_size
         if block_shape is None:


### PR DESCRIPTION
Currently, doing this causes a segfault later (see eg https://github.com/FEniCS/dolfinx/issues/1593) when it is expected that VectorElement's sub element is scalar.

A test that checks this behaviour is added to DOLFINx in https://github.com/FEniCS/dolfinx/pull/1848.

Closes https://github.com/FEniCS/dolfinx/issues/1593