### PR TITLE
Support facet integrals with vertex scheme

### DIFF
--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -403,7 +403,12 @@ def _compute_integral_ir(form_data, form_index, element_numbers, integral_names,
                 # scheme have some properties that other schemes lack, e.g., the
                 # mass matrix is a simple diagonal matrix. This may be
                 # prescribed in certain cases.
+
                 degree = md["quadrature_degree"]
+                if integral_type != "cell":
+                    facet_types = cell.facet_types()
+                    assert len(facet_types) == 1
+                    cellname = facet_types[0].cellname()
                 if degree > 1:
                     warnings.warn(
                         "Explicitly selected vertex quadrature (degree 1), but requested degree is {}.".


### PR DESCRIPTION
I think we are getting to the point where this should really be in basix, as it would be easier to support more complicated cells, such as prisms, if we work directly with basix info.

Reported at: https://fenicsproject.discourse.group/t/set-integration-rule-to-closed-vertex/10695/5?u=dokken