### PR TITLE
Use ArrayAccess for entity_local_index

### DIFF
--- a/ffcx/codegeneration/lnodes.py
+++ b/ffcx/codegeneration/lnodes.py
@@ -311,6 +311,7 @@ class Symbol(LExprTerminal):
 
     def __init__(self, name: str, dtype):
         assert isinstance(name, str)
+        assert name.replace("_", "").isalnum()
         self.name = name
         self.dtype = dtype
 

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -77,13 +77,15 @@ class FFCXBackendSymbols(object):
         if entitytype == "cell":
             # Always 0 for cells (even with restriction)
             return L.LiteralInt(0)
-        elif entitytype == "facet":
-            postfix = "[0]"
+
+        entity_local_index = L.Symbol("entity_local_index", dtype=L.DataType.INT)
+        if entitytype == "facet":
             if restriction == "-":
-                postfix = "[1]"
-            return L.Symbol("entity_local_index" + postfix, dtype=L.DataType.INT)
+                return entity_local_index[1]
+            else:
+                return entity_local_index[0]
         elif entitytype == "vertex":
-            return L.Symbol("entity_local_index[0]", dtype=L.DataType.INT)
+            return entity_local_index[0]
         else:
             logging.exception(f"Unknown entitytype {entitytype}")
 


### PR DESCRIPTION
Fixes code which hardwired the strings `[0]` and `[1]` into the Symbol.