### PR TITLE
Cache Basix elements to avoid computing basis functions multiple times

### DIFF
--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -18,10 +18,10 @@ from abc import ABC, abstractmethod
 import basix
 import numpy
 import ufl
-from functools import cache
+from functools import lru_cache
 
 
-@cache
+@lru_cache
 def create_element(element: ufl.finiteelement.FiniteElementBase) -> BaseElement:
     """Create an FFCx element from a UFL element.
 

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -19,6 +19,8 @@ import basix
 import numpy
 import ufl
 
+_element_cache = {}
+
 
 def create_element(element: ufl.finiteelement.FiniteElementBase) -> BaseElement:
     """Create an FFCx element from a UFL element.
@@ -28,64 +30,68 @@ def create_element(element: ufl.finiteelement.FiniteElementBase) -> BaseElement:
 
     Returns:
         A FFCx finite element
-
     """
-    # TODO: EnrichedElement
-    # TODO: Short/alternative names for elements
-    # TODO: Allow different args for different parts of mixed element
+    global _element_cache
 
-    if isinstance(element, ufl.VectorElement):
-        return BlockedElement(create_element(element.sub_elements()[0]),
-                              element.num_sub_elements())
-    if isinstance(element, ufl.TensorElement):
-        return BlockedElement(create_element(element.sub_elements()[0]),
-                              element.num_sub_elements(), None)  # TODO: block shape
+    if element not in _element_cache:
+        # TODO: EnrichedElement
+        # TODO: Short/alternative names for elements
+        # TODO: Allow different args for different parts of mixed element
 
-    if isinstance(element, ufl.MixedElement):
-        return MixedElement([create_element(e) for e in element.sub_elements()])
+        if isinstance(element, ufl.VectorElement):
+            return BlockedElement(create_element(element.sub_elements()[0]),
+                                  element.num_sub_elements())
+        if isinstance(element, ufl.TensorElement):
+            return BlockedElement(create_element(element.sub_elements()[0]),
+                                  element.num_sub_elements(), None)  # TODO: block shape
 
-    if element.family() == "Quadrature":
-        return QuadratureElement(element)
+        if isinstance(element, ufl.MixedElement):
+            return MixedElement([create_element(e) for e in element.sub_elements()])
 
-    variant_info = []
+        if element.family() == "Quadrature":
+            return QuadratureElement(element)
 
-    family_name = element.family()
-    discontinuous = False
-    if family_name.startswith("Discontinuous "):
-        family_name = family_name[14:]
-        discontinuous = True
-    if family_name == "DP":
-        family_name = "P"
-        discontinuous = True
-    if family_name == "DQ":
-        family_name = "Q"
-        discontinuous = True
-    if family_name == "DPC":
-        discontinuous = True
+        variant_info = []
 
-    family_type = basix.finite_element.string_to_family(family_name, element.cell().cellname())
-    cell_type = basix.cell.string_to_type(element.cell().cellname())
+        family_name = element.family()
+        discontinuous = False
+        if family_name.startswith("Discontinuous "):
+            family_name = family_name[14:]
+            discontinuous = True
+        if family_name == "DP":
+            family_name = "P"
+            discontinuous = True
+        if family_name == "DQ":
+            family_name = "Q"
+            discontinuous = True
+        if family_name == "DPC":
+            discontinuous = True
 
-    if family_type == basix.ElementFamily.P:
-        if element.variant() is None:
-            variant_info.append(basix.LagrangeVariant.gll_warped)
-        else:
-            variant_info.append(basix.variants.string_to_lagrange_variant(element.variant()))
-    elif family_type == basix.ElementFamily.serendipity:
-        if element.variant() is None:
-            variant_info.append(basix.LagrangeVariant.gll_warped)
-            variant_info.append(basix.DPCVariant.diagonal_gll)
-        else:
-            v1, v2 = element.variant().split(",")
-            variant_info.append(basix.variants.string_to_lagrange_variant(v1))
-            variant_info.append(basix.variants.string_to_dpc_variant(v2))
-    elif family_type == basix.ElementFamily.DPC:
-        if element.variant() is None:
-            variant_info.append(basix.DPCVariant.diagonal_gll)
-        else:
-            variant_info.append(basix.variants.string_to_dpc_variant(element.variant()))
+        family_type = basix.finite_element.string_to_family(family_name, element.cell().cellname())
+        cell_type = basix.cell.string_to_type(element.cell().cellname())
 
-    return BasixElement(family_type, cell_type, element.degree(), variant_info, discontinuous)
+        if family_type == basix.ElementFamily.P:
+            if element.variant() is None:
+                variant_info.append(basix.LagrangeVariant.gll_warped)
+            else:
+                variant_info.append(basix.variants.string_to_lagrange_variant(element.variant()))
+        elif family_type == basix.ElementFamily.serendipity:
+            if element.variant() is None:
+                variant_info.append(basix.LagrangeVariant.gll_warped)
+                variant_info.append(basix.DPCVariant.diagonal_gll)
+            else:
+                v1, v2 = element.variant().split(",")
+                variant_info.append(basix.variants.string_to_lagrange_variant(v1))
+                variant_info.append(basix.variants.string_to_dpc_variant(v2))
+        elif family_type == basix.ElementFamily.DPC:
+            if element.variant() is None:
+                variant_info.append(basix.DPCVariant.diagonal_gll)
+            else:
+                variant_info.append(basix.variants.string_to_dpc_variant(element.variant()))
+
+        _element_cache[element] = BasixElement(family_type, cell_type, element.degree(), variant_info, discontinuous)
+
+    return _element_cache[element]
 
 
 def basix_index(*args):

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -18,10 +18,10 @@ from abc import ABC, abstractmethod
 import basix
 import numpy
 import ufl
-import functools
+from functools import cache
 
 
-@functools.cache
+@cache
 def create_element(element: ufl.finiteelement.FiniteElementBase) -> BaseElement:
     """Create an FFCx element from a UFL element.
 


### PR DESCRIPTION
I put a print in the `basix::FiniteElement` initialisation. When compiling a form, each element was being created multiple times:

![image](https://user-images.githubusercontent.com/9850599/162992712-83d4f7fc-3e47-4519-9d3c-4a4cd1a938ad.png)

After this PR, each element is only computed twice (once by FFCx, and once by DOLFINx):

![image](https://user-images.githubusercontent.com/9850599/162992924-1b51928b-f215-4982-a213-762fd1552608.png)

For higher degree elements, this will speed up compilation of forms by a fair amount