### PR TITLE
Fix interval integrals with vertex rules

### DIFF
--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -416,7 +416,7 @@ def _compute_integral_ir(form_data, form_index, element_numbers, integral_names,
                                        np.array([1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0]))
                 elif cellname == "interval":
                     # Trapezoidal rule
-                    return (np.array([[0.0], [1.0]]), np.array([1.0 / 2.0, 1.0 / 2.0]))
+                    points, weights = (np.array([[0.0], [1.0]]), np.array([1.0 / 2.0, 1.0 / 2.0]))
             else:
                 degree = md["quadrature_degree"]
                 points, weights = create_quadrature_points_and_weights(

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -744,3 +744,42 @@ def test_invalid_function_name(compile_args):
 
     # Revert monkey patch for other tests
     ufl.Coefficient.__str__ = old_str
+
+
+def test_interval_vertex_quadrature(compile_args):
+
+    cell = ufl.interval
+    c_el = ufl.VectorElement("Lagrange", cell, 1)
+    mesh = ufl.Mesh(c_el)
+
+    el = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1)
+    V = ufl.FunctionSpace(mesh, el)
+
+    x = ufl.SpatialCoordinate(mesh)
+    v = ufl.TestFunction(V)
+    dx = ufl.Measure(
+        "dx", metadata={"quadrature_rule": "vertex"})
+    b = x[0] * dx
+
+    forms = [b]
+    compiled_forms, module, code = ffcx.codegeneration.jit.compile_forms(
+        forms, cffi_extra_compile_args=compile_args)
+
+    ffi = module.ffi
+    form0 = compiled_forms[0]
+    assert form0.num_integrals(module.lib.cell) == 1
+
+    default_integral = form0.integrals(module.lib.cell)[0]
+    J = np.zeros(1, dtype=np.float64)
+    a = np.pi
+    b = np.exp(1)
+    coords = np.array([a, 0.0, 0.0,
+
+                       b, 0.0, 0.0], dtype=np.float64)
+
+    kernel = getattr(default_integral, "tabulate_tensor_float64")
+    kernel(ffi.cast('double *', J.ctypes.data),
+           ffi.NULL,
+           ffi.NULL,
+           ffi.cast('double *', coords.ctypes.data), ffi.NULL, ffi.NULL)
+    assert np.isclose(J[0], (0.5 * a + 0.5 * b) * np.abs(b - a))

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -752,11 +752,7 @@ def test_interval_vertex_quadrature(compile_args):
     c_el = ufl.VectorElement("Lagrange", cell, 1)
     mesh = ufl.Mesh(c_el)
 
-    el = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1)
-    V = ufl.FunctionSpace(mesh, el)
-
     x = ufl.SpatialCoordinate(mesh)
-    v = ufl.TestFunction(V)
     dx = ufl.Measure(
         "dx", metadata={"quadrature_rule": "vertex"})
     b = x[0] * dx


### PR DESCRIPTION
Reported at:
https://fenicsproject.discourse.group/t/mass-lumping-in-time-dependent-problem/4420/2
MWE:
```python
import ufl

cell = ufl.interval
c_el = ufl.VectorElement("Lagrange", cell, 1)
mesh = ufl.Mesh(c_el)

el = ufl.FiniteElement("Lagrange", mesh.ufl_cell(), 1)
V = ufl.FunctionSpace(mesh, el)

x = ufl.SpatialCoordinate(mesh)
v = ufl.TestFunction(V)
dx = ufl.Measure(
    "dx", metadata={"quadrature_rule": "vertex", 'quadrature_degree': 1})
b = x[0]*v*dx

forms = [b]
```
yielding
```bash
Traceback (most recent call last):
  File "/root/.local/bin/ffcx", line 8, in <module>
    sys.exit(main())
  File "/root/shared/ffcx/ffcx/main.py", line 67, in main
    code_h, code_c = compiler.compile_ufl_objects(
  File "/root/shared/ffcx/ffcx/compiler.py", line 107, in compile_ufl_objects
    code = generate_code(ir, options)
  File "/root/shared/ffcx/ffcx/codegeneration/codegeneration.py", line 50, in generate_code
    code_integrals = [integral_generator(integral_ir, options) for integral_ir in ir.integrals]
  File "/root/shared/ffcx/ffcx/codegeneration/codegeneration.py", line 50, in <listcomp>
    code_integrals = [integral_generator(integral_ir, options) for integral_ir in ir.integrals]
  File "/root/shared/ffcx/ffcx/codegeneration/integrals.py", line 27, in generator
    logger.info(f"--- type: {ir.integral_type}")
AttributeError: 'numpy.ndarray' object has no attribute 'integral_type'
```