### PR TITLE
Add Python's CFLAGS, SOABI to cache key

### DIFF
--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -9,6 +9,7 @@ import io
 import logging
 import os
 import re
+import sysconfig
 import tempfile
 import time
 from contextlib import redirect_stdout
@@ -88,6 +89,22 @@ def get_cached_module(module_name, object_names, cache_dir, timeout):
         Try cleaning cache (e.g. remove {c_filename}) or increase timeout parameter.""")
 
 
+def _compilation_signature(cffi_extra_compile_args=None, cffi_debug=None):
+    """Compute the compilation-inputs part of the signature.
+
+    Used to avoid cache conflicts across Python versions, architectures, installs.
+
+    - SOABI includes platform, Python version, debug flags
+    - CFLAGS includes prefixes, arch targets
+    """
+    return (
+        str(cffi_extra_compile_args)
+        + str(cffi_debug)
+        + sysconfig.get_config_var("CFLAGS", "")
+        + sysconfig.get_config_var("SOABI", "")
+    )
+
+
 def compile_elements(elements, parameters=None, cache_dir=None, timeout=10, cffi_extra_compile_args=None,
                      cffi_verbose=False, cffi_debug=None, cffi_libraries=None):
     """Compile a list of UFL elements and dofmaps into Python objects."""
@@ -96,7 +113,7 @@ def compile_elements(elements, parameters=None, cache_dir=None, timeout=10, cffi
     # Get a signature for these elements
     module_name = 'libffcx_elements_' + \
         ffcx.naming.compute_signature(elements, _compute_parameter_signature(p)
-                                      + str(cffi_extra_compile_args) + str(cffi_debug))
+                                      + _compilation_signature(cffi_extra_compile_args, cffi_debug))
 
     names = []
     for e in elements:
@@ -145,7 +162,7 @@ def compile_forms(forms, parameters=None, cache_dir=None, timeout=10, cffi_extra
     # Get a signature for these forms
     module_name = 'libffcx_forms_' + \
         ffcx.naming.compute_signature(forms, _compute_parameter_signature(p)
-                                      + str(cffi_extra_compile_args) + str(cffi_debug))
+                                      + _compilation_signature(cffi_extra_compile_args, cffi_debug))
 
     form_names = [ffcx.naming.form_name(form, i, module_name) for i, form in enumerate(forms)]
 
@@ -191,7 +208,7 @@ def compile_expressions(expressions, parameters=None, cache_dir=None, timeout=10
 
     module_name = 'libffcx_expressions_' + \
         ffcx.naming.compute_signature(expressions, _compute_parameter_signature(p)
-                                      + str(cffi_extra_compile_args) + str(cffi_debug))
+                                      + _compilation_signature(cffi_extra_compile_args, cffi_debug))
     expr_names = [ffcx.naming.expression_name(expression, module_name) for expression in expressions]
 
     if cache_dir is not None:

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -100,8 +100,8 @@ def _compilation_signature(cffi_extra_compile_args=None, cffi_debug=None):
     return (
         str(cffi_extra_compile_args)
         + str(cffi_debug)
-        + sysconfig.get_config_var("CFLAGS", "")
-        + sysconfig.get_config_var("SOABI", "")
+        + sysconfig.get_config_var("CFLAGS")
+        + sysconfig.get_config_var("SOABI")
     )
 
 


### PR DESCRIPTION
SOABI is _often_ enough, but doesn't capture arm vs intel on mac (`sysconfig.get_platform()` does, but also includes the _current_ OS version rather than the compile target - invalidating the cache on annual upgrades). CFLAGS does capture target architecture, base SDK, etc.

Improves the situation for #290 (not sure if it's enough to close)

Avoids cache conflicts for:

- different Python versions, debug builds (SOABI)
- different architectures on mac (CFLAGS)
- different base SDKs, possible other compilation inputs

CFLAGS _will_ result in some potentially overzealous cache busting for e.g. multiple conda environments because the env prefix is included via `-I$PREFIX/include`, so multiple conda envs will not share a cache (maybe that's a good thing?). But other CFLAGS that change at the Python level may well be relevant.