### PR TITLE
Use float type that matches scalar type

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
+          ref: garth/geometry-type
       - name: Get DOLFINx source (specified branch/tag)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v2

--- a/ffcx/codegeneration/backend.py
+++ b/ffcx/codegeneration/backend.py
@@ -20,7 +20,7 @@ class FFCXBackend(object):
         # This is the seam where cnodes/C is chosen for the FFCx backend
         self.language = ffcx.codegeneration.C.cnodes
         scalar_type = parameters["scalar_type"]
-        self.ufl_to_language = UFL2CNodesTranslatorCpp(self.language, scalar_type)
+        self.ufl_to_language = UFL2CNodesTranslatorCpp(self.language, scalar_type, geom_type)
 
         coefficient_numbering = ir.coefficient_numbering
         coefficient_offsets = ir.coefficient_offsets

--- a/ffcx/codegeneration/backend.py
+++ b/ffcx/codegeneration/backend.py
@@ -20,7 +20,7 @@ class FFCXBackend(object):
         # This is the seam where cnodes/C is chosen for the FFCx backend
         self.language = ffcx.codegeneration.C.cnodes
         scalar_type = parameters["scalar_type"]
-        self.ufl_to_language = UFL2CNodesTranslatorCpp(self.language, scalar_type, geom_type)
+        self.ufl_to_language = UFL2CNodesTranslatorCpp(self.language, scalar_type)
 
         coefficient_numbering = ir.coefficient_numbering
         coefficient_offsets = ir.coefficient_offsets

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -139,11 +139,14 @@ class FFCXBackendDefinitions(object):
         num_dofs = tabledata.values.shape[3]
         bs = tabledata.block_size
 
+        scalar_type = self.parameters["scalar_type"]
+        geom_type = scalar_type.replace(' _Complex', '')
+
         # Inlined version (we know this is bounded by a small number)
         FE = self.symbols.element_table(tabledata, self.entitytype, mt.restriction)
         dof_access = self.symbols.domain_dofs_access(gdim, num_scalar_dofs, mt.restriction)
         value = L.Sum([dof_access[begin + i * bs] * FE[i] for i in range(num_dofs)])
-        code = [L.VariableDecl("const double", access, value)]
+        code = [L.VariableDecl(f"const {geom_type}", access, value)]
 
         return [], code
 

--- a/ffcx/codegeneration/expressions.py
+++ b/ffcx/codegeneration/expressions.py
@@ -74,7 +74,9 @@ def generator(ir, parameters):
     d["num_points"] = ir.points.shape[0]
     d["topological_dimension"] = ir.points.shape[1]
     d["scalar_type"] = parameters["scalar_type"]
+    d["geom_type"] = parameters["scalar_type"].replace(' _Complex', '')
     d["np_scalar_type"] = cdtype_to_numpy(parameters["scalar_type"])
+
     d["rank"] = len(ir.tensor_shape)
 
     if len(ir.coefficient_names) > 0:
@@ -124,7 +126,6 @@ def generator(ir, parameters):
     # Check that no keys are redundant or have been missed
     from string import Formatter
     fields = [fname for _, fname, _, _ in Formatter().parse(expressions_template.factory) if fname]
-
     assert set(fields) == set(d.keys()), "Mismatch between keys in template and in formattting dict"
 
     # Format implementation code

--- a/ffcx/codegeneration/expressions.py
+++ b/ffcx/codegeneration/expressions.py
@@ -191,7 +191,7 @@ class ExpressionGenerator:
         parts = []
         for i, cell_list in cells.items():
             for c in cell_list:
-                parts.append(geometry.write_table(L, ufl_geometry[i], c))
+                parts.append(geometry.write_table(L, ufl_geometry[i], c, geom_type))
 
         return parts
 

--- a/ffcx/codegeneration/expressions.py
+++ b/ffcx/codegeneration/expressions.py
@@ -191,7 +191,7 @@ class ExpressionGenerator:
         parts = []
         for i, cell_list in cells.items():
             for c in cell_list:
-                parts.append(geometry.write_table(L, ufl_geometry[i], c, geom_type))
+                parts.append(geometry.write_table(L, ufl_geometry[i], c))
 
         return parts
 

