### PR TITLE
Only warn for higher degree meshes

### DIFF
--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -154,7 +154,7 @@ def _analyze_form(form: ufl.form.Form, options: typing.Dict) -> ufl.algorithms.f
     # Set default spacing for coordinate elements to be equispaced
     for n, i in enumerate(form._integrals):
         element = i._ufl_domain._ufl_coordinate_element
-        if not isinstance(element, basix.ufl_wrapper._BasixElementBase):
+        if not isinstance(element, basix.ufl_wrapper._BasixElementBase) and element.degree() > 2:
             warn("UFL coordinate elements using elements not created via Basix may not work with DOLFINx")
 
     # Check for complex mode


### PR DESCRIPTION
This warning should only be shown when using higher degree meshes and so point spacing variants make a difference