### PR TITLE
Fix bug that led to Quadrature Elements not being blocked.

### DIFF
--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -26,7 +26,7 @@ def convert_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._
     else:
         return _cached_conversion(element)
 
-
+@lru_cache()
 def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._ElementBase:
     """Create an FFCx element from a UFL element.
 

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -26,6 +26,7 @@ def convert_element(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._
     else:
         return _cached_conversion(element)
 
+
 @lru_cache()
 def _cached_conversion(element: ufl.finiteelement.FiniteElementBase) -> basix.ufl._ElementBase:
     """Create an FFCx element from a UFL element.

--- a/ffcx/element_interface.py
+++ b/ffcx/element_interface.py
@@ -133,7 +133,8 @@ class QuadratureElement(basix.ufl._ElementBase):
 
     def __eq__(self, other) -> bool:
         """Check if two elements are equal."""
-        return isinstance(other, QuadratureElement) and np.allclose(self._points, other._points)
+        return isinstance(other, QuadratureElement) and np.allclose(self._points, other._points) and \
+            np.allclose(self._weights, other._weights)
 
     def __hash__(self) -> int:
         """Return a hash."""

--- a/test/test_blocked_elements.py
+++ b/test/test_blocked_elements.py
@@ -9,6 +9,7 @@ import numpy as np
 import ffcx
 import ffcx.codegeneration.jit
 import basix.ufl
+import ufl
 
 
 def test_finite_element(compile_args):
@@ -77,37 +78,36 @@ def test_vector_element(compile_args):
     assert ufcx_dofmap.num_sub_dofmaps == 2
 
 
-def test_tensor_element(compile_args):
-    ufl_element = basix.ufl.element("Lagrange", "triangle", 1, rank=2)
+def test_vector_quadrature_element(compile_args):
+    ufl_element = ufl.VectorElement(ufl.FiniteElement("Quadrature", "tetrahedron", degree=2, quad_scheme="default"))
     jit_compiled_elements, module, code = ffcx.codegeneration.jit.compile_elements(
         [ufl_element], cffi_extra_compile_args=compile_args)
     ufcx_element, ufcx_dofmap = jit_compiled_elements[0]
 
-    assert ufcx_element.topological_dimension == 2
-    assert ufcx_element.geometric_dimension == 2
+    assert ufcx_element.topological_dimension == 3
+    assert ufcx_element.geometric_dimension == 3
     assert ufcx_element.space_dimension == 12
-    assert ufcx_element.value_rank == 2
-    assert ufcx_element.value_shape[0] == 2
-    assert ufcx_element.value_shape[1] == 2
-    assert ufcx_element.value_size == 4
-    assert ufcx_element.reference_value_rank == 2
-    assert ufcx_element.reference_value_shape[0] == 2
-    assert ufcx_element.reference_value_shape[1] == 2
-    assert ufcx_element.reference_value_size == 4
-    assert ufcx_element.block_size == 4
-    assert ufcx_element.num_sub_elements == 4
+    assert ufcx_element.value_rank == 1
+    assert ufcx_element.value_shape[0] == 3
+    assert ufcx_element.value_size == 3
+    assert ufcx_element.reference_value_rank == 1
+    assert ufcx_element.reference_value_shape[0] == 3
+    assert ufcx_element.reference_value_size == 3
+    assert ufcx_element.block_size == 3
+    assert ufcx_element.num_sub_elements == 3
 
-    assert ufcx_dofmap.block_size == 4
+    assert ufcx_dofmap.block_size == 3
     assert ufcx_dofmap.num_global_support_dofs == 0
     assert ufcx_dofmap.num_global_support_dofs == 0
-    assert ufcx_dofmap.num_element_support_dofs == 3
-    assert ufcx_dofmap.num_entity_dofs[0] == 1
+    assert ufcx_dofmap.num_element_support_dofs == 4
+    assert ufcx_dofmap.num_entity_dofs[0] == 0
     assert ufcx_dofmap.num_entity_dofs[1] == 0
     assert ufcx_dofmap.num_entity_dofs[2] == 0
