### PR TITLE
Rename basix.ufl_wrapper -> basix.ufl

### DIFF
--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -47,7 +47,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         run: |
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/basix.git
+          python3 -m pip install git+https://github.com/FEniCS/basix.git@mscroggs/ufl
       - name: Install UFL and Basix (specified branches/tags)
         if: github.event_name == 'workflow_dispatch'
         run: |
@@ -64,6 +64,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
+          ref: mscroggs/basix-element2
       - name: Get DOLFINx source (specified branch/tag)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v3

--- a/.github/workflows/dolfin-tests.yml
+++ b/.github/workflows/dolfin-tests.yml
@@ -47,7 +47,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         run: |
           python3 -m pip install git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install git+https://github.com/FEniCS/basix.git@mscroggs/ufl
+          python3 -m pip install git+https://github.com/FEniCS/basix.git
       - name: Install UFL and Basix (specified branches/tags)
         if: github.event_name == 'workflow_dispatch'
         run: |
@@ -64,7 +64,7 @@ jobs:
         with:
           path: ./dolfinx
           repository: FEniCS/dolfinx
-          ref: mscroggs/basix-element2
+          ref: main
       - name: Get DOLFINx source (specified branch/tag)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v3

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install FEniCS dependencies (Python)
         run: |
           python -m pip install git+https://github.com/FEniCS/ufl.git
-          python -m pip install git+https://github.com/FEniCS/basix.git
+          python -m pip install git+https://github.com/FEniCS/basix.git@mscroggs/ufl
 
       - name: Install FFCx
         run: |

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install FEniCS dependencies (Python)
         run: |
           python -m pip install git+https://github.com/FEniCS/ufl.git
-          python -m pip install git+https://github.com/FEniCS/basix.git@mscroggs/ufl
+          python -m pip install git+https://github.com/FEniCS/basix.git
 
       - name: Install FFCx
         run: |

--- a/demo/BiharmonicHHJ.py
+++ b/demo/BiharmonicHHJ.py
@@ -3,13 +3,13 @@
 # The bilinear form a(u, v) and linear form L(v) for
 # Biharmonic equation in Hellan-Herrmann-Johnson (HHJ)
 # formulation.
-from basix.ufl import MixedElement, element
+from basix.ufl import mixed_element, element
 from ufl import (Coefficient, FacetNormal, TestFunctions, TrialFunctions, dot,
                  dS, ds, dx, grad, inner, jump, triangle)
 
 HHJ = element('HHJ', "triangle", 2)
 CG = element('CG', "triangle", 3)
-mixed_element = MixedElement([HHJ, CG])
+mixed_element = mixed_element([HHJ, CG])
 
 (sigma, u) = TrialFunctions(mixed_element)
 (tau, v) = TestFunctions(mixed_element)

--- a/demo/BiharmonicHHJ.py
+++ b/demo/BiharmonicHHJ.py
@@ -3,13 +3,13 @@
 # The bilinear form a(u, v) and linear form L(v) for
 # Biharmonic equation in Hellan-Herrmann-Johnson (HHJ)
 # formulation.
-from basix.ufl import mixed_element, element
+import basix.ufl
 from ufl import (Coefficient, FacetNormal, TestFunctions, TrialFunctions, dot,
                  dS, ds, dx, grad, inner, jump, triangle)
 
-HHJ = element('HHJ', "triangle", 2)
-P = element('P', "triangle", 3)
-mixed_element = mixed_element([HHJ, P])
+HHJ = basix.ufl.element('HHJ', "triangle", 2)
+P = basix.ufl.element('P', "triangle", 3)
+mixed_element = basix.ufl.mixed_element([HHJ, P])
 
 (sigma, u) = TrialFunctions(mixed_element)
 (tau, v) = TestFunctions(mixed_element)

--- a/demo/BiharmonicHHJ.py
+++ b/demo/BiharmonicHHJ.py
@@ -3,12 +3,13 @@
 # The bilinear form a(u, v) and linear form L(v) for
 # Biharmonic equation in Hellan-Herrmann-Johnson (HHJ)
 # formulation.
-from ufl import (Coefficient, FacetNormal, FiniteElement, TestFunctions,
-                 TrialFunctions, dot, dS, ds, dx, grad, inner, jump, triangle)
+from basix.ufl import MixedElement, element
+from ufl import (Coefficient, FacetNormal, TestFunctions, TrialFunctions, dot,
+                 dS, ds, dx, grad, inner, jump, triangle)
 
-HHJ = FiniteElement('HHJ', triangle, 2)
-CG = FiniteElement('CG', triangle, 3)
-mixed_element = HHJ * CG
+HHJ = element('HHJ', "triangle", 2)
+CG = element('CG', "triangle", 3)
+mixed_element = MixedElement([HHJ, CG])
 
 (sigma, u) = TrialFunctions(mixed_element)
 (tau, v) = TestFunctions(mixed_element)

--- a/demo/BiharmonicHHJ.py
+++ b/demo/BiharmonicHHJ.py
@@ -8,12 +8,12 @@ from ufl import (Coefficient, FacetNormal, TestFunctions, TrialFunctions, dot,
                  dS, ds, dx, grad, inner, jump, triangle)
 
 HHJ = element('HHJ', "triangle", 2)
-CG = element('CG', "triangle", 3)
-mixed_element = mixed_element([HHJ, CG])
+P = element('P', "triangle", 3)
+mixed_element = mixed_element([HHJ, P])
 
 (sigma, u) = TrialFunctions(mixed_element)
 (tau, v) = TestFunctions(mixed_element)
-f = Coefficient(CG)
+f = Coefficient(P)
 
 
 def b(sigma, v):

--- a/demo/BiharmonicRegge.py
+++ b/demo/BiharmonicRegge.py
@@ -2,13 +2,14 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for
 # Biharmonic equation in Regge formulation.
-from ufl import (Coefficient, FacetNormal, FiniteElement, Identity,
-                 TestFunctions, TrialFunctions, dot, dS, ds, dx, grad, inner,
-                 jump, tetrahedron, tr)
+from basix.ufl import MixedElement, element
+from ufl import (Coefficient, FacetNormal, Identity, TestFunctions,
+                 TrialFunctions, dot, dS, ds, dx, grad, inner, jump,
+                 tetrahedron, tr)
 
-REG = FiniteElement('Regge', tetrahedron, 1)
-CG = FiniteElement('Lagrange', tetrahedron, 2)
-mixed_element = REG * CG
+REG = element("Regge", "tetrahedron", 1)
+CG = element("Lagrange", "tetrahedron", 2)
+mixed_element = MixedElement([REG, CG])
 
 (sigma, u) = TrialFunctions(mixed_element)
 (tau, v) = TestFunctions(mixed_element)

--- a/demo/BiharmonicRegge.py
+++ b/demo/BiharmonicRegge.py
@@ -2,14 +2,14 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for
 # Biharmonic equation in Regge formulation.
-from basix.ufl import mixed_element, element
+import basix.ufl
 from ufl import (Coefficient, FacetNormal, Identity, TestFunctions,
                  TrialFunctions, dot, dS, ds, dx, grad, inner, jump,
                  tetrahedron, tr)
 
-REG = element("Regge", "tetrahedron", 1)
-P = element("Lagrange", "tetrahedron", 2)
-mixed_element = mixed_element([REG, P])
+REG = basix.ufl.element("Regge", "tetrahedron", 1)
+P = basix.ufl.element("Lagrange", "tetrahedron", 2)
+mixed_element = basix.ufl.mixed_element([REG, P])
 
 (sigma, u) = TrialFunctions(mixed_element)
 (tau, v) = TestFunctions(mixed_element)

--- a/demo/BiharmonicRegge.py
+++ b/demo/BiharmonicRegge.py
@@ -2,14 +2,14 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for
 # Biharmonic equation in Regge formulation.
-from basix.ufl import MixedElement, element
+from basix.ufl import mixed_element, element
 from ufl import (Coefficient, FacetNormal, Identity, TestFunctions,
                  TrialFunctions, dot, dS, ds, dx, grad, inner, jump,
                  tetrahedron, tr)
 
 REG = element("Regge", "tetrahedron", 1)
 CG = element("Lagrange", "tetrahedron", 2)
-mixed_element = MixedElement([REG, CG])
+mixed_element = mixed_element([REG, CG])
 
 (sigma, u) = TrialFunctions(mixed_element)
 (tau, v) = TestFunctions(mixed_element)

--- a/demo/BiharmonicRegge.py
+++ b/demo/BiharmonicRegge.py
@@ -8,12 +8,12 @@ from ufl import (Coefficient, FacetNormal, Identity, TestFunctions,
                  tetrahedron, tr)
 
 REG = element("Regge", "tetrahedron", 1)
-CG = element("Lagrange", "tetrahedron", 2)
-mixed_element = mixed_element([REG, CG])
+P = element("Lagrange", "tetrahedron", 2)
+mixed_element = mixed_element([REG, P])
 
 (sigma, u) = TrialFunctions(mixed_element)
 (tau, v) = TestFunctions(mixed_element)
-f = Coefficient(CG)
+f = Coefficient(P)
 
 
 def S(mu):

--- a/demo/CellGeometry.py
+++ b/demo/CellGeometry.py
@@ -6,7 +6,7 @@ from ufl import (CellVolume, Circumradius, Coefficient, FacetArea, FacetNormal,
                  SpatialCoordinate, ds, dx, tetrahedron)
 
 cell = tetrahedron
-V = element("CG", cell.cellname(), 1)
+V = element("P", cell.cellname(), 1)
 u = Coefficient(V)
 
 # TODO: Add all geometry for all cell types to this and other demo files, need for regression test.

--- a/demo/CellGeometry.py
+++ b/demo/CellGeometry.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2013 Martin S. Alnaes
 #
 # A functional M involving a bunch of cell geometry quantities.
+from basix.ufl import element
 from ufl import (CellVolume, Circumradius, Coefficient, FacetArea, FacetNormal,
-                 FiniteElement, SpatialCoordinate, ds, dx, tetrahedron)
+                 SpatialCoordinate, ds, dx, tetrahedron)
 
 cell = tetrahedron
-
-V = FiniteElement("CG", cell, 1)
+V = element("CG", cell.cellname(), 1)
 u = Coefficient(V)
 
 # TODO: Add all geometry for all cell types to this and other demo files, need for regression test.

--- a/demo/CellGeometry.py
+++ b/demo/CellGeometry.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2013 Martin S. Alnaes
 #
 # A functional M involving a bunch of cell geometry quantities.
-from basix.ufl import element
+import basix.ufl
 from ufl import (CellVolume, Circumradius, Coefficient, FacetArea, FacetNormal,
                  SpatialCoordinate, ds, dx, tetrahedron)
 
 cell = tetrahedron
-V = element("P", cell.cellname(), 1)
+V = basix.ufl.element("P", cell.cellname(), 1)
 u = Coefficient(V)
 
 # TODO: Add all geometry for all cell types to this and other demo files, need for regression test.

--- a/demo/Components.py
+++ b/demo/Components.py
@@ -16,10 +16,10 @@
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
 #
 # This example demonstrates how to create vectors component-wise
-from ufl import (Coefficient, TestFunction, VectorElement, as_vector, dot, dx,
-                 tetrahedron)
+import basix.ufl
+from ufl import Coefficient, TestFunction, as_vector, dot, dx
 
-element = VectorElement("Lagrange", tetrahedron, 1)
+element = basix.ufl.element("Lagrange", "tetrahedron", 1, rank=1)
 
 v = TestFunction(element)
 f = Coefficient(element)

--- a/demo/Conditional.py
+++ b/demo/Conditional.py
@@ -16,10 +16,11 @@
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
 #
 # Illustration on how to use Conditional to define a source term
-from ufl import (And, Constant, FiniteElement, Not, Or, SpatialCoordinate,
-                 TestFunction, conditional, dx, ge, gt, le, lt, triangle)
+import basix.ufl
+from ufl import (And, Constant, Not, Or, SpatialCoordinate, TestFunction,
+                 conditional, dx, ge, gt, le, lt, triangle)
 
