### PR TITLE
Fix long_description after README changed from rst to md

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,8 @@ project_urls =
     Documentation = https://docs.fenicsproject.org
     Issues = https://github.com/FEniCS/ffcx/issues
     Funding = https://numfocus.org/donate
-long_description = file: README.rst
-long_description_content_type = text/x-rst
+long_description = file: README.md
+long_description_content_type = text/markdown
 license=LGPL-3.0-or-later
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Needs to be backported to create v0.5.0.post0 tag for pypi wheel push