-    assert ufcx_dofmap.num_entity_dofs[3] == 0
-    for v in range(3):
-        vals = np.zeros(1, dtype=np.int32)
-        vals_ptr = module.ffi.cast("int *", module.ffi.from_buffer(vals))
-        ufcx_dofmap.tabulate_entity_dofs(vals_ptr, 0, v)
-        assert vals[0] == v
-    assert ufcx_dofmap.num_sub_dofmaps == 4
+    assert ufcx_dofmap.num_entity_dofs[3] == 4
+
+    vals = np.zeros(4, dtype=np.int32)
+    vals_ptr = module.ffi.cast("int *", module.ffi.from_buffer(vals))
+    ufcx_dofmap.tabulate_entity_dofs(vals_ptr, 3, 0)
+    assert (vals == [0, 1, 2, 3]).all()
+
+    assert ufcx_dofmap.num_sub_dofmaps == 3

--- a/test/test_blocked_elements.py
+++ b/test/test_blocked_elements.py
@@ -78,6 +78,42 @@ def test_vector_element(compile_args):
     assert ufcx_dofmap.num_sub_dofmaps == 2
 
 
+def test_tensor_element(compile_args):
+    ufl_element = basix.ufl.element("Lagrange", "triangle", 1, rank=2)
+    jit_compiled_elements, module, code = ffcx.codegeneration.jit.compile_elements(
+        [ufl_element], cffi_extra_compile_args=compile_args)
+    ufcx_element, ufcx_dofmap = jit_compiled_elements[0]
+
+    assert ufcx_element.topological_dimension == 2
+    assert ufcx_element.geometric_dimension == 2
+    assert ufcx_element.space_dimension == 12
+    assert ufcx_element.value_rank == 2
+    assert ufcx_element.value_shape[0] == 2
+    assert ufcx_element.value_shape[1] == 2
+    assert ufcx_element.value_size == 4
+    assert ufcx_element.reference_value_rank == 2
+    assert ufcx_element.reference_value_shape[0] == 2
+    assert ufcx_element.reference_value_shape[1] == 2
+    assert ufcx_element.reference_value_size == 4
+    assert ufcx_element.block_size == 4
+    assert ufcx_element.num_sub_elements == 4
+
+    assert ufcx_dofmap.block_size == 4
+    assert ufcx_dofmap.num_global_support_dofs == 0
+    assert ufcx_dofmap.num_global_support_dofs == 0
+    assert ufcx_dofmap.num_element_support_dofs == 3
+    assert ufcx_dofmap.num_entity_dofs[0] == 1
+    assert ufcx_dofmap.num_entity_dofs[1] == 0
+    assert ufcx_dofmap.num_entity_dofs[2] == 0
+    assert ufcx_dofmap.num_entity_dofs[3] == 0
+    for v in range(3):
+        vals = np.zeros(1, dtype=np.int32)
+        vals_ptr = module.ffi.cast("int *", module.ffi.from_buffer(vals))
+        ufcx_dofmap.tabulate_entity_dofs(vals_ptr, 0, v)
+        assert vals[0] == v
+    assert ufcx_dofmap.num_sub_dofmaps == 4
+
+
 def test_vector_quadrature_element(compile_args):
     ufl_element = ufl.VectorElement(ufl.FiniteElement("Quadrature", "tetrahedron", degree=2, quad_scheme="default"))
     jit_compiled_elements, module, code = ffcx.codegeneration.jit.compile_elements(


### PR DESCRIPTION
The order of the logic in element_interface.py led to the built in FFCx type QuadratureElement always being handled 
prior to the call to Basix's block element. This PR changes this to handle elements in order of higher-order types, FFCx types, and then finally UFL types.

It's not clear to be what the modern 'basix' way to handle QuadratureElements might be (regarding the warning).