--- a/ffcx/codegeneration/expressions_template.py
+++ b/ffcx/codegeneration/expressions_template.py
@@ -20,7 +20,7 @@ factory = """
 void tabulate_tensor_{factory_name}({scalar_type}* restrict A,
                                     const {scalar_type}* restrict w,
                                     const {scalar_type}* restrict c,
-                                    const double* restrict coordinate_dofs,
+                                    const {geom_type}* restrict coordinate_dofs,
                                     const int* restrict entity_local_index,
                                     const uint8_t* restrict quadrature_permutation)
 {{

--- a/ffcx/codegeneration/geometry.py
+++ b/ffcx/codegeneration/geometry.py
@@ -8,23 +8,23 @@ import basix
 import numpy
 
 
-def write_table(L, tablename, cellname):
+def write_table(L, tablename, cellname, type):
     if tablename == "facet_edge_vertices":
-        return facet_edge_vertices(L, tablename, cellname)
+        return facet_edge_vertices(L, tablename, cellname, type)
     if tablename == "reference_facet_jacobian":
-        return reference_facet_jacobian(L, tablename, cellname)
+        return reference_facet_jacobian(L, tablename, cellname, type)
     if tablename == "reference_cell_volume":
-        return reference_cell_volume(L, tablename, cellname)
+        return reference_cell_volume(L, tablename, cellname, type)
     if tablename == "reference_facet_volume":
-        return reference_facet_volume(L, tablename, cellname)
+        return reference_facet_volume(L, tablename, cellnam, type)
     if tablename == "reference_edge_vectors":
-        return reference_edge_vectors(L, tablename, cellname)
+        return reference_edge_vectors(L, tablename, cellname, type)
     if tablename == "facet_reference_edge_vectors":
-        return facet_reference_edge_vectors(L, tablename, cellname)
+        return facet_reference_edge_vectors(L, tablename, cellname, type)
     if tablename == "reference_facet_normals":
-        return reference_facet_normals(L, tablename, cellname)
+        return reference_facet_normals(L, tablename, cellname, type)
     if tablename == "facet_orientation":
-        return facet_orientation(L, tablename, cellname)
+        return facet_orientation(L, tablename, cellname, type)
     raise ValueError(f"Unknown geometry table name: {tablename}")
 
 
@@ -50,28 +50,28 @@ def facet_edge_vertices(L, tablename, cellname):
     return L.ArrayDecl("static const unsigned int", f"{cellname}_{tablename}", out.shape, out)
 
 
-def reference_facet_jacobian(L, tablename, cellname):
+def reference_facet_jacobian(L, tablename, cellname, type):
     celltype = getattr(basix.CellType, cellname)
     out = basix.cell.facet_jacobians(celltype)
-    return L.ArrayDecl("static const double", f"{cellname}_{tablename}", out.shape, out)
+    return L.ArrayDecl(f"static const {type}", f"{cellname}_{tablename}", out.shape, out)
 
 
-def reference_cell_volume(L, tablename, cellname):
+def reference_cell_volume(L, tablename, cellname, type):
     celltype = getattr(basix.CellType, cellname)
     out = basix.cell.volume(celltype)
-    return L.VariableDecl("static const double", f"{cellname}_{tablename}", out)
+    return L.VariableDecl(f"static const {type}", f"{cellname}_{tablename}", out)
 
 
-def reference_facet_volume(L, tablename, cellname):
+def reference_facet_volume(L, tablename, cellna, typeme):
     celltype = getattr(basix.CellType, cellname)
     volumes = basix.cell.facet_reference_volumes(celltype)
     for i in volumes[1:]:
         if not numpy.isclose(i, volumes[0]):
             raise ValueError("Reference facet volume not supported for this cell type.")
-    return L.VariableDecl("static const double", f"{cellname}_{tablename}", volumes[0])
+    return L.VariableDecl(f"static const {type}", f"{cellname}_{tablename}", volumes[0])
 
 
-def reference_edge_vectors(L, tablename, cellname):
+def reference_edge_vectors(L, tablename, cellname, type):
     celltype = getattr(basix.CellType, cellname)
     topology = basix.topology(celltype)
     geometry = basix.geometry(celltype)
@@ -79,10 +79,10 @@ def reference_edge_vectors(L, tablename, cellname):
     edge_vectors = [geometry[j] - geometry[i] for i, j in topology[1]]
 
     out = numpy.array(edge_vectors[cellname])
-    return L.ArrayDecl("static const double", f"{cellname}_{tablename}", out.shape, out)
+    return L.ArrayDecl(f"static const {type}", f"{cellname}_{tablename}", out.shape, out)
 
 
-def facet_reference_edge_vectors(L, tablename, cellname):
+def facet_reference_edge_vectors(L, tablename, cellname, type):
     celltype = getattr(basix.CellType, cellname)
     topology = basix.topology(celltype)
     geometry = basix.geometry(celltype)
@@ -102,16 +102,16 @@ def facet_reference_edge_vectors(L, tablename, cellname):
             raise ValueError("Only triangular and quadrilateral faces supported.")
 
     out = numpy.array(edge_vectors)
-    return L.ArrayDecl("static const double", f"{cellname}_{tablename}", out.shape, out)
+    return L.ArrayDecl(f"static const {type}", f"{cellname}_{tablename}", out.shape, out)
 
 
-def reference_facet_normals(L, tablename, cellname):
+def reference_facet_normals(L, tablename, cellname, type):
     celltype = getattr(basix.CellType, cellname)
     out = basix.cell.facet_outward_normals(celltype)
-    return L.ArrayDecl("static const double", f"{cellname}_{tablename}", out.shape, out)
+    return L.ArrayDecl(f"static const {type}", f"{cellname}_{tablename}", out.shape, out)
 
 
-def facet_orientation(L, tablename, cellname):
+def facet_orientation(L, tablename, cellname, type):
     celltype = getattr(basix.CellType, cellname)
     out = basix.cell.facet_orientations(celltype)
-    return L.ArrayDecl("static const double", f"{cellname}_{tablename}", out.shape, out)
+    return L.ArrayDecl(f"static const {type}", f"{cellname}_{tablename}", out.shape, out)

--- a/ffcx/codegeneration/geometry.py
+++ b/ffcx/codegeneration/geometry.py
@@ -16,7 +16,7 @@ def write_table(L, tablename, cellname, type):
     if tablename == "reference_cell_volume":
         return reference_cell_volume(L, tablename, cellname, type)
     if tablename == "reference_facet_volume":
-        return reference_facet_volume(L, tablename, cellnam, type)
+        return reference_facet_volume(L, tablename, cellname, type)
     if tablename == "reference_edge_vectors":
         return reference_edge_vectors(L, tablename, cellname, type)
     if tablename == "facet_reference_edge_vectors":
@@ -62,7 +62,7 @@ def reference_cell_volume(L, tablename, cellname, type):
     return L.VariableDecl(f"static const {type}", f"{cellname}_{tablename}", out)
 
 
-def reference_facet_volume(L, tablename, cellna, typeme):
+def reference_facet_volume(L, tablename, cellname, type):
     celltype = getattr(basix.CellType, cellname)
     volumes = basix.cell.facet_reference_volumes(celltype)
     for i in volumes[1:]:

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -288,8 +288,7 @@ class IntegralGenerator(object):
         return parts
 
     def generate_element_tables(self, float_type: str):
-        """Generate static tables with precomputed element basis
-        function values in quadrature points."""
+        """Generate static tables with precomputed element basisfunction values in quadrature points."""
         L = self.backend.language
         parts = []
 
@@ -692,8 +691,7 @@ class IntegralGenerator(object):
         return preparts, quadparts
 
     def fuse_loops(self, definitions):
-        """Merge a sequence of loops with the same iteration space into
-        a single loop.
+        """Merge a sequence of loops with the same iteration space into a single loop.
 
         Loop fusion improves data locality, cache reuse and decreases
         the loop control overhead.
@@ -701,6 +699,7 @@ class IntegralGenerator(object):
         NOTE: Loop fusion might increase the pressure on register
         allocation. Ideally, we should define a cost function to
         determine how many loops should fuse at a time.
+
         """
         L = self.backend.language
 

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -12,8 +12,8 @@ import ufl
 from ffcx.codegeneration import geometry
 from ffcx.codegeneration import integrals_template as ufcx_integrals
 from ffcx.codegeneration.backend import FFCXBackend
