### PR TITLE
Cache Basix element creation

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -55,11 +55,11 @@ jobs:
 
       - name: Build DOLFINx C++ unit tests
         run: |
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B dolfinx/cpp/build/test/ -S dolfinx/cpp/build/test/
-          cmake --build dolfinx/cpp/build/test
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B build/test/ -S build/test/
+          cmake --build build/test
       - name: Run DOLFINx C++ unit tests
         run: |
-          cd dolfinx/cpp/build/test
+          cd build/test
           ctest -V --output-on-failure -R unittests
 
       - name: Run DOLFINx Python unit tests

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -53,5 +53,14 @@ jobs:
           cmake --install build
           pip3 -v install --global-option build --global-option --debug dolfinx/python/
 
-      - name: Run DOLFINx unit tests
+      - name: Build DOLFINx C++ unit tests
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -B dolfinx/cpp/build/test/ -S dolfinx/cpp/build/test/
+          cmake --build dolfinx/cpp/build/test
+      - name: Run DOLFINx C++ unit tests
+        run: |
+          cd dolfinx/cpp/build/test
+          ctest -V --output-on-failure -R unittests
+
+      - name: Run DOLFINx Python unit tests
         run: python3 -m pytest -n auto dolfinx/python/test/unit

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -19,10 +19,15 @@ import basix
 import numpy
 import ufl
 import basix.ufl_wrapper
-# from functools import lru_cache
+import functools
 
 
-# @lru_cache
+@functools.lru_cache
+def create_basix_element(family_type, cell_type, degree, variant_info, discontinuous):
+    """Create a basix element."""
+    return basix.create_element(family_type, cell_type, degree, *variant_info, discontinuous)
+
+
 def create_element(element: ufl.finiteelement.FiniteElementBase) -> BaseElement:
     """Create an FFCx element from a UFL element.
 
@@ -90,8 +95,8 @@ def create_element(element: ufl.finiteelement.FiniteElementBase) -> BaseElement:
         else:
             variant_info.append(basix.variants.string_to_dpc_variant(element.variant()))
 
-    return BasixElement(basix.create_element(
-        family_type, cell_type, element.degree(), *variant_info, discontinuous))
+    return BasixElement(create_basix_element(
+        family_type, cell_type, element.degree(), tuple(variant_info), discontinuous))
 
 
 def basix_index(*args):

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -19,10 +19,10 @@ import basix
 import numpy
 import ufl
 import basix.ufl_wrapper
-from functools import lru_cache
+# from functools import lru_cache
 
 
-@lru_cache
+# @lru_cache
 def create_element(element: ufl.finiteelement.FiniteElementBase) -> BaseElement:
     """Create an FFCx element from a UFL element.
 


### PR DESCRIPTION
Make DOLFINx workflow run the DOLFINx C++ tests (as previous attempt at caching caused one of these to fail).

Cache creation of Basix elements, not the full create_element function