### PR TITLE
Fix flake8 error due to version bump

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -14,6 +14,8 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+
+0.5.0
+-----
+See: https://github.com/FEniCS/ffcx/compare/v0.5.0...v0.4.0 for details
+
+0.4.0
+-----
+See: https://github.com/FEniCS/ffcx/compare/v0.4.0...v0.3.0 for details
+
+0.3.0
+-----
+See: https://github.com/FEniCS/ffcx/compare/v0.3.0...v0.2.0 for details
+
+0.2.0
+-----
+
+- No changes
+
 0.1.0
 -----
 Alpha release of ffcx

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,5 +74,8 @@ console_scripts =
 [flake8]
 max-line-length = 120
 exclude = .git,__pycache__,docs/source/conf.py,build,dist,libs
-ignore = W503,  # Line length
-         E741   # Variable names l, O, I, ...
+ignore =
+    # Line length
+    W503,
+    # Variable names l, O, I, ...
+    E741,


### PR DESCRIPTION
- Add workflow dispatch button to be able to execute workflows from github
- Fix setup.cfg as shown in: https://flake8.pycqa.org/en/latest/user/configuration.html
![image](https://user-images.githubusercontent.com/8554300/208698259-577cc521-26fd-49f2-afbb-d48ebbe7b4d3.png)