-element = FiniteElement("Lagrange", triangle, 2)
+element = basix.ufl.element("Lagrange", "triangle", 2)
 
 v = TestFunction(element)
 g = Constant(triangle)

--- a/demo/ExpressionInterpolation.py
+++ b/demo/ExpressionInterpolation.py
@@ -29,7 +29,7 @@ v_el = element("Lagrange", cell, 1, rank=1)
 mesh = Mesh(v_el)
 
 # Define mixed function space
-el = element("CG", cell, 2)
+el = element("P", cell, 2)
 el_int = element("Discontinuous Lagrange", cell, 1, rank=1)
 me = mixed_element([el, el_int])
 V = FunctionSpace(mesh, me)

--- a/demo/ExpressionInterpolation.py
+++ b/demo/ExpressionInterpolation.py
@@ -19,7 +19,7 @@
 # a set of interpolation points
 
 import basix
-from basix.ufl import MixedElement, element
+from basix.ufl import mixed_element, element
 from ffcx.element_interface import QuadratureElement
 from ufl import Coefficient, FunctionSpace, Mesh, grad
 
@@ -31,7 +31,7 @@ mesh = Mesh(v_el)
 # Define mixed function space
 el = element("CG", cell, 2)
 el_int = element("Discontinuous Lagrange", cell, 1, rank=1)
-me = MixedElement([el, el_int])
+me = mixed_element([el, el_int])
 V = FunctionSpace(mesh, me)
 u = Coefficient(V)
 

--- a/demo/ExpressionInterpolation.py
+++ b/demo/ExpressionInterpolation.py
@@ -19,17 +19,18 @@
 # a set of interpolation points
 
 import basix
-from ufl import (Coefficient, FiniteElement, FunctionSpace, Mesh, MixedElement,
-                 VectorElement, grad, triangle)
+from basix.ufl import MixedElement, element
+from ffcx.element_interface import QuadratureElement
+from ufl import Coefficient, FunctionSpace, Mesh, grad
 
 # Define mesh
-cell = triangle
-v_el = VectorElement("Lagrange", cell, 1)
+cell = "triangle"
+v_el = element("Lagrange", cell, 1, rank=1)
 mesh = Mesh(v_el)
 
 # Define mixed function space
-el = FiniteElement("CG", cell, 2)
-el_int = VectorElement("Discontinuous Lagrange", cell, 1)
+el = element("CG", cell, 2)
+el_int = element("Discontinuous Lagrange", cell, 1, rank=1)
 me = MixedElement([el, el_int])
 V = FunctionSpace(mesh, me)
 u = Coefficient(V)
@@ -41,20 +42,20 @@ du1 = grad(u[1])
 # Define an expression using quadrature elements
 q_rule = "gauss_jacobi"
 q_degree = 3
-q_el = FiniteElement("Quadrature", cell, q_degree, quad_scheme=q_rule)
+q_el = QuadratureElement(cell, (), q_rule, q_degree)
 Q = FunctionSpace(mesh, q_el)
 q = Coefficient(Q)
 powq = 3 * q**2
 
 # Extract basix cell type
-b_cell = basix.cell.string_to_type(cell.cellname())
+b_cell = basix.cell.string_to_type(cell)
 
 # Find quadrature points for quadrature element
 b_rule = basix.quadrature.string_to_type(q_rule)
 quadrature_points, _ = basix.make_quadrature(b_rule, b_cell, q_degree)
 
 # Get interpolation points for output space
-family = basix.finite_element.string_to_family("Lagrange", cell.cellname())
+family = basix.finite_element.string_to_family("Lagrange", cell)
 b_element = basix.create_element(family, b_cell, 4, basix.LagrangeVariant.gll_warped, discontinuous=True)
 interpolation_points = b_element.points
 

--- a/demo/ExpressionInterpolation.py
+++ b/demo/ExpressionInterpolation.py
@@ -19,19 +19,19 @@
 # a set of interpolation points
 
 import basix
-from basix.ufl import mixed_element, element
+import basix.ufl
 from ffcx.element_interface import QuadratureElement
 from ufl import Coefficient, FunctionSpace, Mesh, grad
 
 # Define mesh
 cell = "triangle"
-v_el = element("Lagrange", cell, 1, rank=1)
+v_el = basix.ufl.element("Lagrange", cell, 1, rank=1)
 mesh = Mesh(v_el)
 
 # Define mixed function space
-el = element("P", cell, 2)
-el_int = element("Discontinuous Lagrange", cell, 1, rank=1)
-me = mixed_element([el, el_int])
+el = basix.ufl.element("P", cell, 2)
+el_int = basix.ufl.element("Discontinuous Lagrange", cell, 1, rank=1)
+me = basix.ufl.mixed_element([el, el_int])
 V = FunctionSpace(mesh, me)
 u = Coefficient(V)
 

--- a/demo/FacetIntegrals.py
+++ b/demo/FacetIntegrals.py
@@ -19,10 +19,11 @@
 # Last changed: 2011-03-08
 #
 # Simple example of a form defined over exterior and interior facets.
-from ufl import (FacetNormal, FiniteElement, TestFunction, TrialFunction, avg,
-                 ds, dS, grad, inner, jump, triangle)
+import basix.ufl
+from ufl import (FacetNormal, TestFunction, TrialFunction, avg, ds, dS, grad,
+                 inner, jump, triangle)
 
-element = FiniteElement("Discontinuous Lagrange", triangle, 1)
+element = basix.ufl.element("Discontinuous Lagrange", "triangle", 1)
 
 u = TrialFunction(element)
 v = TestFunction(element)

--- a/demo/FacetRestrictionAD.py
+++ b/demo/FacetRestrictionAD.py
@@ -14,10 +14,11 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
-from ufl import (Coefficient, FiniteElement, TestFunction, TrialFunction, avg,
-                 derivative, dot, dS, dx, grad, inner, triangle)
+import basix.ufl
+from ufl import (Coefficient, TestFunction, TrialFunction, avg, derivative,
+                 dot, dS, dx, grad, inner)
 
-element = FiniteElement("Discontinuous Lagrange", triangle, 1)
+element = basix.ufl.element("Discontinuous Lagrange", "triangle", 1)
 
 v = TestFunction(element)
 w = Coefficient(element)

--- a/demo/HyperElasticity.py
+++ b/demo/HyperElasticity.py
@@ -3,11 +3,12 @@
 # Date: 2008-12-22
 #
 
+from basix.ufl import element
 # Modified by Garth N. Wells, 2009
-from ufl import (Coefficient, Constant, FacetNormal, FiniteElement, Identity,
-                 SpatialCoordinate, TensorElement, TestFunction, TrialFunction,
-                 VectorElement, derivative, det, diff, dot, ds, dx, exp, grad,
-                 inner, inv, tetrahedron, tr, variable)
+from ufl import (Coefficient, Constant, FacetNormal, Identity,
+                 SpatialCoordinate, TestFunction, TrialFunction, derivative,
+                 det, diff, dot, ds, dx, exp, grad, inner, inv, tetrahedron,
+                 tr, variable)
 
 # Cell and its properties
 cell = tetrahedron
@@ -16,9 +17,9 @@ N = FacetNormal(cell)
 x = SpatialCoordinate(cell)
 
 # Elements
-u_element = VectorElement("CG", cell, 2)
-p_element = FiniteElement("CG", cell, 1)
-A_element = TensorElement("CG", cell, 1)
+u_element = element("CG", cell.cellname(), 2, rank=1)
+p_element = element("CG", cell.cellname(), 1)
+A_element = element("CG", cell.cellname(), 1, rank=2)
 
 # Test and trial functions
 v = TestFunction(u_element)

--- a/demo/HyperElasticity.py
+++ b/demo/HyperElasticity.py
@@ -17,9 +17,9 @@ N = FacetNormal(cell)
 x = SpatialCoordinate(cell)
 
 # Elements
-u_element = element("CG", cell.cellname(), 2, rank=1)
-p_element = element("CG", cell.cellname(), 1)
-A_element = element("CG", cell.cellname(), 1, rank=2)
+u_element = element("P", cell.cellname(), 2, rank=1)
+p_element = element("P", cell.cellname(), 1)
+A_element = element("P", cell.cellname(), 1, rank=2)
 
 # Test and trial functions
 v = TestFunction(u_element)

--- a/demo/HyperElasticity.py
+++ b/demo/HyperElasticity.py
@@ -3,7 +3,7 @@
 # Date: 2008-12-22
 #
 
