### PR TITLE
Revert constraint on setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=58,<61", "wheel"]
+requires = ["setuptools>=58", "wheel"]
 
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ include_package_data = True
 zip_safe = False
 python_requires = >= 3.7
 setup_requires =
-    setuptools >= 58, < 61
+    setuptools >= 58
     wheel
 install_requires =
     numpy


### PR DESCRIPTION
mMax version was set to avoid a bug in a recent setiptools release