+from ffcx.codegeneration.C.cnodes import BinOp, CNode
 from ffcx.codegeneration.C.format_lines import format_indented_lines
-from ffcx.codegeneration.C.cnodes import CNode, BinOp
 from ffcx.ir.elementtables import piecewise_ttypes
 from ffcx.ir.integral import block_data_t
 from ffcx.ir.representationutils import QuadratureRule
@@ -58,8 +58,8 @@ def generator(ir, parameters):
     L = backend.language
     if len(ir.enabled_coefficients) > 0:
         code["enabled_coefficients_init"] = L.ArrayDecl(
-            "bool", f"enabled_coefficients_{ir.name}",
-            values=ir.enabled_coefficients, sizes=len(ir.enabled_coefficients))
+            "bool", f"enabled_coefficients_{ir.name}", values=ir.enabled_coefficients,
+            sizes=len(ir.enabled_coefficients))
         code["enabled_coefficients"] = f"enabled_coefficients_{ir.name}"
     else:
         code["enabled_coefficients_init"] = ""
@@ -100,8 +100,8 @@ class IntegralGenerator(object):
         # - access: for accessing backend specific variables
         self.backend = backend
 
-        # Set of operator names code has been generated for,
-        # used in the end for selecting necessary includes
+        # Set of operator names code has been generated for, used in the
+        # end for selecting necessary includes
         self._ufl_names = set()
 
         # Initialize lookup tables for variable scopes
@@ -110,7 +110,8 @@ class IntegralGenerator(object):
         # Cache
         self.shared_symbols = {}
 
-        # Set of counters used for assigning names to intermediate variables
+        # Set of counters used for assigning names to intermediate
+        # variables
         self.symbol_counters = collections.defaultdict(int)
 
     def init_scopes(self):
@@ -168,33 +169,32 @@ class IntegralGenerator(object):
     def generate(self):
         """Generate entire tabulate_tensor body.
 
-        Assumes that the code returned from here will be wrapped in a context
-        that matches a suitable version of the UFC tabulate_tensor signatures.
+        Assumes that the code returned from here will be wrapped in a
+        context that matches a suitable version of the UFC
+        tabulate_tensor signatures.
         """
         L = self.backend.language
 