-from basix.ufl import element
+import basix.ufl
 # Modified by Garth N. Wells, 2009
 from ufl import (Coefficient, Constant, FacetNormal, Identity,
                  SpatialCoordinate, TestFunction, TrialFunction, derivative,
@@ -17,9 +17,9 @@ N = FacetNormal(cell)
 x = SpatialCoordinate(cell)
 
 # Elements
-u_element = element("P", cell.cellname(), 2, rank=1)
-p_element = element("P", cell.cellname(), 1)
-A_element = element("P", cell.cellname(), 1, rank=2)
+u_element = basix.ufl.element("P", cell.cellname(), 2, rank=1)
+p_element = basix.ufl.element("P", cell.cellname(), 1)
+A_element = basix.ufl.element("P", cell.cellname(), 1, rank=2)
 
 # Test and trial functions
 v = TestFunction(u_element)

--- a/demo/MassDG0.py
+++ b/demo/MassDG0.py
@@ -16,10 +16,10 @@
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
 #
 # The bilinear form for a mass matrix.
-from ufl import (FiniteElement, TestFunction, TrialFunction, dx, inner,
-                 tetrahedron)
+import basix.ufl
+from ufl import TestFunction, TrialFunction, dx, inner
 
-element = FiniteElement("DG", tetrahedron, 0)
+element = basix.ufl.element("DG", "tetrahedron", 0)
 
 v = TestFunction(element)
 u = TrialFunction(element)

--- a/demo/MassHcurl_2D_1.py
+++ b/demo/MassHcurl_2D_1.py
@@ -14,9 +14,10 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
-from ufl import FiniteElement, TestFunction, TrialFunction, dx, inner, triangle
+import basix.ufl
+from ufl import TestFunction, TrialFunction, dx, inner
 
-element = FiniteElement("N1curl", triangle, 1)
+element = basix.ufl.element("N1curl", "triangle", 1)
 
 v = TestFunction(element)
 u = TrialFunction(element)

--- a/demo/MassHdiv_2D_1.py
+++ b/demo/MassHdiv_2D_1.py
@@ -14,9 +14,10 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
-from ufl import FiniteElement, TestFunction, TrialFunction, dx, inner, triangle
+import basix.ufl
+from ufl import TestFunction, TrialFunction, dx, inner
 
-element = FiniteElement("BDM", triangle, 1)
+element = basix.ufl.element("BDM", "triangle", 1)
 
 v = TestFunction(element)
 u = TrialFunction(element)

--- a/demo/MathFunctions.py
+++ b/demo/MathFunctions.py
@@ -16,10 +16,11 @@
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
 #
 # Test all algebra operators on Coefficients.
-from ufl import (Coefficient, FiniteElement, acos, asin, atan, bessel_J,
-                 bessel_Y, cos, dx, erf, exp, ln, sin, sqrt, tan, triangle)
+import basix.ufl
+from ufl import (Coefficient, acos, asin, atan, bessel_J, bessel_Y, cos, dx,
+                 erf, exp, ln, sin, sqrt, tan)
 
-element = FiniteElement("Lagrange", triangle, 1)
+element = basix.ufl.element("Lagrange", "triangle", 1)
 
 c0 = Coefficient(element)
 c1 = Coefficient(element)

--- a/demo/MetaData.py
+++ b/demo/MetaData.py
@@ -16,11 +16,11 @@
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
 #
 # Test form for metadata.
-from ufl import (Coefficient, FiniteElement, TestFunction, TrialFunction,
-                 VectorElement, dx, grad, inner, triangle)
+import basix.ufl
+from ufl import Coefficient, TestFunction, TrialFunction, dx, grad, inner
 
-element = FiniteElement("Lagrange", triangle, 1)
-vector_element = VectorElement("Lagrange", triangle, 1)
+element = basix.ufl.element("Lagrange", "triangle", 1)
+vector_element = basix.ufl.element("Lagrange", "triangle", 1, rank=1)
 
 
 u = TrialFunction(element)

--- a/demo/Mini.py
+++ b/demo/Mini.py
@@ -25,7 +25,7 @@ from ufl import TestFunctions, TrialFunctions, div, dx, grad, inner
 P1 = element("Lagrange", "triangle", 1)
 B = element("Bubble", "triangle", 3)
 V = blocked_element(enriched_element([P1, B]), shape=(2, ))
-Q = element("CG", "triangle", 1)
+Q = element("P", "triangle", 1)
 
 Mini = mixed_element([V, Q])
 (u, p) = TrialFunctions(Mini)

--- a/demo/Mini.py
+++ b/demo/Mini.py
@@ -19,15 +19,15 @@
 # bilinear form a(u, v) for the Stokes equations using a mixed
 # formulation involving the Mini element. The velocity element is
 # composed of a P1 element augmented by the cubic bubble function.
-from basix.ufl import BlockedElement, MixedElement, element, enriched_element
+from basix.ufl import blocked_element, mixed_element, element, enriched_element
 from ufl import TestFunctions, TrialFunctions, div, dx, grad, inner
 
 P1 = element("Lagrange", "triangle", 1)
 B = element("Bubble", "triangle", 3)
-V = BlockedElement(enriched_element([P1, B]), shape=(2, ))
+V = blocked_element(enriched_element([P1, B]), shape=(2, ))
 Q = element("CG", "triangle", 1)
 
-Mini = MixedElement([V, Q])
+Mini = mixed_element([V, Q])
 (u, p) = TrialFunctions(Mini)
 (v, q) = TestFunctions(Mini)
 

--- a/demo/Mini.py
+++ b/demo/Mini.py
@@ -19,15 +19,15 @@
 # bilinear form a(u, v) for the Stokes equations using a mixed
 # formulation involving the Mini element. The velocity element is
 # composed of a P1 element augmented by the cubic bubble function.
-from ufl import (FiniteElement, TestFunctions, TrialFunctions, VectorElement,
-                 div, dx, grad, inner, triangle)
+from basix.ufl import BlockedElement, MixedElement, element, enriched_element
+from ufl import TestFunctions, TrialFunctions, div, dx, grad, inner
 
-P1 = FiniteElement("Lagrange", triangle, 1)
-B = FiniteElement("Bubble", triangle, 3)
-V = VectorElement(P1 + B)
-Q = FiniteElement("CG", triangle, 1)
+P1 = element("Lagrange", "triangle", 1)
+B = element("Bubble", "triangle", 3)
+V = BlockedElement(enriched_element([P1, B]), shape=(2, ))
+Q = element("CG", "triangle", 1)
 
-Mini = V * Q
+Mini = MixedElement([V, Q])
 (u, p) = TrialFunctions(Mini)
 (v, q) = TestFunctions(Mini)
 

--- a/demo/Mini.py
+++ b/demo/Mini.py
@@ -19,15 +19,15 @@
 # bilinear form a(u, v) for the Stokes equations using a mixed
 # formulation involving the Mini element. The velocity element is
 # composed of a P1 element augmented by the cubic bubble function.
-from basix.ufl import blocked_element, mixed_element, element, enriched_element
+import basix.ufl
 from ufl import TestFunctions, TrialFunctions, div, dx, grad, inner
 
-P1 = element("Lagrange", "triangle", 1)
-B = element("Bubble", "triangle", 3)
-V = blocked_element(enriched_element([P1, B]), shape=(2, ))
-Q = element("P", "triangle", 1)
+P1 = basix.ufl.element("Lagrange", "triangle", 1)
+B = basix.ufl.element("Bubble", "triangle", 3)
+V = basix.ufl.blocked_element(basix.ufl.enriched_element([P1, B]), shape=(2, ))
+Q = basix.ufl.element("P", "triangle", 1)
 
-Mini = mixed_element([V, Q])
+Mini = basix.ufl.mixed_element([V, Q])
 (u, p) = TrialFunctions(Mini)
 (v, q) = TestFunctions(Mini)
 

--- a/demo/MixedCoefficient.py
+++ b/demo/MixedCoefficient.py
@@ -18,16 +18,14 @@
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
 #
 # Mixed coefficient.
-from ufl import (Coefficients, FiniteElement, MixedElement, VectorElement, dot,
-                 dS, dx, triangle)
+import basix.ufl
+from ufl import Coefficients, dot, dS, dx
 
-cell = triangle
+DG = basix.ufl.element("DG", "triangle", 0, rank=1)
+CG = basix.ufl.element("Lagrange", "triangle", 2)
+RT = basix.ufl.element("RT", "triangle", 3)
 
-DG = VectorElement("DG", cell, 0)
-CG = FiniteElement("Lagrange", cell, 2)
-RT = FiniteElement("RT", cell, 3)
-
-element = MixedElement(DG, CG, RT)
+element = basix.ufl.MixedElement([DG, CG, RT])
 
 f, g, h = Coefficients(element)
 

--- a/demo/MixedCoefficient.py
+++ b/demo/MixedCoefficient.py
@@ -25,7 +25,7 @@ DG = basix.ufl.element("DG", "triangle", 0, rank=1)
 CG = basix.ufl.element("Lagrange", "triangle", 2)
 RT = basix.ufl.element("RT", "triangle", 3)
 
-element = basix.ufl.MixedElement([DG, CG, RT])
+element = basix.ufl.mixed_element([DG, CG, RT])
 
 f, g, h = Coefficients(element)
 

--- a/demo/MixedGradient.py
+++ b/demo/MixedGradient.py
@@ -3,7 +3,7 @@ from ufl import TestFunctions, TrialFunctions, ds, grad, inner
 
 element1 = basix.ufl.element("DG", "triangle", 1)
 element2 = basix.ufl.element("DGT", "triangle", 1)
-element = basix.ufl.MixedElement([element1, element2])
+element = basix.ufl.mixed_element([element1, element2])
 
 u = TrialFunctions(element)[0]
 v = TestFunctions(element)[0]

--- a/demo/MixedGradient.py
+++ b/demo/MixedGradient.py
@@ -1,9 +1,9 @@
-from ufl import (FiniteElement, MixedElement, TestFunctions, TrialFunctions,
-                 ds, grad, inner, triangle)
+import basix.ufl
+from ufl import TestFunctions, TrialFunctions, ds, grad, inner
 
-element1 = FiniteElement("DG", triangle, 1)
-element2 = FiniteElement("DGT", triangle, 1)
-element = MixedElement(element1, element2)
+element1 = basix.ufl.element("DG", "triangle", 1)
+element2 = basix.ufl.element("DGT", "triangle", 1)
+element = basix.ufl.MixedElement([element1, element2])
 
 u = TrialFunctions(element)[0]
 v = TestFunctions(element)[0]

--- a/demo/MixedPoissonDual.py
+++ b/demo/MixedPoissonDual.py
@@ -24,15 +24,15 @@ from basix.ufl import mixed_element, element
 from ufl import Coefficient, TestFunctions, TrialFunctions, dot, ds, dx, grad
 
 DRT = element("Discontinuous RT", "triangle", 2)
-CG = element("CG", "triangle", 3)
-W = mixed_element([DRT, CG])
+P = element("P", "triangle", 3)
+W = mixed_element([DRT, P])
 
 (sigma, u) = TrialFunctions(W)
 (tau, v) = TestFunctions(W)
 
-CG1 = element("CG", "triangle", 1)
-f = Coefficient(CG1)
-g = Coefficient(CG1)
+P1 = element("P", "triangle", 1)
+f = Coefficient(P1)
+g = Coefficient(P1)
 
 a = (dot(sigma, tau) + dot(grad(u), tau) + dot(sigma, grad(v))) * dx
 L = - f * v * dx - g * v * ds

--- a/demo/MixedPoissonDual.py
+++ b/demo/MixedPoissonDual.py
@@ -20,17 +20,17 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for a two-field
 # (mixed) formulation of Poisson's equation
-from ufl import (Coefficient, FiniteElement, TestFunctions, TrialFunctions,
-                 dot, ds, dx, grad, triangle)
+from basix.ufl import MixedElement, element
+from ufl import Coefficient, TestFunctions, TrialFunctions, dot, ds, dx, grad
 
-DRT = FiniteElement("DRT", triangle, 2)
-CG = FiniteElement("CG", triangle, 3)
-W = DRT * CG
+DRT = element("Discontinuous RT", "triangle", 2)
+CG = element("CG", "triangle", 3)
+W = MixedElement([DRT, CG])
 
 (sigma, u) = TrialFunctions(W)
 (tau, v) = TestFunctions(W)
 
-CG1 = FiniteElement("CG", triangle, 1)
+CG1 = element("CG", "triangle", 1)
 f = Coefficient(CG1)
 g = Coefficient(CG1)
 

--- a/demo/MixedPoissonDual.py
+++ b/demo/MixedPoissonDual.py
@@ -20,12 +20,12 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for a two-field
 # (mixed) formulation of Poisson's equation
-from basix.ufl import mixed_element, element
+import basix.ufl
 from ufl import Coefficient, TestFunctions, TrialFunctions, dot, ds, dx, grad
 
-DRT = element("Discontinuous RT", "triangle", 2)
-P = element("P", "triangle", 3)
-W = mixed_element([DRT, P])
+DRT = basix.ufl.element("Discontinuous RT", "triangle", 2)
+P = basix.ufl.element("P", "triangle", 3)
+W = basix.ufl.mixed_element([DRT, P])
 
 (sigma, u) = TrialFunctions(W)
 (tau, v) = TestFunctions(W)

--- a/demo/MixedPoissonDual.py
+++ b/demo/MixedPoissonDual.py
@@ -30,7 +30,7 @@ W = basix.ufl.mixed_element([DRT, P])
 (sigma, u) = TrialFunctions(W)
 (tau, v) = TestFunctions(W)
 
-P1 = element("P", "triangle", 1)
+P1 = basix.ufl.element("P", "triangle", 1)
 f = Coefficient(P1)
 g = Coefficient(P1)
 

--- a/demo/MixedPoissonDual.py
+++ b/demo/MixedPoissonDual.py
@@ -20,12 +20,12 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for a two-field
 # (mixed) formulation of Poisson's equation
-from basix.ufl import MixedElement, element
+from basix.ufl import mixed_element, element
 from ufl import Coefficient, TestFunctions, TrialFunctions, dot, ds, dx, grad
 
 DRT = element("Discontinuous RT", "triangle", 2)
 CG = element("CG", "triangle", 3)
-W = MixedElement([DRT, CG])
+W = mixed_element([DRT, CG])
 
 (sigma, u) = TrialFunctions(W)
 (tau, v) = TestFunctions(W)

--- a/demo/Normals.py
+++ b/demo/Normals.py
@@ -17,12 +17,12 @@
 #
 # This example demonstrates how to use the facet normals
 # Merely project the normal onto a vector section.
-from ufl import (FacetNormal, TestFunction, TrialFunction, VectorElement, dot,
-                 ds, triangle)
+import basix.ufl
+from ufl import FacetNormal, TestFunction, TrialFunction, dot, ds, triangle
 
 cell = triangle
 
-element = VectorElement("Lagrange", cell, 1)
+element = basix.ufl.element("Lagrange", cell.cellname(), 1, rank=1)
 
 n = FacetNormal(cell)
 

--- a/demo/Poisson1D.py
+++ b/demo/Poisson1D.py
@@ -17,10 +17,10 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for
 # Poisson's equation.
-from ufl import (Coefficient, FiniteElement, TestFunction, TrialFunction, dx,
-                 grad, inner, interval)
+import basix.ufl
+from ufl import Coefficient, TestFunction, TrialFunction, dx, grad, inner
 
-element = FiniteElement("Lagrange", interval, 1)
+element = basix.ufl.element("Lagrange", "interval", 1)
 
 u = TrialFunction(element)
 v = TestFunction(element)

--- a/demo/PoissonQuad.py
+++ b/demo/PoissonQuad.py
@@ -17,14 +17,15 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for
 # Poisson's equation using bilinear elements on bilinear mesh geometry.
-from ufl import (Coefficient, FiniteElement, FunctionSpace, Mesh, TestFunction,
-                 TrialFunction, VectorElement, dx, grad, inner, triangle)
+import basix.ufl
+from ufl import (Coefficient, FunctionSpace, Mesh, TestFunction, TrialFunction,
+                 dx, grad, inner)
 
-coords = VectorElement("P", triangle, 2)
+coords = basix.ufl.element("P", "triangle", 2, rank=1)
 mesh = Mesh(coords)
 dx = dx(mesh)
 
-element = FiniteElement("P", mesh.ufl_cell(), 2)
+element = basix.ufl.element("P", mesh.ufl_cell().cellname(), 2)
 space = FunctionSpace(mesh, element)
 
 u = TrialFunction(space)

--- a/demo/ProjectionManifold.py
+++ b/demo/ProjectionManifold.py
@@ -17,13 +17,13 @@
 #
 # This demo illustrates use of finite element spaces defined over
 # simplicies embedded in higher dimensions
-from basix.ufl import mixed_element, element
+import basix.ufl
 from ufl import TestFunctions, TrialFunctions, div, dx, inner
 
 # Define element over this domain
-V = element("RT", "triangle", 1, gdim=3)
-Q = element("DG", "triangle", 0, gdim=3)
-element = mixed_element([V, Q])
+V = basix.ufl.element("RT", "triangle", 1, gdim=3)
+Q = basix.ufl.element("DG", "triangle", 0, gdim=3)
+element = basix.ufl.mixed_element([V, Q])
 
 (u, p) = TrialFunctions(element)
 (v, q) = TestFunctions(element)

--- a/demo/ProjectionManifold.py
+++ b/demo/ProjectionManifold.py
@@ -17,16 +17,13 @@
 #
 # This demo illustrates use of finite element spaces defined over
 # simplicies embedded in higher dimensions
-from ufl import (Cell, FiniteElement, TestFunctions, TrialFunctions, div, dx,
-                 inner)
-
-# Define interval embedded in 3D:
-domain = Cell("triangle", geometric_dimension=3)
+from basix.ufl import MixedElement, element
+from ufl import TestFunctions, TrialFunctions, div, dx, inner
 
 # Define element over this domain
-V = FiniteElement("RT", domain, 1)
-Q = FiniteElement("DG", domain, 0)
-element = V * Q
+V = element("RT", "triangle", 1, gdim=3)
+Q = element("DG", "triangle", 0, gdim=3)
+element = MixedElement([V, Q])
 
 (u, p) = TrialFunctions(element)
 (v, q) = TestFunctions(element)

--- a/demo/ProjectionManifold.py
+++ b/demo/ProjectionManifold.py
@@ -17,13 +17,13 @@
 #
 # This demo illustrates use of finite element spaces defined over
 # simplicies embedded in higher dimensions
-from basix.ufl import MixedElement, element
+from basix.ufl import mixed_element, element
 from ufl import TestFunctions, TrialFunctions, div, dx, inner
 
 # Define element over this domain
 V = element("RT", "triangle", 1, gdim=3)
 Q = element("DG", "triangle", 0, gdim=3)
-element = MixedElement([V, Q])
+element = mixed_element([V, Q])
 
 (u, p) = TrialFunctions(element)
 (v, q) = TestFunctions(element)

--- a/demo/ReactionDiffusion.py
+++ b/demo/ReactionDiffusion.py
@@ -17,10 +17,10 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for a simple
 # reaction-diffusion equation using simplified tuple notation.
-from ufl import (Coefficient, FiniteElement, TestFunction, TrialFunction, dx,
-                 grad, inner, triangle)
+import basix.ufl
+from ufl import Coefficient, TestFunction, TrialFunction, dx, grad, inner
 
-element = FiniteElement("Lagrange", triangle, 1)
+element = basix.ufl.element("Lagrange", "triangle", 1)
 
 u = TrialFunction(element)
 v = TestFunction(element)

--- a/demo/SpatialCoordinates.py
+++ b/demo/SpatialCoordinates.py
@@ -18,10 +18,11 @@
 # The bilinear form a(u, v) and linear form L(v) for
 # Poisson's equation where spatial coordinates are used to define the source
 # and boundary flux terms.
-from ufl import (FiniteElement, SpatialCoordinate, TestFunction, TrialFunction,
-                 ds, dx, exp, grad, inner, sin, triangle)
+import basix.ufl
+from ufl import (SpatialCoordinate, TestFunction, TrialFunction, ds, dx, exp,
+                 grad, inner, sin, triangle)
 
-element = FiniteElement("Lagrange", triangle, 2)
+element = basix.ufl.element("Lagrange", "triangle", 2)
 
 u = TrialFunction(element)
 v = TestFunction(element)

--- a/demo/StabilisedStokes.py
+++ b/demo/StabilisedStokes.py
@@ -17,12 +17,13 @@
 #
 # The bilinear form a(u, v) and Linear form L(v) for the Stokes
 # equations using a mixed formulation (equal-order stabilized).
-from ufl import (Coefficient, FiniteElement, TestFunctions, TrialFunctions,
-                 VectorElement, div, dot, dx, grad, inner, triangle)
+from basix.ufl import MixedElement, element
+from ufl import (Coefficient, TestFunctions, TrialFunctions, div, dot, dx,
+                 grad, inner)
 
-vector = VectorElement("Lagrange", triangle, 1)
-scalar = FiniteElement("Lagrange", triangle, 1)
-system = vector * scalar
+vector = element("Lagrange", "triangle", 1, rank=1)
+scalar = element("Lagrange", "triangle", 1)
+system = MixedElement([vector, scalar])
 
 (u, p) = TrialFunctions(system)
 (v, q) = TestFunctions(system)

--- a/demo/StabilisedStokes.py
+++ b/demo/StabilisedStokes.py
@@ -17,13 +17,13 @@
 #
 # The bilinear form a(u, v) and Linear form L(v) for the Stokes
 # equations using a mixed formulation (equal-order stabilized).
-from basix.ufl import MixedElement, element
+from basix.ufl import mixed_element, element
 from ufl import (Coefficient, TestFunctions, TrialFunctions, div, dot, dx,
                  grad, inner)
 
 vector = element("Lagrange", "triangle", 1, rank=1)
 scalar = element("Lagrange", "triangle", 1)
-system = MixedElement([vector, scalar])
+system = mixed_element([vector, scalar])
 
 (u, p) = TrialFunctions(system)
 (v, q) = TestFunctions(system)

--- a/demo/StabilisedStokes.py
+++ b/demo/StabilisedStokes.py
@@ -17,13 +17,13 @@
 #
 # The bilinear form a(u, v) and Linear form L(v) for the Stokes
 # equations using a mixed formulation (equal-order stabilized).
-from basix.ufl import mixed_element, element
+import basix.ufl
 from ufl import (Coefficient, TestFunctions, TrialFunctions, div, dot, dx,
                  grad, inner)
 
-vector = element("Lagrange", "triangle", 1, rank=1)
-scalar = element("Lagrange", "triangle", 1)
-system = mixed_element([vector, scalar])
+vector = basix.ufl.element("Lagrange", "triangle", 1, rank=1)
+scalar = basix.ufl.element("Lagrange", "triangle", 1)
+system = basix.ufl.mixed_element([vector, scalar])
 
 (u, p) = TrialFunctions(system)
 (v, q) = TestFunctions(system)

--- a/demo/Symmetry.py
+++ b/demo/Symmetry.py
@@ -1,7 +1,7 @@
-from basix.ufl import element
+import basix.ufl
 from ufl import TestFunction, TrialFunction, dx, grad, inner
 
-P1 = element("P", "triangle", 1, shape=(2, 2), symmetry=True)
+P1 = basix.ufl.element("P", "triangle", 1, shape=(2, 2), symmetry=True)
 
 u = TrialFunction(P1)
 v = TestFunction(P1)

--- a/demo/Symmetry.py
+++ b/demo/Symmetry.py
@@ -1,7 +1,7 @@
-from ufl import (TensorElement, TestFunction, TrialFunction, dx, grad, inner,
-                 triangle)
+from basix.ufl import element
+from ufl import TestFunction, TrialFunction, dx, grad, inner
 
-P1 = TensorElement("CG", triangle, 1, (2, 2), symmetry={(1, 0): (0, 1)})
+P1 = element("CG", "triangle", 1, shape=(2, 2), symmetry=True)
 
 u = TrialFunction(P1)
 v = TestFunction(P1)

--- a/demo/Symmetry.py
+++ b/demo/Symmetry.py
@@ -1,7 +1,7 @@
 from basix.ufl import element
 from ufl import TestFunction, TrialFunction, dx, grad, inner
 
-P1 = element("CG", "triangle", 1, shape=(2, 2), symmetry=True)
+P1 = element("P", "triangle", 1, shape=(2, 2), symmetry=True)
 
 u = TrialFunction(P1)
 v = TestFunction(P1)

--- a/demo/TraceElement.py
+++ b/demo/TraceElement.py
@@ -14,8 +14,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with FFCx. If not, see <http://www.gnu.org/licenses/>.
-from ufl import FiniteElement, TestFunction, avg, ds, dS
+import basix.ufl
+from ufl import TestFunction, avg, ds, dS
 
-element = FiniteElement("HDiv Trace", "triangle", 0)
+element = basix.ufl.element("HDiv Trace", "triangle", 0)
 v = TestFunction(element)
 L = v * ds + avg(v) * dS

--- a/demo/VectorPoisson.py
+++ b/demo/VectorPoisson.py
@@ -17,10 +17,10 @@
 #
 # The bilinear form a(u, v) and linear form L(v) for
 # the vector-valued Poisson's equation.
-from ufl import (Coefficient, TestFunction, TrialFunction, VectorElement, dx,
-                 grad, inner, triangle)
+import basix.ufl
+from ufl import Coefficient, TestFunction, TrialFunction, dx, grad, inner
 
-element = VectorElement("Lagrange", triangle, 1)
+element = basix.ufl.element("Lagrange", "triangle", 1, rank=1)
 
 u = TrialFunction(element)
 v = TestFunction(element)

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -27,10 +27,10 @@ logger = logging.getLogger("ffcx")
 
 class UFLData(typing.NamedTuple):
     form_data: typing.Tuple[ufl.algorithms.formdata.FormData, ...]  # Tuple of ufl form data
-    unique_elements: typing.List[basix.ufl._BasixElementBase]  # List of unique elements
+    unique_elements: typing.List[basix.ufl._ElementBase]  # List of unique elements
     # Lookup table from each unique element to its index in `unique_elements`
-    element_numbers: typing.Dict[basix.ufl._BasixElementBase, int]
-    unique_coordinate_elements: typing.List[basix.ufl._BasixElementBase]  # List of unique coordinate elements
+    element_numbers: typing.Dict[basix.ufl._ElementBase, int]
+    unique_coordinate_elements: typing.List[basix.ufl._ElementBase]  # List of unique coordinate elements
     # List of ufl Expressions as tuples (expression, points, original_expression)
     expressions: typing.List[typing.Tuple[ufl.core.expr.Expr, npt.NDArray[np.float64], ufl.core.expr.Expr]]
 
@@ -102,7 +102,7 @@ def analyze_ufl_objects(ufl_objects: typing.List, options: typing.Dict) -> UFLDa
     unique_coordinate_element_list = sorted(set(coordinate_elements), key=lambda x: repr(x))
 
     for e in unique_elements:
-        assert isinstance(e, basix.ufl._BasixElementBase)
+        assert isinstance(e, basix.ufl._ElementBase)
 
     # Compute dict (map) from element to index
     element_numbers = {element: i for i, element in enumerate(unique_elements)}
@@ -153,7 +153,7 @@ def _analyze_form(form: ufl.form.Form, options: typing.Dict) -> ufl.algorithms.f
     # Set default spacing for coordinate elements to be equispaced
     for n, i in enumerate(form._integrals):
         element = i._ufl_domain._ufl_coordinate_element
-        if not isinstance(element, basix.ufl._BasixElementBase) and element.degree() > 2:
+        if not isinstance(element, basix.ufl._ElementBase) and element.degree() > 2:
             warn("UFL coordinate elements using elements not created via Basix may not work with DOLFINx")
 
     # Check for complex mode

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -18,7 +18,7 @@ from warnings import warn
 import numpy as np
 import numpy.typing as npt
 
-import basix.ufl_wrapper
+import basix.ufl
 import ufl
 from ffcx.element_interface import QuadratureElement, convert_element
 
@@ -27,10 +27,10 @@ logger = logging.getLogger("ffcx")
 
 class UFLData(typing.NamedTuple):
     form_data: typing.Tuple[ufl.algorithms.formdata.FormData, ...]  # Tuple of ufl form data
-    unique_elements: typing.List[basix.ufl_wrapper._BasixElementBase]  # List of unique elements
+    unique_elements: typing.List[basix.ufl._BasixElementBase]  # List of unique elements
     # Lookup table from each unique element to its index in `unique_elements`
-    element_numbers: typing.Dict[basix.ufl_wrapper._BasixElementBase, int]
-    unique_coordinate_elements: typing.List[basix.ufl_wrapper._BasixElementBase]  # List of unique coordinate elements
+    element_numbers: typing.Dict[basix.ufl._BasixElementBase, int]
+    unique_coordinate_elements: typing.List[basix.ufl._BasixElementBase]  # List of unique coordinate elements
     # List of ufl Expressions as tuples (expression, points, original_expression)
     expressions: typing.List[typing.Tuple[ufl.core.expr.Expr, npt.NDArray[np.float64], ufl.core.expr.Expr]]
 
@@ -102,7 +102,7 @@ def analyze_ufl_objects(ufl_objects: typing.List, options: typing.Dict) -> UFLDa
     unique_coordinate_element_list = sorted(set(coordinate_elements), key=lambda x: repr(x))
 
     for e in unique_elements:
-        assert isinstance(e, basix.ufl_wrapper._BasixElementBase)
+        assert isinstance(e, basix.ufl._BasixElementBase)
 
     # Compute dict (map) from element to index
     element_numbers = {element: i for i, element in enumerate(unique_elements)}
@@ -153,7 +153,7 @@ def _analyze_form(form: ufl.form.Form, options: typing.Dict) -> ufl.algorithms.f
     # Set default spacing for coordinate elements to be equispaced
     for n, i in enumerate(form._integrals):
         element = i._ufl_domain._ufl_coordinate_element
-        if not isinstance(element, basix.ufl_wrapper._BasixElementBase) and element.degree() > 2:
+        if not isinstance(element, basix.ufl._BasixElementBase) and element.degree() > 2:
             warn("UFL coordinate elements using elements not created via Basix may not work with DOLFINx")
 
     # Check for complex mode

--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -9,7 +9,7 @@ import logging
 import warnings
 
 import ufl
-from basix.ufl import BlockedElement
+from basix.ufl import _BlockedElement
 from ffcx.element_interface import convert_element
 
 logger = logging.getLogger("ffcx")
@@ -257,7 +257,7 @@ class FFCXBackendAccess(object):
         coordinate_element = convert_element(domain.ufl_coordinate_element())
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, BlockedElement)
+        assert isinstance(coordinate_element, _BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)
@@ -288,7 +288,7 @@ class FFCXBackendAccess(object):
             raise RuntimeError(f"Unhandled cell types {cellname}.")
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, BlockedElement)
+        assert isinstance(coordinate_element, _BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)
@@ -330,7 +330,7 @@ class FFCXBackendAccess(object):
             raise RuntimeError(f"Unhandled cell types {cellname}.")
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, BlockedElement)
+        assert isinstance(coordinate_element, _BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)

