### PR TITLE
setuptools is required at runtime

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ setup_requires =
 install_requires =
     numpy
     cffi
+    setuptools
     fenics-basix >= 0.4.2.dev0, <0.5.0
     fenics-ufl >= 2022.2.0.dev0, <2022.3.0
 
@@ -74,4 +75,3 @@ max-line-length = 120
 exclude = .git,__pycache__,docs/source/conf.py,build,dist,libs
 ignore = W503,  # Line length
          E741   # Variable names l, O, I, ...
-


### PR DESCRIPTION
`__init__.py` [imports pkg_resources](https://github.com/FEniCS/ffcx/blob/main/ffcx/__init__.py#L15) to resolve `__version__`