-        # Assert that scopes are empty: expecting this to be called only once
+        # Assert that scopes are empty: expecting this to be called only
+        # once
         assert not any(d for d in self.scopes.values())
 
         parts = []
-
         scalar_type = self.backend.access.parameters["scalar_type"]
         float_type = scalar_type.replace(' _Complex', '')
-
         alignment = self.ir.params['assume_aligned']
         if alignment != -1:
             scalar_type = self.backend.access.parameters["scalar_type"]
             parts += [L.VerbatimStatement(f"A = ({scalar_type}*)__builtin_assume_aligned(A, {alignment});"),
                       L.VerbatimStatement(f"w = (const {scalar_type}*)__builtin_assume_aligned(w, {alignment});"),
                       L.VerbatimStatement(f"c = (const {scalar_type}*)__builtin_assume_aligned(c, {alignment});"),
-                      L.VerbatimStatement(f"coordinate_dofs = (const {float_type}*)__builtin_assume_aligned(coordinate_dofs, {alignment});")]
-
+                      L.VerbatimStatement(f"coordinate_dofs = (const {float_type}*)__builtin_assume_aligned(coordinate_dofs, {alignment});")]  # noqa
 
         # Generate the tables of quadrature points and weights
         parts += self.generate_quadrature_tables(float_type)
 
-        # Generate the tables of basis function values and preintegrated
-        # blocks
+        # Generate the tables of basis function values and
+        # pre-integrated blocks
         parts += self.generate_element_tables(float_type)
 
         # Generate the tables of geometry data that are needed
@@ -206,10 +206,9 @@ class IntegralGenerator(object):
         all_preparts = []
         all_quadparts = []
 
-        # Pre-definitions are collected across all quadrature loops
-        # to improve re-use and avoid name clashes
+        # Pre-definitions are collected across all quadrature loops to
+        # improve re-use and avoid name clashes
         all_predefinitions = dict()
-
         for rule in self.ir.integrand.keys():
             # Generate code to compute piecewise constant scalar factors
             all_preparts += self.generate_piecewise_partition(rule)
@@ -246,8 +245,8 @@ class IntegralGenerator(object):
 
         # Loop over quadrature rules
         for quadrature_rule, integrand in self.ir.integrand.items():
-
             num_points = quadrature_rule.weights.shape[0]