--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -10,7 +10,7 @@ import warnings
 
 import ufl
 from basix.ufl import BlockedElement
-from ffcx.element_interface import convert_element, create_element
+from ffcx.element_interface import convert_element
 
 logger = logging.getLogger("ffcx")
 
@@ -260,7 +260,7 @@ class FFCXBackendAccess(object):
         assert isinstance(coordinate_element, BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
-        scalar_element = create_element(ufl_scalar_element)
+        scalar_element = convert_element(ufl_scalar_element)
         assert scalar_element.value_size == 1 and scalar_element.block_size == 1
 
         vertex_scalar_dofs = scalar_element.entity_dofs[0]
@@ -291,7 +291,7 @@ class FFCXBackendAccess(object):
         assert isinstance(coordinate_element, BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
-        scalar_element = create_element(ufl_scalar_element)
+        scalar_element = convert_element(ufl_scalar_element)
         assert scalar_element.value_size == 1 and scalar_element.block_size == 1
 
         vertex_scalar_dofs = scalar_element.entity_dofs[0]
@@ -333,10 +333,10 @@ class FFCXBackendAccess(object):
         assert isinstance(coordinate_element, BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
-        scalar_element = create_element(ufl_scalar_element)
+        scalar_element = convert_element(ufl_scalar_element)
         assert scalar_element.value_size == 1 and scalar_element.block_size == 1
 
-        scalar_element = create_element(ufl_scalar_element)
+        scalar_element = convert_element(ufl_scalar_element)
         num_scalar_dofs = scalar_element.dim
 
         # Get edge vertices

--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -9,7 +9,7 @@ import logging
 import warnings
 
 import ufl
-from basix.ufl import blocked_element
+from basix.ufl import BlockedElement
 from ffcx.element_interface import convert_element
 
 logger = logging.getLogger("ffcx")
@@ -257,7 +257,7 @@ class FFCXBackendAccess(object):
         coordinate_element = convert_element(domain.ufl_coordinate_element())
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, blocked_element)
+        assert isinstance(coordinate_element, BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)
@@ -288,7 +288,7 @@ class FFCXBackendAccess(object):
             raise RuntimeError(f"Unhandled cell types {cellname}.")
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, blocked_element)
+        assert isinstance(coordinate_element, BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)
@@ -330,7 +330,7 @@ class FFCXBackendAccess(object):
             raise RuntimeError(f"Unhandled cell types {cellname}.")
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, blocked_element)
+        assert isinstance(coordinate_element, BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)

