### PR TITLE
Fix facet and cell averages

### DIFF
--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -33,7 +33,7 @@ class UFLData(typing.NamedTuple):
 
 def replace_average_quantities(form: ufl.form.Form) -> ufl.form.Form:
     """
-    Replaces cell_avg(a) with a/CellVolume(mesh) and facet_avg(a) with a/FacetArea(mesh)
+    Replaces cell_avg(a) with a/CellVolume(mesh) and facet_avg(a) with a/FacetArea(mesh).
 
     Parameters
     ----------

--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -87,8 +87,6 @@ class FFCXBackendAccess(object):
     def spatial_coordinate(self, e, mt, tabledata, num_points):
         if mt.global_derivatives:
             raise RuntimeError("Not expecting global derivatives of SpatialCoordinate.")
-        if mt.averaged is not None:
-            raise RuntimeError("Not expecting average of SpatialCoordinates.")
 
         if self.integral_type in ufl.custom_integral_types:
             if mt.local_derivatives:
@@ -117,8 +115,6 @@ class FFCXBackendAccess(object):
             raise RuntimeError("Not expecting derivatives of CellCoordinate.")
         if mt.local_derivatives:
             raise RuntimeError("Not expecting derivatives of CellCoordinate.")
-        if mt.averaged is not None:
-            raise RuntimeError("Not expecting average of CellCoordinate.")
 
         if self.integral_type == "cell" and not mt.restriction:
             # Access predefined quadrature points table
@@ -143,8 +139,6 @@ class FFCXBackendAccess(object):
             raise RuntimeError("Not expecting derivatives of FacetCoordinate.")
         if mt.local_derivatives:
             raise RuntimeError("Not expecting derivatives of FacetCoordinate.")
-        if mt.averaged is not None:
-            raise RuntimeError("Not expecting average of FacetCoordinate.")
         if mt.restriction:
             raise RuntimeError("Not expecting restriction of FacetCoordinate.")
 
@@ -173,8 +167,6 @@ class FFCXBackendAccess(object):
             raise RuntimeError("Expecting reference facet coordinate to be symbolically rewritten.")
 
     def jacobian(self, e, mt, tabledata, num_points):
-        if mt.averaged is not None:
-            raise RuntimeError("Not expecting average of Jacobian.")
         return self.symbols.J_component(mt)
 
     def reference_cell_volume(self, e, mt, tabledata, access):

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -27,11 +27,6 @@ def format_mt_name(basename, mt):
     """Format variable name for modified terminal."""
     access = str(basename)
 
-    # Add averaged state to name
-    if mt.averaged is not None:
-        avg = f"_a{mt.averaged}"
-        access += avg
-
     # Format restriction
     res = ufcx_restriction_postfix(mt.restriction).replace("_", "_r")
     access += res

--- a/ffcx/ir/analysis/valuenumbering.py
+++ b/ffcx/ir/analysis/valuenumbering.py
@@ -122,7 +122,6 @@ class ValueNumberer(object):
         global_derivatives - tuple of ints, each meaning derivative in that global direction
         local_derivatives  - tuple of ints, each meaning derivative in that local direction
         reference_value    - bool, whether this is represented in reference frame
-        averaged           - None, 'facet' or 'cell'
         restriction        - None, '+' or '-'
         component          - tuple of ints, the global component of the Terminal
         flat_component     - single int, flattened local component of the Terminal, considering symmetry

--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -12,8 +12,7 @@ import numpy
 import ufl
 import ufl.utils.derivativetuples
 from ffcx.element_interface import basix_index, create_element
-from ffcx.ir.representationutils import (create_quadrature_points_and_weights,
-                                         integral_type_to_entity_dim,
+from ffcx.ir.representationutils import (integral_type_to_entity_dim,
                                          map_integral_points)
 
 logger = logging.getLogger("ffcx")

--- a/ffcx/naming.py
+++ b/ffcx/naming.py
@@ -12,6 +12,7 @@ import numpy.typing
 import ufl
 
 import ffcx
+import ffcx.analysis
 
 
 def compute_signature(ufl_objects: typing.List[
@@ -27,8 +28,9 @@ def compute_signature(ufl_objects: typing.List[
     for ufl_object in ufl_objects:
         # Get signature from ufl object
         if isinstance(ufl_object, ufl.Form):
+            object = ffcx.analysis.replace_average_quantities(ufl_object)
             kind = "form"
-            object_signature += ufl_object.signature()
+            object_signature += object.signature()
         elif isinstance(ufl_object, ufl.FiniteElementBase):
             object_signature += repr(ufl_object)
             kind = "element"


### PR DESCRIPTION
Currently we do not support `FacetAvg` or `CellAvg` in ufl forms, as the following mwe illustrates:
```python
import ufl

cell = ufl.triangle
c_el = ufl.VectorElement("Lagrange", cell, 1)
mesh = ufl.Mesh(c_el)
el = ufl.FiniteElement("Lagrange", cell, 1)
V = ufl.FunctionSpace(mesh, el)
u = ufl.Coefficient(V)

a = ufl.cell_avg(u) * ufl.dx
L = ufl.facet_avg(u) * ufl.ds
forms = [a, L]
```
```bash
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/root/shared/ffcx/ffcx/__main__.py", line 12, in <module>
    sys.exit(main())
  File "/root/shared/ffcx/ffcx/main.py", line 68, in main
    code_h, code_c = compiler.compile_ufl_objects(
  File "/root/shared/ffcx/ffcx/compiler.py", line 102, in compile_ufl_objects
    ir = compute_ir(analysis, object_names, prefix, parameters, visualise)
  File "/root/shared/ffcx/ffcx/ir/representation.py", line 197, in compute_ir
    irs = [
  File "/root/shared/ffcx/ffcx/ir/representation.py", line 198, in <listcomp>
    _compute_integral_ir(fd, i, analysis.element_numbers, integral_names, finite_element_names,
  File "/root/shared/ffcx/ffcx/ir/representation.py", line 487, in _compute_integral_ir
    integral_ir = compute_integral_ir(itg_data.domain.ufl_cell(), itg_data.integral_type,
  File "/root/shared/ffcx/ffcx/ir/integral.py", line 71, in compute_integral_ir
    S = build_scalar_graph(expression)
  File "/root/shared/ffcx/ffcx/ir/analysis/graph.py", line 79, in build_scalar_graph
    scalar_expressions = rebuild_with_scalar_subexpressions(G)
  File "/root/shared/ffcx/ffcx/ir/analysis/graph.py", line 179, in rebuild_with_scalar_subexpressions
    ws = reconstruct(expr, wops)
  File "/root/shared/ffcx/ffcx/ir/analysis/reconstruct.py", line 168, in reconstruct
    raise RuntimeError("Not expecting expression of type %s in here." % type(o))
RuntimeError: Not expecting expression of type <class 'ufl.averaging.CellAvg'> in here.
```
This is due to: https://bitbucket.org/fenics-project/ufl/pull-requests/89
which never got fixed in old DOLFIN.