+
             # Generate quadrature weights array
             wsym = self.backend.symbols.weights_table(quadrature_rule)
             parts += [L.ArrayDecl(f"static const {float_type}", wsym, num_points,
@@ -289,7 +288,8 @@ class IntegralGenerator(object):
         return parts
 
     def generate_element_tables(self, float_type: str):
-        """Generate static tables with precomputed element basis function values in quadrature points."""
+        """Generate static tables with precomputed element basis
+        function values in quadrature points."""
         L = self.backend.language
         parts = []
 
@@ -333,8 +333,7 @@ class IntegralGenerator(object):
         # Generate varying partition
         pre_definitions, body = self.generate_varying_partition(quadrature_rule)
 
-        body = L.commented_code_list(
-            body, f"Quadrature loop body setup for quadrature rule {quadrature_rule.id()}")
+        body = L.commented_code_list(body, f"Quadrature loop body setup for quadrature rule {quadrature_rule.id()}")
 
         # Generate dofblock parts, some of this will be placed before or
         # after quadloop
@@ -376,8 +375,7 @@ class IntegralGenerator(object):
 
         arraysymbol = L.Symbol(f"sv_{quadrature_rule.id()}")
         pre_definitions, parts = self.generate_partition(arraysymbol, F, "varying", quadrature_rule)
-        parts = L.commented_code_list(
-            parts, f"Varying computations for quadrature rule {quadrature_rule.id()}")
+        parts = L.commented_code_list(parts, f"Varying computations for quadrature rule {quadrature_rule.id()}")
 
         return pre_definitions, parts
 
@@ -500,8 +498,8 @@ class IntegralGenerator(object):
             block_groups[tuple(scalar_blockmap)].append(blockdata)
 
         for blockmap in block_groups:
-            block_preparts, block_quadparts = \
-                self.generate_block_parts(quadrature_rule, blockmap, block_groups[blockmap])
+            block_preparts, block_quadparts = self.generate_block_parts(
+                quadrature_rule, blockmap, block_groups[blockmap])
 
             # Add definitions
             preparts.extend(block_preparts)
@@ -539,9 +537,11 @@ class IntegralGenerator(object):
     def generate_block_parts(self, quadrature_rule: QuadratureRule, blockmap: Tuple, blocklist: List[block_data_t]):
         """Generate and return code parts for a given block.
 
-        Returns parts occuring before, inside, and after the quadrature loop identified by the quadrature rule.
+        Returns parts occuring before, inside, and after the quadrature
+        loop identified by the quadrature rule.
 
-        Should be called with quadrature_rule=None for quadloop-independent blocks.
+        Should be called with quadrature_rule=None for
+        quadloop-independent blocks.
         """
         L = self.backend.language
 
@@ -634,8 +634,8 @@ class IntegralGenerator(object):
         for indices in rhs_expressions:
             hoist_rhs = collections.defaultdict(list)
 
-            # Hoist loop invariant code and group array access (each table should only be read one
-            # time in the inner loop).
+            # Hoist loop invariant code and group array access (each
+            # table should only be read one time in the inner loop)
             if block_rank == 2:
                 ind = B_indices[-1]
                 for rhs in rhs_expressions[indices]:
@@ -649,8 +649,9 @@ class IntegralGenerator(object):
                         else:
                             keep[indices].append(rhs)
 
-                # Perform algebraic manipulations to reduce number of floating point
-                # operations (factorize expressions by grouping)
+                # Perform algebraic manipulations to reduce number of
+                # floating point operations (factorize expressions by
+                # grouping)
                 for statement in hoist_rhs:
                     sum = []
                     for rhs in hoist_rhs[statement]:
@@ -691,12 +692,15 @@ class IntegralGenerator(object):
         return preparts, quadparts
 
     def fuse_loops(self, definitions):
-        """
-        Merge a sequence of loops with the same iteration space into a single loop.
+        """Merge a sequence of loops with the same iteration space into
+        a single loop.
 
-        Loop fusion improves data locality, cache reuse and decreases the loop control overhead.
-        NOTE: Loop fusion might increase the pressure on register allocation.
-        Ideally, we should define a cost function to determine how many loops should fuse at a time.
+        Loop fusion improves data locality, cache reuse and decreases
+        the loop control overhead.
+
+        NOTE: Loop fusion might increase the pressure on register
+        allocation. Ideally, we should define a cost function to
+        determine how many loops should fuse at a time.
         """
         L = self.backend.language
 

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -178,17 +178,17 @@ class IntegralGenerator(object):
 
         parts = []
 
+        scalar_type = self.backend.access.parameters["scalar_type"]
+        float_type = scalar_type.replace(' _Complex', '')
+
         alignment = self.ir.params['assume_aligned']
         if alignment != -1:
             scalar_type = self.backend.access.parameters["scalar_type"]
             parts += [L.VerbatimStatement(f"A = ({scalar_type}*)__builtin_assume_aligned(A, {alignment});"),
                       L.VerbatimStatement(f"w = (const {scalar_type}*)__builtin_assume_aligned(w, {alignment});"),
                       L.VerbatimStatement(f"c = (const {scalar_type}*)__builtin_assume_aligned(c, {alignment});"),
-                      L.VerbatimStatement(
-                          f"coordinate_dofs = (const double*)__builtin_assume_aligned(coordinate_dofs, {alignment});")]
+                      L.VerbatimStatement(f"coordinate_dofs = (const {float_type}*)__builtin_assume_aligned(coordinate_dofs, {alignment});")]
 
-        scalar_type = self.backend.access.parameters["scalar_type"]
-        float_type = scalar_type.replace(' _Complex', '')
 
         # Generate the tables of quadrature points and weights
         parts += self.generate_quadrature_tables(float_type)

--- a/ffcx/codegeneration/integrals_template.py
+++ b/ffcx/codegeneration/integrals_template.py
@@ -13,7 +13,7 @@ factory = """
 void tabulate_tensor_{factory_name}({scalar_type}* restrict A,
                                     const {scalar_type}* restrict w,
                                     const {scalar_type}* restrict c,
-                                    const double* restrict coordinate_dofs,
+                                    const {geom_type}* restrict coordinate_dofs,
                                     const int* restrict entity_local_index,
                                     const uint8_t* restrict quadrature_permutation)
 {{

--- a/ffcx/codegeneration/ufcx.h
+++ b/ffcx/codegeneration/ufcx.h
@@ -268,7 +268,7 @@ extern "C"
   /// (one permutation for each cell adjacent to the facet).
   typedef void(ufcx_tabulate_tensor_float32)(
       float* restrict A, const float* restrict w,
-      const float* restrict c, const double* restrict coordinate_dofs,
+      const float* restrict c, const float* restrict coordinate_dofs,
       const int* restrict entity_local_index,
       const uint8_t* restrict quadrature_permutation);
 
@@ -288,7 +288,7 @@ extern "C"
   /// @see ufcx_tabulate_tensor_single
   typedef void(ufcx_tabulate_tensor_longdouble)(
       long double* restrict A, const long double* restrict w,
-      const long double* restrict c, const double* restrict coordinate_dofs,
+      const long double* restrict c, const long double* restrict coordinate_dofs,
       const int* restrict entity_local_index,
       const uint8_t* restrict quadrature_permutation);
 
@@ -298,7 +298,7 @@ extern "C"
   /// @see ufcx_tabulate_tensor_single
   typedef void(ufcx_tabulate_tensor_complex64)(
       float _Complex* restrict A, const float _Complex* restrict w,
-      const float _Complex* restrict c, const double* restrict coordinate_dofs,
+      const float _Complex* restrict c, const float* restrict coordinate_dofs,
       const int* restrict entity_local_index,
       const uint8_t* restrict quadrature_permutation);
 

--- a/test/test_add_mode.py
+++ b/test/test_add_mode.py
@@ -48,13 +48,14 @@ def test_additive_facet_integral(mode, compile_args):
     facets = np.array([0], dtype=np.int32)
     perm = np.array([0], dtype=np.uint8)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
     coords = np.array([0.0, 2.0, 0.0,
                        np.sqrt(3.0), -1.0, 0.0,
-                       -np.sqrt(3.0), -1.0, 0.0], dtype=np.float64)
+                       -np.sqrt(3.0), -1.0, 0.0], dtype=np_gtype)
 
     kernel = getattr(default_integral, f"tabulate_tensor_{np_type}")
 
-    geom_type = mode.replace(' _Complex', '')
     for i in range(3):
         facets[0] = i
         kernel(ffi.cast('{type} *'.format(type=mode), A.ctypes.data),
@@ -94,23 +95,24 @@ def test_additive_cell_integral(mode, compile_args):
     w = np.array([], dtype=np_type)
     c = np.array([], dtype=np_type)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
     coords = np.array([0.0, 2.0, 0.0,
                        np.sqrt(3.0), -1.0, 0.0,
-                       -np.sqrt(3.0), -1.0, 0.0], dtype=np.float64)
+                       -np.sqrt(3.0), -1.0, 0.0], dtype=np_gtype)
 
     kernel = getattr(default_integral, f"tabulate_tensor_{np_type}")
 
     kernel(ffi.cast('{type} *'.format(type=mode), A.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-           ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+           ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     A0 = np.array(A)
-
     for i in range(3):
         kernel(ffi.cast('{type} *'.format(type=mode), A.ctypes.data),
                ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
                ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-               ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+               ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
         assert np.all(np.isclose(A, (i + 2) * A0))

--- a/test/test_add_mode.py
+++ b/test/test_add_mode.py
@@ -12,7 +12,14 @@ import ufl
 from ffcx.naming import cdtype_to_numpy
 
 
-@pytest.mark.parametrize("mode", ["double", "float", "long double", "double _Complex", "float _Complex"])
+@pytest.mark.parametrize("mode",
+                         [
+                             "double",
+                             "float",
+                             "long double",
+                             "double _Complex",
+                             "float _Complex"
+                         ])
 def test_additive_facet_integral(mode, compile_args):
     cell = ufl.triangle
     element = ufl.FiniteElement("Lagrange", cell, 1)
@@ -47,12 +54,13 @@ def test_additive_facet_integral(mode, compile_args):
 
     kernel = getattr(default_integral, f"tabulate_tensor_{np_type}")
 
+    geom_type = mode.replace(' _Complex', '')
     for i in range(3):
         facets[0] = i
         kernel(ffi.cast('{type} *'.format(type=mode), A.ctypes.data),
                ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
                ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-               ffi.cast('double *', coords.ctypes.data),
+               ffi.cast(f'{geom_type} *', coords.ctypes.data),
                ffi.cast('int *', facets.ctypes.data),
                ffi.cast('uint8_t *', perm.ctypes.data))
 

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -5,12 +5,12 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
-import numpy as np
-
+import basix
 import cffi
 import ffcx.codegeneration.jit
+import numpy as np
 import ufl
-import basix
+from ffcx.naming import cdtype_to_numpy
 
 
 def float_to_type(name):
@@ -64,7 +64,7 @@ def test_matvec(compile_args):
     entity_index = np.array([0], dtype=np.intc)
     quad_perm = np.array([0], dtype=np.dtype("uint8"))
 
-    geom_type = mode.replace(' _Complex', '')
+    geom_type = c_type.replace(' _Complex', '')
     np_gtype = cdtype_to_numpy(geom_type)
 
     # Coords storage XYZXYZXYZ
@@ -117,6 +117,8 @@ def test_rank1(compile_args):
     expression = obj[0]
 
     c_type, np_type = float_to_type("double")
+    geom_type = c_type.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
 
     # 2 components for vector components of expression
     # 3 points of evaluation
@@ -130,13 +132,13 @@ def test_rank1(compile_args):
     quad_perm = np.array([0], dtype=np.dtype("uint8"))
 
     # Coords storage XYZXYZXYZ
-    coords = np.zeros((points.shape[0], 3), dtype=np.float64)
+    coords = np.zeros((points.shape[0], 3), dtype=np_gtype)
     coords[:, :2] = points
     expression.tabulate_tensor_float64(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data),
+        ffi.cast(f'{geom_type} *', coords.ctypes.data),
         ffi.cast('int *', entity_index.ctypes.data),
         ffi.cast('uint8_t *', quad_perm.ctypes.data))
 

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -64,15 +64,18 @@ def test_matvec(compile_args):
     entity_index = np.array([0], dtype=np.intc)
     quad_perm = np.array([0], dtype=np.dtype("uint8"))
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
+
     # Coords storage XYZXYZXYZ
     coords = np.array([[0.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0],
-                       [0.0, 1.0, 0.0]], dtype=np.float64)
+                       [0.0, 1.0, 0.0]], dtype=np_gtype)
     expression.tabulate_tensor_float64(
         ffi.cast('{type} *'.format(type=c_type), A.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), w.ctypes.data),
         ffi.cast('{type} *'.format(type=c_type), c.ctypes.data),
-        ffi.cast('double *', coords.ctypes.data),
+        ffi.cast(f'{geom_type} *', coords.ctypes.data),
         ffi.cast('int *', entity_index.ctypes.data),
         ffi.cast('uint8_t *', quad_perm.ctypes.data))
 

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -52,13 +52,14 @@ def test_laplace_bilinear_form_2d(mode, expected_result, compile_args):
     kappa_value = np.array([[1.0, 2.0], [3.0, 4.0]])
     c = np.array(kappa_value.flatten(), dtype=np_type)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
     coords = np.array([[0.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0],
-                       [0.0, 1.0, 0.0]], dtype=np.float64)
+                       [0.0, 1.0, 0.0]], dtype=np_gtype)
 
     kernel = getattr(default_integral, f"tabulate_tensor_{np_type}")
 