--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -9,7 +9,7 @@ import logging
 import warnings
 
 import ufl
-from basix.ufl import _BlockedElement
+import basix.ufl
 from ffcx.element_interface import convert_element
 
 logger = logging.getLogger("ffcx")
@@ -257,7 +257,7 @@ class FFCXBackendAccess(object):
         coordinate_element = convert_element(domain.ufl_coordinate_element())
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, _BlockedElement)
+        assert isinstance(coordinate_element, basix.ufl._BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)
@@ -288,7 +288,7 @@ class FFCXBackendAccess(object):
             raise RuntimeError(f"Unhandled cell types {cellname}.")
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, _BlockedElement)
+        assert isinstance(coordinate_element, basix.ufl._BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)
@@ -330,7 +330,7 @@ class FFCXBackendAccess(object):
             raise RuntimeError(f"Unhandled cell types {cellname}.")
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, _BlockedElement)
+        assert isinstance(coordinate_element, basix.ufl._BlockedElement)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)

--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -9,7 +9,7 @@ import logging
 import warnings
 
 import ufl
-from basix.ufl_wrapper import BlockedElement
+from basix.ufl import BlockedElement
 from ffcx.element_interface import convert_element, create_element
 
 logger = logging.getLogger("ffcx")

--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -9,7 +9,7 @@ import logging
 import warnings
 
 import ufl
-from basix.ufl import BlockedElement
+from basix.ufl import blocked_element
 from ffcx.element_interface import convert_element
 
 logger = logging.getLogger("ffcx")
@@ -257,7 +257,7 @@ class FFCXBackendAccess(object):
         coordinate_element = convert_element(domain.ufl_coordinate_element())
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, BlockedElement)
+        assert isinstance(coordinate_element, blocked_element)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)
@@ -288,7 +288,7 @@ class FFCXBackendAccess(object):
             raise RuntimeError(f"Unhandled cell types {cellname}.")
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, BlockedElement)
+        assert isinstance(coordinate_element, blocked_element)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)
@@ -330,7 +330,7 @@ class FFCXBackendAccess(object):
             raise RuntimeError(f"Unhandled cell types {cellname}.")
 
         # Get dimension and dofmap of scalar element
-        assert isinstance(coordinate_element, BlockedElement)
+        assert isinstance(coordinate_element, blocked_element)
         assert coordinate_element.value_shape() == (gdim, )
         ufl_scalar_element, = set(coordinate_element.sub_elements())
         scalar_element = convert_element(ufl_scalar_element)

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -8,7 +8,7 @@
 import logging
 
 import ufl
-from ffcx.element_interface import create_element
+from ffcx.element_interface import convert_element
 from ffcx.naming import scalar_to_value_type
 
 logger = logging.getLogger("ffcx")
@@ -124,7 +124,7 @@ class FFCXBackendDefinitions(object):
         # Get properties of domain
         domain = ufl.domain.extract_unique_domain(mt.terminal)
         coordinate_element = domain.ufl_coordinate_element()
-        num_scalar_dofs = create_element(coordinate_element).sub_element.dim
+        num_scalar_dofs = convert_element(coordinate_element).sub_element.dim
 
         num_dofs = tabledata.values.shape[3]
         begin = tabledata.offset

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -39,7 +39,9 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
     if isinstance(element, basix.ufl._BasixElementBase):
         return element
 
-    warnings.warn("Use of elements created by UFL is deprecated. You should create elements directly using Basix.", DeprecationWarning)
+    warnings.warn(
+        "Use of elements created by UFL is deprecated. You should create elements directly using Basix.",
+        DeprecationWarning)
 
     if hasattr(ufl, "VectorElement") and isinstance(element, ufl.VectorElement):
         return basix.ufl.VectorElement(_cached_conversion(element.sub_elements()[0]), element.num_sub_elements())

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -49,7 +49,8 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
         DeprecationWarning)
 
     if hasattr(ufl, "VectorElement") and isinstance(element, ufl.VectorElement):
-        return basix.ufl.blocked_element(_cached_conversion(element.sub_elements()[0]), shape=(element.num_sub_elements(), ))
+        return basix.ufl.blocked_element(
+            _cached_conversion(element.sub_elements()[0]), shape=(element.num_sub_elements(), ))
     elif hasattr(ufl, "TensorElement") and isinstance(element, ufl.TensorElement):
         if len(element.symmetry()) == 0:
             return basix.ufl.blocked_element(_cached_conversion(element.sub_elements()[0]), shape=element._value_shape)

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -44,10 +44,10 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
         DeprecationWarning)
 
     if hasattr(ufl, "VectorElement") and isinstance(element, ufl.VectorElement):
-        return basix.ufl.blocked_element(_cached_conversion(element.sub_elements()[0]), (element.num_sub_elements(), ))
+        return basix.ufl.blocked_element(_cached_conversion(element.sub_elements()[0]), shape=(element.num_sub_elements(), ))
     elif hasattr(ufl, "TensorElement") and isinstance(element, ufl.TensorElement):
         if len(element.symmetry()) == 0:
