### PR TITLE
Argument in test should be `np.array`

### DIFF
--- a/test/test_elements.py
+++ b/test/test_elements.py
@@ -187,7 +187,7 @@ supported (non-mixed) for low degrees"""
         # Get some points and check basis function values at points
         points = [random_point(element_coords(cell)) for i in range(5)]
         for x in points:
-            table = e.tabulate(0, (x,))
+            table = e.tabulate(0, np.array([x], dtype=np.float64))
             basis = table[0]
             if sum(e.value_shape()) == 1:
                 for i, value in enumerate(basis[0]):


### PR DESCRIPTION
The `nanobind` bindings do not automatically convert from a tuple to a `numpy` array, so we need to use the correct type.
This seems to be the only place (so far) that it has come up.