### PR TITLE
Don't change the UFL form

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: mscroggs/leave-ufl-elements-alone
       - name: Get DOLFINx source (specified branch/tag)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v2

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
+          ref: mscroggs/leave-ufl-elements-alone
       - name: Get DOLFINx source (specified branch/tag)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v2

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -150,16 +150,6 @@ def _analyze_form(form: ufl.form.Form, options: typing.Dict) -> ufl.algorithms.f
     if _has_custom_integrals(form):
         raise RuntimeError(f"Form ({form}) contains unsupported custom integrals.")
 
-    # Set default spacing for coordinate elements to be equispaced
-    for n, i in enumerate(form._integrals):
-        element = i._ufl_domain._ufl_coordinate_element
-        if not isinstance(element, basix.ufl_wrapper._BasixElementBase) and element._sub_element._variant is None:
-            sub_element = ufl.FiniteElement(
-                element.family(), element.cell(), element.degree(), element.quadrature_scheme(),
-                variant="equispaced")
-            equi_element = ufl.VectorElement(sub_element)
-            form._integrals[n]._ufl_domain._ufl_coordinate_element = equi_element
-
     # Check for complex mode
     complex_mode = "_Complex" in options["scalar_type"]
 

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -20,6 +20,7 @@ import numpy.typing
 import basix.ufl_wrapper
 import ufl
 from ffcx.element_interface import convert_element, QuadratureElement
+from warnings import warn
 
 logger = logging.getLogger("ffcx")
 
@@ -149,6 +150,12 @@ def _analyze_form(form: ufl.form.Form, options: typing.Dict) -> ufl.algorithms.f
         raise RuntimeError(f"Form ({form}) seems to be zero: cannot compile it.")
     if _has_custom_integrals(form):
         raise RuntimeError(f"Form ({form}) contains unsupported custom integrals.")
+
+    # Set default spacing for coordinate elements to be equispaced
+    for n, i in enumerate(form._integrals):
+        element = i._ufl_domain._ufl_coordinate_element
+        if not isinstance(element, basix.ufl_wrapper._BasixElementBase):
+            warn("UFL coordinate elements using elements not created via Basix may not work with DOLFINx")
 
     # Check for complex mode
     complex_mode = "_Complex" in options["scalar_type"]


### PR DESCRIPTION
Fixes FEniCS/dolfinx#2352.

This is coupled with https://github.com/FEniCS/dolfinx/pull/2388

Some DOLFINx code run from C++ may not longer work once this is merged if the ufl/py file creates the coordinate element via UFL instead of Basix. I've made the C++ demos do this correctly and made FFCx show a warning if a non-Basix element is used