-            return basix.ufl.blocked_element(_cached_conversion(element.sub_elements()[0]), element._value_shape)
+            return basix.ufl.blocked_element(_cached_conversion(element.sub_elements()[0]), shape=element._value_shape)
         else:
             assert element.symmetry()[(1, 0)] == (0, 1)
             return basix.ufl.blocked_element(_cached_conversion(

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -44,16 +44,16 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
         DeprecationWarning)
 
     if hasattr(ufl, "VectorElement") and isinstance(element, ufl.VectorElement):
-        return basix.ufl.BlockedElement(_cached_conversion(element.sub_elements()[0]), (element.num_sub_elements(), ))
+        return basix.ufl.blocked_element(_cached_conversion(element.sub_elements()[0]), (element.num_sub_elements(), ))
     elif hasattr(ufl, "TensorElement") and isinstance(element, ufl.TensorElement):
         if len(element.symmetry()) == 0:
-            return basix.ufl.BlockedElement(_cached_conversion(element.sub_elements()[0]), element._value_shape)
+            return basix.ufl.blocked_element(_cached_conversion(element.sub_elements()[0]), element._value_shape)
         else:
             assert element.symmetry()[(1, 0)] == (0, 1)
-            return basix.ufl.BlockedElement(_cached_conversion(
+            return basix.ufl.blocked_element(_cached_conversion(
                 element.sub_elements()[0]), element._value_shape, symmetry=True)
     elif hasattr(ufl, "MixedElement") and isinstance(element, ufl.MixedElement):
-        return basix.ufl.MixedElement([_cached_conversion(e) for e in element.sub_elements()])
+        return basix.ufl.mixed_element([_cached_conversion(e) for e in element.sub_elements()])
     elif hasattr(ufl, "EnrichedElement") and isinstance(element, ufl.EnrichedElement):
         return basix.ufl.enriched_element([_cached_conversion(e) for e in element._elements])
     elif element.family() == "Quadrature":

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -19,15 +19,15 @@ import numpy as np
 import numpy.typing as npt
 
 
-def convert_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._BasixElementBase:
+def convert_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._ElementBase:
     """Convert and element to a FFCx element."""
-    if isinstance(element, basix.ufl._BasixElementBase):
+    if isinstance(element, basix.ufl._ElementBase):
         return element
     return _cached_conversion(element)
 
 
 @lru_cache()
-def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._BasixElementBase:
+def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._ElementBase:
     """Create an FFCx element from a UFL element.
 
     Args:
@@ -36,7 +36,7 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
     Returns:
         A Basix finite element
     """
-    if isinstance(element, basix.ufl._BasixElementBase):
+    if isinstance(element, basix.ufl._ElementBase):
         return element
 
     warnings.warn(
@@ -105,7 +105,7 @@ def map_facet_points(points: npt.NDArray[np.float64], facet: int,
                        for p in points], dtype=np.float64)
 
 
-class QuadratureElement(basix.ufl._BasixElementBase):
+class QuadratureElement(basix.ufl._ElementBase):
     """A quadrature element."""
 
     _points: npt.NDArray[np.float64]
@@ -168,7 +168,7 @@ class QuadratureElement(basix.ufl._BasixElementBase):
         tables = np.asarray([np.eye(points.shape[0], points.shape[0])])
         return tables
 
-    def get_component_element(self, flat_component: int) -> typing.Tuple[basix.ufl._BasixElementBase, int, int]:
+    def get_component_element(self, flat_component: int) -> typing.Tuple[basix.ufl._ElementBase, int, int]:
         """Get element that represents a component of the element, and the offset and stride of the component.
 
         Args:
@@ -273,7 +273,7 @@ class QuadratureElement(basix.ufl._BasixElementBase):
         return basix.MapType.identity
 
 
-class RealElement(basix.ufl._BasixElementBase):
+class RealElement(basix.ufl._ElementBase):
     """A real element."""
 
     _family_name: str
@@ -321,7 +321,7 @@ class RealElement(basix.ufl._BasixElementBase):
         out[0, :] = 1.
         return out
 
-    def get_component_element(self, flat_component: int) -> typing.Tuple[basix.ufl._BasixElementBase, int, int]:
+    def get_component_element(self, flat_component: int) -> typing.Tuple[basix.ufl._ElementBase, int, int]:
         """Get element that represents a component of the element, and the offset and stride of the component.
 
         Args:

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -51,7 +51,7 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
         else:
             assert element.symmetry()[(1, 0)] == (0, 1)
             return basix.ufl.TensorElement(_cached_conversion(
-                element.sub_elements()[0]), element._value_shape, symmetric=True)
+                element.sub_elements()[0]), element._value_shape, symmetry=True)
     elif hasattr(ufl, "MixedElement") and isinstance(element, ufl.MixedElement):
         return basix.ufl.MixedElement([_cached_conversion(e) for e in element.sub_elements()])
     elif hasattr(ufl, "EnrichedElement") and isinstance(element, ufl.EnrichedElement):

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -55,7 +55,7 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
     elif hasattr(ufl, "MixedElement") and isinstance(element, ufl.MixedElement):
         return basix.ufl.MixedElement([_cached_conversion(e) for e in element.sub_elements()])
     elif hasattr(ufl, "EnrichedElement") and isinstance(element, ufl.EnrichedElement):
-        return basix.ufl._create_enriched_element([_cached_conversion(e) for e in element._elements])
+        return basix.ufl.enriched_element([_cached_conversion(e) for e in element._elements])
     elif element.family() == "Quadrature":
         return QuadratureElement(element.cell().cellname(), element.value_shape(), scheme=element.quadrature_scheme(),
                                  degree=element.degree())

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -13,21 +13,21 @@ from functools import lru_cache
 
 
 import basix
-import basix.ufl_wrapper
+import basix.ufl
 import ufl
 import numpy as np
 import numpy.typing as npt
 
 
-def convert_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl_wrapper._BasixElementBase:
+def convert_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._BasixElementBase:
     """Convert and element to a FFCx element."""
-    if isinstance(element, basix.ufl_wrapper._BasixElementBase):
+    if isinstance(element, basix.ufl._BasixElementBase):
         return element
     return create_element(element)
 
 
 @lru_cache()
-def create_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl_wrapper._BasixElementBase:
+def create_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._BasixElementBase:
     """Create an FFCx element from a UFL element.
 
     Args:
@@ -36,21 +36,21 @@ def create_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl_wr
     Returns:
         A Basix finite element
     """
-    if isinstance(element, basix.ufl_wrapper._BasixElementBase):
+    if isinstance(element, basix.ufl._BasixElementBase):
         return element
     elif isinstance(element, ufl.VectorElement):
-        return basix.ufl_wrapper.VectorElement(create_element(element.sub_elements()[0]), element.num_sub_elements())
+        return basix.ufl.VectorElement(create_element(element.sub_elements()[0]), element.num_sub_elements())
     elif isinstance(element, ufl.TensorElement):
         if len(element.symmetry()) == 0:
-            return basix.ufl_wrapper.TensorElement(create_element(element.sub_elements()[0]), element._value_shape)
+            return basix.ufl.TensorElement(create_element(element.sub_elements()[0]), element._value_shape)
         else:
             assert element.symmetry()[(1, 0)] == (0, 1)
-            return basix.ufl_wrapper.TensorElement(create_element(
+            return basix.ufl.TensorElement(create_element(
                 element.sub_elements()[0]), element._value_shape, symmetric=True)
     elif isinstance(element, ufl.MixedElement):
-        return basix.ufl_wrapper.MixedElement([create_element(e) for e in element.sub_elements()])
+        return basix.ufl.MixedElement([create_element(e) for e in element.sub_elements()])
     elif isinstance(element, ufl.EnrichedElement):
-        return basix.ufl_wrapper._create_enriched_element([create_element(e) for e in element._elements])
+        return basix.ufl._create_enriched_element([create_element(e) for e in element._elements])
     elif element.family() == "Quadrature":
         return QuadratureElement(element.cell().cellname(), element.value_shape(), scheme=element.quadrature_scheme(),
                                  degree=element.degree())
@@ -58,7 +58,7 @@ def create_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl_wr
     elif element.family() == "Real":
         return RealElement(element)
     else:
-        return basix.ufl_wrapper.convert_ufl_element(element)
+        return basix.ufl.convert_ufl_element(element)
 
 
 def basix_index(indices: typing.Tuple[int]) -> int:
@@ -100,7 +100,7 @@ def map_facet_points(points: npt.NDArray[np.float64], facet: int,
                        for p in points], dtype=np.float64)
 
 
-class QuadratureElement(basix.ufl_wrapper._BasixElementBase):
+class QuadratureElement(basix.ufl._BasixElementBase):
     """A quadrature element."""
 
     _points: npt.NDArray[np.float64]
@@ -163,7 +163,7 @@ class QuadratureElement(basix.ufl_wrapper._BasixElementBase):
         tables = np.asarray([np.eye(points.shape[0], points.shape[0])])
         return tables
 
-    def get_component_element(self, flat_component: int) -> typing.Tuple[basix.ufl_wrapper._BasixElementBase, int, int]:
+    def get_component_element(self, flat_component: int) -> typing.Tuple[basix.ufl._BasixElementBase, int, int]:
         """Get element that represents a component of the element, and the offset and stride of the component.
 
         Args:
@@ -268,7 +268,7 @@ class QuadratureElement(basix.ufl_wrapper._BasixElementBase):
         return basix.MapType.identity
 
 
-class RealElement(basix.ufl_wrapper._BasixElementBase):
+class RealElement(basix.ufl._BasixElementBase):
     """A real element."""
 
     _family_name: str
@@ -316,7 +316,7 @@ class RealElement(basix.ufl_wrapper._BasixElementBase):
         out[0, :] = 1.
         return out
 
-    def get_component_element(self, flat_component: int) -> typing.Tuple[basix.ufl_wrapper._BasixElementBase, int, int]:
+    def get_component_element(self, flat_component: int) -> typing.Tuple[basix.ufl._BasixElementBase, int, int]:
         """Get element that represents a component of the element, and the offset and stride of the component.
 
         Args:

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -38,6 +38,11 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
     """
     if isinstance(element, basix.ufl._ElementBase):
         return element
+    elif element.family() == "Quadrature":
+        return QuadratureElement(element.cell().cellname(), element.value_shape(), scheme=element.quadrature_scheme(),
+                                 degree=element.degree())
+    elif element.family() == "Real":
+        return RealElement(element)
 
     warnings.warn(
         "Use of elements created by UFL is deprecated. You should create elements directly using Basix.",
@@ -56,12 +61,6 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
         return basix.ufl.mixed_element([_cached_conversion(e) for e in element.sub_elements()])
     elif hasattr(ufl, "EnrichedElement") and isinstance(element, ufl.EnrichedElement):
         return basix.ufl.enriched_element([_cached_conversion(e) for e in element._elements])
-    elif element.family() == "Quadrature":
-        return QuadratureElement(element.cell().cellname(), element.value_shape(), scheme=element.quadrature_scheme(),
-                                 degree=element.degree())
-
-    elif element.family() == "Real":
-        return RealElement(element)
     else:
         return basix.ufl.convert_ufl_element(element)
 

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -44,13 +44,13 @@ def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.uf
         DeprecationWarning)
 
     if hasattr(ufl, "VectorElement") and isinstance(element, ufl.VectorElement):
-        return basix.ufl.VectorElement(_cached_conversion(element.sub_elements()[0]), element.num_sub_elements())
+        return basix.ufl.BlockedElement(_cached_conversion(element.sub_elements()[0]), (element.num_sub_elements(), ))
     elif hasattr(ufl, "TensorElement") and isinstance(element, ufl.TensorElement):
         if len(element.symmetry()) == 0:
-            return basix.ufl.TensorElement(_cached_conversion(element.sub_elements()[0]), element._value_shape)
+            return basix.ufl.BlockedElement(_cached_conversion(element.sub_elements()[0]), element._value_shape)
         else:
             assert element.symmetry()[(1, 0)] == (0, 1)
-            return basix.ufl.TensorElement(_cached_conversion(
+            return basix.ufl.BlockedElement(_cached_conversion(
                 element.sub_elements()[0]), element._value_shape, symmetry=True)
     elif hasattr(ufl, "MixedElement") and isinstance(element, ufl.MixedElement):
         return basix.ufl.MixedElement([_cached_conversion(e) for e in element.sub_elements()])

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -542,7 +542,7 @@ def _compute_form_ir(form_data, form_id, prefix, form_names, integral_names, ele
         el = convert_element(convert_element(function.ufl_function_space().ufl_element()))
         cmap = function.ufl_function_space().ufl_domain().ufl_coordinate_element()
         # Default point spacing for CoordinateElement is equispaced
-        if not isinstance(cmap, basix.ufl._BasixElementBase) and cmap.variant() is None:
+        if not isinstance(cmap, basix.ufl._ElementBase) and cmap.variant() is None:
             cmap._sub_element._variant = "equispaced"
         cmap = convert_element(cmap)
         family = cmap.family()

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -416,7 +416,7 @@ def _compute_integral_ir(form_data, form_index, element_numbers, integral_names,
                                        np.array([1.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0]))
                 elif cellname == "interval":
                     # Trapezoidal rule
-                    return (np.array([[0.0], [1.0]]), np.array([1.0 / 2.0, 1.0 / 2.0]))
+                    points, weights = (np.array([[0.0], [1.0]]), np.array([1.0 / 2.0, 1.0 / 2.0]))
             else:
                 degree = md["quadrature_degree"]
                 points, weights = create_quadrature_points_and_weights(

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -26,6 +26,7 @@ import numpy as np
 import numpy.typing as npt
 
 import basix
+import basix.ufl
 import ufl
 from ffcx import naming
 from ffcx.analysis import UFLData
@@ -531,7 +532,7 @@ def _compute_form_ir(form_data, form_id, prefix, form_names, integral_names, ele
         el = convert_element(convert_element(function.ufl_function_space().ufl_element()))
         cmap = function.ufl_function_space().ufl_domain().ufl_coordinate_element()
         # Default point spacing for CoordinateElement is equispaced
-        if not isinstance(cmap, basix.ufl_wrapper._BasixElementBase) and cmap.variant() is None:
+        if not isinstance(cmap, basix.ufl._BasixElementBase) and cmap.variant() is None:
             cmap._sub_element._variant = "equispaced"
         cmap = convert_element(cmap)
         family = cmap.family()

--- a/test/Poisson.py
+++ b/test/Poisson.py
@@ -23,7 +23,7 @@ from ufl import (Coefficient, Constant, Mesh, TestFunction,
                  TrialFunction, dx, grad, inner)
 import basix.ufl
 
-mesh = Mesh(element('P', "triangle", 2, rank=1))
+mesh = Mesh(basix.ufl.element('P', "triangle", 2, rank=1))
 
 e = basix.ufl.element("Lagrange", "triangle", 2)
 

--- a/test/Poisson.py
+++ b/test/Poisson.py
@@ -19,20 +19,20 @@
 # Poisson's equation.
 #
 # Compile this form with FFCx: ffcx Poisson.ufl
-from ufl import (Coefficient, Constant, FiniteElement, Mesh, TestFunction,
-                 TrialFunction, VectorElement, dx, grad, inner, triangle)
+from ufl import (Coefficient, Constant, Mesh, TestFunction,
+                 TrialFunction, dx, grad, inner)
+from basix.ufl import element
 
-cell = triangle
-mesh = Mesh(VectorElement('P', cell, 2))
+mesh = Mesh(element('P', "triangle", 2, rank=1))
 
-element = FiniteElement("Lagrange", triangle, 2)
+e = element("Lagrange", "triangle", 2)
 
-u = TrialFunction(element)
-v = TestFunction(element)
-f = Coefficient(element)
+u = TrialFunction(e)
+v = TestFunction(e)
+f = Coefficient(e)
 
-kappa1 = Constant(triangle, shape=(2, 2))
-kappa2 = Constant(triangle, shape=(2, 2))
+kappa1 = Constant(mesh.ufl_cell(), shape=(2, 2))
+kappa2 = Constant(mesh.ufl_cell(), shape=(2, 2))
 
 a = inner(kappa1, kappa2) * inner(grad(u), grad(v)) * dx
 L = f * v * dx

--- a/test/Poisson.py
+++ b/test/Poisson.py
@@ -21,11 +21,11 @@
 # Compile this form with FFCx: ffcx Poisson.ufl
 from ufl import (Coefficient, Constant, Mesh, TestFunction,
                  TrialFunction, dx, grad, inner)
-from basix.ufl import element
+import basix.ufl
 
 mesh = Mesh(element('P', "triangle", 2, rank=1))
 
-e = element("Lagrange", "triangle", 2)
+e = basix.ufl.element("Lagrange", "triangle", 2)
 
 u = TrialFunction(e)
 v = TestFunction(e)

--- a/test/test_add_mode.py
+++ b/test/test_add_mode.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import ffcx.codegeneration.jit
+import basix.ufl
 import ufl
 from ffcx.naming import cdtype_to_numpy, scalar_to_value_type
 
@@ -21,8 +22,7 @@ from ffcx.naming import cdtype_to_numpy, scalar_to_value_type
                              "float _Complex"
                          ])
 def test_additive_facet_integral(mode, compile_args):
-    cell = ufl.triangle
-    element = ufl.FiniteElement("Lagrange", cell, 1)
+    element = basix.ufl.element("Lagrange", "triangle", 1)
     u, v = ufl.TrialFunction(element), ufl.TestFunction(element)
     a = ufl.inner(u, v) * ufl.ds
     forms = [a]
@@ -70,8 +70,7 @@ def test_additive_facet_integral(mode, compile_args):
 
 @pytest.mark.parametrize("mode", ["double", "float", "long double", "double _Complex", "float _Complex"])
 def test_additive_cell_integral(mode, compile_args):
-    cell = ufl.triangle
-    element = ufl.FiniteElement("Lagrange", cell, 1)
+    element = basix.ufl.element("Lagrange", "triangle", 1)
     u, v = ufl.TrialFunction(element), ufl.TestFunction(element)
     a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
     forms = [a]

--- a/test/test_blocked_elements.py
+++ b/test/test_blocked_elements.py
@@ -8,7 +8,6 @@ import numpy as np
 
 import ffcx
 import ffcx.codegeneration.jit
-import ufl
 import basix.ufl
 
 

--- a/test/test_blocked_elements.py
+++ b/test/test_blocked_elements.py
@@ -9,10 +9,11 @@ import numpy as np
 import ffcx
 import ffcx.codegeneration.jit
 import ufl
+import basix.ufl
 
 
 def test_finite_element(compile_args):
-    ufl_element = ufl.FiniteElement("Lagrange", ufl.triangle, 1)
+    ufl_element = basix.ufl.element("Lagrange", "triangle", 1)
     jit_compiled_elements, module, code = ffcx.codegeneration.jit.compile_elements(
         [ufl_element], cffi_extra_compile_args=compile_args)
     ufcx_element, ufcx_dofmap = jit_compiled_elements[0]
@@ -44,7 +45,7 @@ def test_finite_element(compile_args):
 
 
 def test_vector_element(compile_args):
-    ufl_element = ufl.VectorElement("Lagrange", ufl.triangle, 1)
+    ufl_element = basix.ufl.element("Lagrange", "triangle", 1, rank=1)
     jit_compiled_elements, module, code = ffcx.codegeneration.jit.compile_elements(
         [ufl_element], cffi_extra_compile_args=compile_args)
     ufcx_element, ufcx_dofmap = jit_compiled_elements[0]
@@ -78,7 +79,7 @@ def test_vector_element(compile_args):
 
 
 def test_tensor_element(compile_args):
-    ufl_element = ufl.TensorElement("Lagrange", ufl.triangle, 1)
+    ufl_element = basix.ufl.element("Lagrange", "triangle", 1, rank=2)
     jit_compiled_elements, module, code = ffcx.codegeneration.jit.compile_elements(
         [ufl_element], cffi_extra_compile_args=compile_args)
     ufcx_element, ufcx_dofmap = jit_compiled_elements[0]

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -8,11 +8,11 @@ import sys
 
 import ffcx.codegeneration.jit
 import ufl
+import basix.ufl
 
 
 def test_cache_modes(compile_args):
-    cell = ufl.triangle
-    element = ufl.FiniteElement("Lagrange", cell, 1)
+    element = basix.ufl.element("Lagrange", "triangle", 1)
     u, v = ufl.TrialFunction(element), ufl.TestFunction(element)
     a = ufl.inner(ufl.grad(u), ufl.grad(v)) * ufl.dx
     forms = [a]

--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -23,8 +23,7 @@
 import numpy as np
 import pytest
 
-from ffcx.element_interface import convert_element
-from ufl import FiniteElement
+from basix.ufl import finite_element
 
 
 def element_coords(cell):
@@ -50,28 +49,28 @@ def random_point(shape):
 @pytest.mark.parametrize("degree, expected_dim", [(1, 3), (2, 6), (3, 10)])
 def test_continuous_lagrange(degree, expected_dim):
     "Test space dimensions of continuous Lagrange elements."
-    P = convert_element(FiniteElement("Lagrange", "triangle", degree))
+    P = finite_element("Lagrange", "triangle", degree)
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(1, 4), (2, 9), (3, 16)])
 def xtest_continuous_lagrange_quadrilateral(degree, expected_dim):
     "Test space dimensions of continuous TensorProduct elements (quadrilateral)."
-    P = convert_element(FiniteElement("Lagrange", "quadrilateral", degree))
+    P = finite_element("Lagrange", "quadrilateral", degree)
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(1, 4), (2, 9), (3, 16)])
 def xtest_continuous_lagrange_quadrilateral_spectral(degree, expected_dim):
     "Test space dimensions of continuous TensorProduct elements (quadrilateral)."
-    P = convert_element(FiniteElement("Lagrange", "quadrilateral", degree, variant="spectral"))
+    P = finite_element("Lagrange", "quadrilateral", degree, variant="spectral")
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(0, 1), (1, 3), (2, 6), (3, 10)])
 def test_discontinuous_lagrange(degree, expected_dim):
     "Test space dimensions of discontinuous Lagrange elements."
-    P = convert_element(FiniteElement("DG", "triangle", degree))
+    P = finite_element("DG", "triangle", degree)
     assert P.dim == expected_dim
 
 
@@ -79,7 +78,7 @@ def test_discontinuous_lagrange(degree, expected_dim):
                          [(0, 3), (1, 9), (2, 18), (3, 30)])
 def test_regge(degree, expected_dim):
     "Test space dimensions of generalized Regge element."
-    P = convert_element(FiniteElement("Regge", "triangle", degree))
+    P = finite_element("Regge", "triangle", degree)
     assert P.dim == expected_dim
 
 
@@ -87,7 +86,7 @@ def test_regge(degree, expected_dim):
                          [(0, 3), (1, 9), (2, 18), (3, 30)])
 def xtest_hhj(degree, expected_dim):
     "Test space dimensions of Hellan-Herrmann-Johnson element."
-    P = convert_element(FiniteElement("HHJ", "triangle", degree))
+    P = finite_element("HHJ", "triangle", degree)
     assert P.dim == expected_dim
 
 
@@ -183,7 +182,7 @@ supported (non-mixed) for low degrees"""
     @pytest.mark.parametrize("family, cell, degree, reference", tests)
     def test_values(self, family, cell, degree, reference):
         # Create element
-        element = convert_element(FiniteElement(family, cell, degree))
+        element = finite_element(family, cell, degree)
 
         # Get some points and check basis function values at points
         points = [random_point(element_coords(cell)) for i in range(5)]

--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -23,7 +23,7 @@
 import numpy as np
 import pytest
 
-from basix.ufl import element
+import basix.ufl
 
 
 def element_coords(cell):
@@ -49,28 +49,28 @@ def random_point(shape):
 @pytest.mark.parametrize("degree, expected_dim", [(1, 3), (2, 6), (3, 10)])
 def test_continuous_lagrange(degree, expected_dim):
     "Test space dimensions of continuous Lagrange elements."
-    P = element("Lagrange", "triangle", degree)
+    P = basix.ufl.element("Lagrange", "triangle", degree)
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(1, 4), (2, 9), (3, 16)])
 def xtest_continuous_lagrange_quadrilateral(degree, expected_dim):
     "Test space dimensions of continuous TensorProduct elements (quadrilateral)."
