### PR TITLE
Restore python 3.7 compatibile usage of functools.lru_cache

### DIFF
--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -22,7 +22,7 @@ import basix.ufl_wrapper
 import functools
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def create_basix_element(family_type, cell_type, degree, variant_info, discontinuous):
     """Create a basix element."""
     return basix.create_element(family_type, cell_type, degree, *variant_info, discontinuous)


### PR DESCRIPTION
Caught this on my [FEM on Colab](https://github.com/fem-on-colab/fem-on-colab) CI weekly run.

Fixes #475 for py3.7, see https://docs.python.org/3/library/functools.html#functools.lru_cache

