### PR TITLE
Fix various typos

### DIFF
--- a/ffcx/codegeneration/C/cnodes.py
+++ b/ffcx/codegeneration/C/cnodes.py
@@ -882,7 +882,7 @@ class Call(CExprOperator):
     def __init__(self, function, arguments=None):
         self.function = as_cexpr_or_string_symbol(function)
 
-        # Accept None, single, or multple arguments; literals or CExprs
+        # Accept None, single, or multiple arguments; literals or CExprs
         if arguments is None:
             arguments = ()
         elif not isinstance(arguments, (tuple, list)):
@@ -905,7 +905,7 @@ def Sqrt(x):
     return Call("sqrt", x)
 
 
-# Convertion function to expression nodes
+# Conversion function to expression nodes
 
 
 def _is_zero_valued(values):

--- a/ffcx/codegeneration/C/format_value.py
+++ b/ffcx/codegeneration/C/format_value.py
@@ -35,7 +35,7 @@ def format_int(x, precision=None):
 
 
 def format_value(value, precision=None):
-    """Format a literal value as s tring.
+    """Format a literal value as string.
 
     - float: Formatted according to current precision configuration.
 

--- a/ffcx/codegeneration/dofmap.py
+++ b/ffcx/codegeneration/dofmap.py
@@ -105,7 +105,7 @@ def generator(ir, parameters):
     # Remove square brackets from any field names
     fields = [f.split("[")[0] for f in fields]
     assert set(fields) == set(
-        d.keys()), "Mismatch between keys in template and in formattting dict."
+        d.keys()), "Mismatch between keys in template and in formatting dict."
 
     # Format implementation code
     implementation = ufcx_dofmap.factory.format_map(d)

--- a/ffcx/codegeneration/expressions.py
+++ b/ffcx/codegeneration/expressions.py
@@ -124,7 +124,7 @@ def generator(ir, parameters):
     # Check that no keys are redundant or have been missed
     from string import Formatter
     fields = [fname for _, fname, _, _ in Formatter().parse(expressions_template.factory) if fname]
-    assert set(fields) == set(d.keys()), "Mismatch between keys in template and in formattting dict"
+    assert set(fields) == set(d.keys()), "Mismatch between keys in template and in formatting dict"
 
     # Format implementation code
     implementation = expressions_template.factory.format_map(d)
@@ -263,7 +263,7 @@ class ExpressionGenerator:
         return parts
 
     def generate_piecewise_partition(self):
-        """Generate factors of blocks which are constant (i.e. do not depent on quadrature points)."""
+        """Generate factors of blocks which are constant (i.e. do not depend on quadrature points)."""
         L = self.backend.language
 
         # Get annotated graph of factorisation

--- a/ffcx/codegeneration/finite_element.py
+++ b/ffcx/codegeneration/finite_element.py
@@ -104,7 +104,7 @@ def generator(ir, parameters):
         fname for _, fname, _, _ in Formatter().parse(ufcx_finite_element.factory) if fname
     ]
     assert set(fieldnames) == set(
-        d.keys()), "Mismatch between keys in template and in formattting dict"
+        d.keys()), "Mismatch between keys in template and in formatting dict"
 
     # Format implementation code
     implementation = ufcx_finite_element.factory.format_map(d)
@@ -180,7 +180,7 @@ def generate_custom_element(name, ir):
         fname for _, fname, _, _ in Formatter().parse(ufcx_basix_custom_finite_element.factory) if fname
     ]
     assert set(fieldnames) == set(
-        d.keys()), "Mismatch between keys in template and in formattting dict"
+        d.keys()), "Mismatch between keys in template and in formatting dict"
 
     # Format implementation code
     implementation = ufcx_basix_custom_finite_element.factory.format_map(d)

--- a/ffcx/codegeneration/form.py
+++ b/ffcx/codegeneration/form.py
@@ -134,7 +134,7 @@ def generator(ir, parameters):
     # Check that no keys are redundant or have been missed
     from string import Formatter
     fields = [fname for _, fname, _, _ in Formatter().parse(form_template.factory) if fname]
-    assert set(fields) == set(d.keys()), "Mismatch between keys in template and in formattting dict"
+    assert set(fields) == set(d.keys()), "Mismatch between keys in template and in formatting dict"
 
     # Format implementation code
     implementation = form_template.factory.format_map(d)

--- a/ffcx/codegeneration/integrals.py
+++ b/ffcx/codegeneration/integrals.py
@@ -527,7 +527,7 @@ class IntegralGenerator(object):
     def generate_block_parts(self, quadrature_rule: QuadratureRule, blockmap: Tuple, blocklist: List[BlockDataT]):
         """Generate and return code parts for a given block.
 
-        Returns parts occuring before, inside, and after the quadrature
+        Returns parts occurring before, inside, and after the quadrature
         loop identified by the quadrature rule.
 
         Should be called with quadrature_rule=None for
@@ -539,7 +539,7 @@ class IntegralGenerator(object):
         preparts: List[CNode] = []
         quadparts: List[CNode] = []
 
-        # RHS expressiong grouped by LHS "dofmap"
+        # RHS expressions grouped by LHS "dofmap"
         rhs_expressions = collections.defaultdict(list)
 
         block_rank = len(blockmap)

--- a/ffcx/codegeneration/ufcx.h
+++ b/ffcx/codegeneration/ufcx.h
@@ -163,10 +163,10 @@ extern "C"
     /// The number of rows in the wcoeffs matrix
     int wcoeffs_rows;
 
-    /// The number of columnss in the wcoeffs matrix
+    /// The number of columns in the wcoeffs matrix
     int wcoeffs_cols;
 
-    /// The coefficents that define the polynomial set of the element in terms
+    /// The coefficients that define the polynomial set of the element in terms
     /// of the orthonormal polynomials on the cell
     double* wcoeffs;
 

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -326,7 +326,7 @@ def _compute_dofmap_ir(element, element_numbers, dofmap_names):
 
 def _compute_integral_ir(form_data, form_index, element_numbers, integral_names,
                          finite_element_names, parameters, visualise):
-    """Compute intermediate represention for form integrals."""
+    """Compute intermediate representation for form integrals."""
     _entity_types = {
         "cell": "cell",
         "exterior_facet": "facet",

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -172,7 +172,7 @@ def test_elimiate_zero_tables_tensor(compile_args):
                                   [u.dx(1), u.dx(1), 0],
                                   [0, 0, 0]]))
 
-    # Get vectices of cell
+    # Get vertices of cell
     # Coords storage XYZXYZXYZ
     basix_c_e = basix.create_element(basix.ElementFamily.P, basix.cell.string_to_type(cell), 1, False)
     coords = basix_c_e.points


### PR DESCRIPTION
Found via `codespell -q 3 -S ChangeLog.rst -L childs,nd,ned`