-    geom_type = mode.replace(' _Complex', '')
     kernel(ffi.cast('{type} *'.format(type=mode), A.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
@@ -115,23 +116,26 @@ def test_mass_bilinear_form_2d(mode, expected_result, compile_args):
     w = np.array([], dtype=np_type)
     c = np.array([], dtype=np_type)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
+
     ffi = module.ffi
     coords = np.array([[0.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0],
-                       [0.0, 1.0, 0.0]], dtype=np.float64)
+                       [0.0, 1.0, 0.0]], dtype=np_gtype)
 
     kernel0 = ffi.cast(f"ufcx_tabulate_tensor_{np_type} *", getattr(form0, f"tabulate_tensor_{np_type}"))
     kernel0(ffi.cast('{type} *'.format(type=mode), A.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-            ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+            ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     b = np.zeros(3, dtype=np_type)
     kernel1 = ffi.cast(f"ufcx_tabulate_tensor_{np_type} *", getattr(form1, f"tabulate_tensor_{np_type}"))
     kernel1(ffi.cast('{type} *'.format(type=mode), b.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-            ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+            ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     assert np.allclose(A, expected_result)
     assert np.allclose(b, 1.0 / 6.0)
@@ -170,16 +174,19 @@ def test_helmholtz_form_2d(mode, expected_result, compile_args):
     w = np.array([], dtype=np_type)
     c = np.array([], dtype=np_type)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
+
     ffi = module.ffi
     coords = np.array([[0.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0],
-                       [0.0, 1.0, 0.0]], dtype=np.float64)
+                       [0.0, 1.0, 0.0]], dtype=np_gtype)
     kernel = getattr(form0, f"tabulate_tensor_{np_type}")
 
     kernel(ffi.cast('{type} *'.format(type=mode), A.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-           ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+           ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     assert np.allclose(A, expected_result)
 
@@ -216,17 +223,20 @@ def test_laplace_bilinear_form_3d(mode, expected_result, compile_args):
     w = np.array([], dtype=np_type)
     c = np.array([], dtype=np_type)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
+
     ffi = module.ffi
     coords = np.array([0.0, 0.0, 0.0,
                        1.0, 0.0, 0.0,
                        0.0, 1.0, 0.0,
-                       0.0, 0.0, 1.0], dtype=np.float64)
+                       0.0, 0.0, 1.0], dtype=np_gtype)
 
     kernel = getattr(form0, f"tabulate_tensor_{np_type}")
     kernel(ffi.cast('{type} *'.format(type=mode), A.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-           ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+           ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     assert np.allclose(A, expected_result)
 
@@ -329,18 +339,21 @@ def test_interior_facet_integral(mode, compile_args):
     facets = np.array([0, 2], dtype=np.intc)
     perms = np.array([0, 1], dtype=np.uint8)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
+
     coords = np.array([[0.0, 0.0, 0.0,
                         1.0, 0.0, 0.0,
                         0.0, 1.0, 0.0],
                        [1.0, 0.0, 0.0,
                        0.0, 1.0, 0.0,
-                       1.0, 1.0, 0.0]], dtype=np.float64)
+                       1.0, 1.0, 0.0]], dtype=np_gtype)
 
     kernel = getattr(integral0, f"tabulate_tensor_{np_type}")
     kernel(ffi.cast(f'{mode}  *', A.ctypes.data),
            ffi.cast(f'{mode}  *', w.ctypes.data),
            ffi.cast(f'{mode}  *', c.ctypes.data),
-           ffi.cast('double *', coords.ctypes.data), ffi.cast('int *', facets.ctypes.data),
+           ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.cast('int *', facets.ctypes.data),
            ffi.cast('uint8_t *', perms.ctypes.data))
 
 
@@ -374,15 +387,18 @@ def test_conditional(mode, compile_args):
     w1 = np.array([1.0, 1.0, 1.0], dtype=np_type)
     c = np.array([], dtype=np.float64)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
+
     coords = np.array([[0.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0],
-                       [0.0, 1.0, 0.0]], dtype=np.float64)
+                       [0.0, 1.0, 0.0]], dtype=np_gtype)
 
     kernel0 = ffi.cast(f"ufcx_tabulate_tensor_{np_type} *", getattr(form0, f"tabulate_tensor_{np_type}"))
     kernel0(ffi.cast('{type} *'.format(type=mode), A1.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), w1.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-            ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+            ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     expected_result = np.array([[2, -1, -1], [-1, 1, 0], [-1, 0, 1]], dtype=np_type)
     assert np.allclose(A1, expected_result)
@@ -394,7 +410,7 @@ def test_conditional(mode, compile_args):
     kernel1(ffi.cast('{type} *'.format(type=mode), A2.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), w2.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-            ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+            ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     expected_result = np.ones(3, dtype=np_type)
     assert np.allclose(A2, expected_result)
@@ -511,15 +527,18 @@ def test_lagrange_triangle(compile_args, order, mode, sym_fun, ufl_fun):
     b = np.zeros((order + 2) * (order + 1) // 2, dtype=np_type)
     w = np.array([], dtype=np_type)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
+
     coords = np.array([[1.0, 0.0, 0.0],
                        [2.0, 0.0, 0.0],
-                       [0.0, 1.0, 0.0]], dtype=np.float64)
+                       [0.0, 1.0, 0.0]], dtype=np_gtype)
 
     kernel = getattr(default_integral, f"tabulate_tensor_{np_type}")
     kernel(ffi.cast('{type} *'.format(type=mode), b.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
            ffi.NULL,
-           ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+           ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     # Check that the result is the same as for sympy
     assert np.allclose(b, [float(i) for i in sym])
@@ -601,16 +620,19 @@ def test_lagrange_tetrahedron(compile_args, order, mode, sym_fun, ufl_fun):
     b = np.zeros((order + 3) * (order + 2) * (order + 1) // 6, dtype=np_type)
     w = np.array([], dtype=np_type)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
+
     coords = np.array([1.0, 0.0, 0.0,
                        2.0, 0.0, 0.0,
                        0.0, 1.0, 0.0,
-                       0.0, 0.0, 1.0], dtype=np.float64)
+                       0.0, 0.0, 1.0], dtype=np_gtype)
 
     kernel = getattr(default_integral, f"tabulate_tensor_{np_type}")
     kernel(ffi.cast('{type} *'.format(type=mode), b.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
            ffi.NULL,
-           ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+           ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     # Check that the result is the same as for sympy
     assert np.allclose(b, [float(i) for i in sym])
@@ -671,15 +693,18 @@ def test_complex_operations(compile_args):
     w1 = np.array([3 + 5j, 8 - 7j], dtype=np_type)
     c = np.array([], dtype=np_type)
 
+    geom_type = mode.replace(' _Complex', '')
+    np_gtype = cdtype_to_numpy(geom_type)
+
     coords = np.array([[0.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0],
-                       [0.0, 1.0, 0.0]], dtype=np.float64)
+                       [0.0, 1.0, 0.0]], dtype=np_gtype)
     J_1 = np.zeros((1), dtype=np_type)
     kernel0 = ffi.cast(f"ufcx_tabulate_tensor_{np_type} *", getattr(form0, f"tabulate_tensor_{np_type}"))
     kernel0(ffi.cast('{type} *'.format(type=mode), J_1.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), w1.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-            ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+            ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     expected_result = np.array([0.5 * np.real(w1[0]) * np.imag(w1[1])
                                * (np.real(w1[0]) - 1j * np.imag(w1[0]))], dtype=np_type)
@@ -691,7 +716,7 @@ def test_complex_operations(compile_args):
     kernel1(ffi.cast('{type} *'.format(type=mode), J_2.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), w1.ctypes.data),
             ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-            ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+            ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     assert np.allclose(J_2, expected_result)
 

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -58,10 +58,11 @@ def test_laplace_bilinear_form_2d(mode, expected_result, compile_args):
 
     kernel = getattr(default_integral, f"tabulate_tensor_{np_type}")
 
+    geom_type = mode.replace(' _Complex', '')
     kernel(ffi.cast('{type} *'.format(type=mode), A.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), w.ctypes.data),
            ffi.cast('{type} *'.format(type=mode), c.ctypes.data),
-           ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+           ffi.cast(f'{geom_type} *', coords.ctypes.data), ffi.NULL, ffi.NULL)
 
     assert np.allclose(A, np.trace(kappa_value) * expected_result)
 


### PR DESCRIPTION
Previously `double` was used for basis functions and geometry. This eliminated performance benefits of using reduced precision for the fields. This change uses the same float type as for the fields.