-    P = element("Lagrange", "quadrilateral", degree)
+    P = basix.ufl.element("Lagrange", "quadrilateral", degree)
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(1, 4), (2, 9), (3, 16)])
 def xtest_continuous_lagrange_quadrilateral_spectral(degree, expected_dim):
     "Test space dimensions of continuous TensorProduct elements (quadrilateral)."
-    P = element("Lagrange", "quadrilateral", degree, variant="spectral")
+    P = basix.ufl.element("Lagrange", "quadrilateral", degree, variant="spectral")
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(0, 1), (1, 3), (2, 6), (3, 10)])
 def test_discontinuous_lagrange(degree, expected_dim):
     "Test space dimensions of discontinuous Lagrange elements."
-    P = element("DG", "triangle", degree)
+    P = basix.ufl.element("DG", "triangle", degree)
     assert P.dim == expected_dim
 
 
@@ -78,7 +78,7 @@ def test_discontinuous_lagrange(degree, expected_dim):
                          [(0, 3), (1, 9), (2, 18), (3, 30)])
 def test_regge(degree, expected_dim):
     "Test space dimensions of generalized Regge element."
-    P = element("Regge", "triangle", degree)
+    P = basix.ufl.element("Regge", "triangle", degree)
     assert P.dim == expected_dim
 
 
@@ -86,7 +86,7 @@ def test_regge(degree, expected_dim):
                          [(0, 3), (1, 9), (2, 18), (3, 30)])
 def xtest_hhj(degree, expected_dim):
     "Test space dimensions of Hellan-Herrmann-Johnson element."
-    P = element("HHJ", "triangle", degree)
+    P = basix.ufl.element("HHJ", "triangle", degree)
     assert P.dim == expected_dim
 
 
@@ -182,7 +182,7 @@ supported (non-mixed) for low degrees"""
     @pytest.mark.parametrize("family, cell, degree, reference", tests)
     def test_values(self, family, cell, degree, reference):
         # Create element
-        e = element(family, cell, degree)
+        e = basix.ufl.element(family, cell, degree)
 
         # Get some points and check basis function values at points
         points = [random_point(element_coords(cell)) for i in range(5)]

--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -23,7 +23,7 @@
 import numpy as np
 import pytest
 
-from ffcx.element_interface import create_element
+from ffcx.element_interface import convert_element
 from ufl import FiniteElement
 
 
@@ -50,28 +50,28 @@ def random_point(shape):
 @pytest.mark.parametrize("degree, expected_dim", [(1, 3), (2, 6), (3, 10)])
 def test_continuous_lagrange(degree, expected_dim):
     "Test space dimensions of continuous Lagrange elements."
-    P = create_element(FiniteElement("Lagrange", "triangle", degree))
+    P = convert_element(FiniteElement("Lagrange", "triangle", degree))
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(1, 4), (2, 9), (3, 16)])
 def xtest_continuous_lagrange_quadrilateral(degree, expected_dim):
     "Test space dimensions of continuous TensorProduct elements (quadrilateral)."
-    P = create_element(FiniteElement("Lagrange", "quadrilateral", degree))
+    P = convert_element(FiniteElement("Lagrange", "quadrilateral", degree))
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(1, 4), (2, 9), (3, 16)])
 def xtest_continuous_lagrange_quadrilateral_spectral(degree, expected_dim):
     "Test space dimensions of continuous TensorProduct elements (quadrilateral)."
-    P = create_element(FiniteElement("Lagrange", "quadrilateral", degree, variant="spectral"))
+    P = convert_element(FiniteElement("Lagrange", "quadrilateral", degree, variant="spectral"))
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(0, 1), (1, 3), (2, 6), (3, 10)])
 def test_discontinuous_lagrange(degree, expected_dim):
     "Test space dimensions of discontinuous Lagrange elements."
-    P = create_element(FiniteElement("DG", "triangle", degree))
+    P = convert_element(FiniteElement("DG", "triangle", degree))
     assert P.dim == expected_dim
 
 
@@ -79,7 +79,7 @@ def test_discontinuous_lagrange(degree, expected_dim):
                          [(0, 3), (1, 9), (2, 18), (3, 30)])
 def test_regge(degree, expected_dim):
     "Test space dimensions of generalized Regge element."
-    P = create_element(FiniteElement("Regge", "triangle", degree))
+    P = convert_element(FiniteElement("Regge", "triangle", degree))
     assert P.dim == expected_dim
 
 
@@ -87,7 +87,7 @@ def test_regge(degree, expected_dim):
                          [(0, 3), (1, 9), (2, 18), (3, 30)])
 def xtest_hhj(degree, expected_dim):
     "Test space dimensions of Hellan-Herrmann-Johnson element."
-    P = create_element(FiniteElement("HHJ", "triangle", degree))
+    P = convert_element(FiniteElement("HHJ", "triangle", degree))
     assert P.dim == expected_dim
 
 
@@ -183,7 +183,7 @@ supported (non-mixed) for low degrees"""
     @pytest.mark.parametrize("family, cell, degree, reference", tests)
     def test_values(self, family, cell, degree, reference):
         # Create element
-        element = create_element(FiniteElement(family, cell, degree))
+        element = convert_element(FiniteElement(family, cell, degree))
 
         # Get some points and check basis function values at points
         points = [random_point(element_coords(cell)) for i in range(5)]

--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -23,7 +23,7 @@
 import numpy as np
 import pytest
 
-from basix.ufl import finite_element
+from basix.ufl import element
 
 
 def element_coords(cell):
@@ -49,28 +49,28 @@ def random_point(shape):
 @pytest.mark.parametrize("degree, expected_dim", [(1, 3), (2, 6), (3, 10)])
 def test_continuous_lagrange(degree, expected_dim):
     "Test space dimensions of continuous Lagrange elements."
-    P = finite_element("Lagrange", "triangle", degree)
+    P = element("Lagrange", "triangle", degree)
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(1, 4), (2, 9), (3, 16)])
 def xtest_continuous_lagrange_quadrilateral(degree, expected_dim):
     "Test space dimensions of continuous TensorProduct elements (quadrilateral)."
-    P = finite_element("Lagrange", "quadrilateral", degree)
+    P = element("Lagrange", "quadrilateral", degree)
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(1, 4), (2, 9), (3, 16)])
 def xtest_continuous_lagrange_quadrilateral_spectral(degree, expected_dim):
     "Test space dimensions of continuous TensorProduct elements (quadrilateral)."
-    P = finite_element("Lagrange", "quadrilateral", degree, variant="spectral")
+    P = element("Lagrange", "quadrilateral", degree, variant="spectral")
     assert P.dim == expected_dim
 
 
 @pytest.mark.parametrize("degree, expected_dim", [(0, 1), (1, 3), (2, 6), (3, 10)])
 def test_discontinuous_lagrange(degree, expected_dim):
     "Test space dimensions of discontinuous Lagrange elements."
-    P = finite_element("DG", "triangle", degree)
+    P = element("DG", "triangle", degree)
     assert P.dim == expected_dim
 
 
@@ -78,7 +78,7 @@ def test_discontinuous_lagrange(degree, expected_dim):
                          [(0, 3), (1, 9), (2, 18), (3, 30)])
 def test_regge(degree, expected_dim):
     "Test space dimensions of generalized Regge element."
-    P = finite_element("Regge", "triangle", degree)
+    P = element("Regge", "triangle", degree)
     assert P.dim == expected_dim
 
 
@@ -86,7 +86,7 @@ def test_regge(degree, expected_dim):
                          [(0, 3), (1, 9), (2, 18), (3, 30)])
 def xtest_hhj(degree, expected_dim):
     "Test space dimensions of Hellan-Herrmann-Johnson element."
-    P = finite_element("HHJ", "triangle", degree)
+    P = element("HHJ", "triangle", degree)
     assert P.dim == expected_dim
 
 
@@ -182,14 +182,14 @@ supported (non-mixed) for low degrees"""
     @pytest.mark.parametrize("family, cell, degree, reference", tests)
     def test_values(self, family, cell, degree, reference):
         # Create element
-        element = finite_element(family, cell, degree)
+        e = element(family, cell, degree)
 
         # Get some points and check basis function values at points
         points = [random_point(element_coords(cell)) for i in range(5)]
         for x in points:
-            table = element.tabulate(0, (x,))
+            table = e.tabulate(0, (x,))
             basis = table[0]
-            if sum(element.value_shape()) == 1:
+            if sum(e.value_shape()) == 1:
                 for i, value in enumerate(basis[0]):
                     assert np.isclose(value, reference[i](x))
             else:

--- a/test/test_flops.py
+++ b/test/test_flops.py
@@ -6,12 +6,13 @@
 
 
 import ufl
+import basix.ufl
 from ffcx.codegeneration.flop_count import count_flops
 
 
 def create_form(degree):
-    mesh = ufl.Mesh(ufl.VectorElement("Lagrange", "triangle", 1))
-    element = ufl.FiniteElement("Lagrange", ufl.triangle, degree)
+    mesh = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 1, rank=1))
+    element = basix.ufl.element("Lagrange", "triangle", degree)
     V = ufl.FunctionSpace(mesh, element)
 
     u = ufl.TrialFunction(V)

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -9,6 +9,7 @@ import cffi
 import numpy as np
 
 import basix
+import basix.ufl
 import ffcx.codegeneration.jit
 import ufl
 from ffcx.naming import cdtype_to_numpy, scalar_to_value_type
@@ -38,7 +39,7 @@ def test_matvec(compile_args):
     of user specified vector-valued finite element function (in P1 space).
 
     """
-    e = ufl.VectorElement("P", "triangle", 1)
+    e = basix.ufl.element("P", "triangle", 1, rank=1)
     mesh = ufl.Mesh(e)
     V = ufl.FunctionSpace(mesh, e)
     f = ufl.Coefficient(V)
@@ -102,7 +103,7 @@ def test_rank1(compile_args):
     and evaluates expression [u_y, u_x] + grad(u_x) at specified points.
 
     """
-    e = ufl.VectorElement("P", "triangle", 1)
+    e = basix.ufl.element("P", "triangle", 1, rank=1)
     mesh = ufl.Mesh(e)
 
     V = ufl.FunctionSpace(mesh, e)
@@ -163,10 +164,10 @@ def test_elimiate_zero_tables_tensor(compile_args):
     Test elimination of tensor-valued expressions with zero tables
     """
     cell = "tetrahedron"
-    c_el = ufl.VectorElement("P", cell, 1)
+    c_el = basix.ufl.element("P", cell, 1, rank=1)
     mesh = ufl.Mesh(c_el)
 
-    e = ufl.FiniteElement("CG", cell, 1)
+    e = basix.ufl.element("CG", cell, 1)
     V = ufl.FunctionSpace(mesh, e)
     u = ufl.Coefficient(V)
     expr = ufl.sym(ufl.as_tensor([[u, u.dx(0).dx(0), 0],

--- a/test/test_jit_expression.py
+++ b/test/test_jit_expression.py
@@ -167,7 +167,7 @@ def test_elimiate_zero_tables_tensor(compile_args):
     c_el = basix.ufl.element("P", cell, 1, rank=1)
     mesh = ufl.Mesh(c_el)
 
-    e = basix.ufl.element("CG", cell, 1)
+    e = basix.ufl.element("P", cell, 1)
     V = ufl.FunctionSpace(mesh, e)
     u = ufl.Coefficient(V)
     expr = ufl.sym(ufl.as_tensor([[u, u.dx(0).dx(0), 0],


### PR DESCRIPTION
Coupled with https://github.com/FEniCS/basix/pull/655 and https://github.com/FEniCS/dolfinx/pull/2381.

This PR adds a deprecation warning whenever elements are creates with UFL directly, encouraging users to move to using `basix.ufl`