### PR TITLE
Add test to LNodes and reuse more Symbols

### DIFF
--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -95,8 +95,8 @@ class FFCXBackendAccess(object):
                 raise RuntimeError("FIXME: Jacobian in custom integrals is not implemented.")
 
             # Access predefined quadrature points table
-            x = self.symbols.custom_points_table()
-            iq = self.symbols.quadrature_loop_index()
+            x = self.symbols.custom_points_table
+            iq = self.symbols.quadrature_loop_index
             gdim, = mt.terminal.ufl_shape
             if gdim == 1:
                 index = iq

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -81,7 +81,7 @@ class FFCXBackendDefinitions(object):
 
         # Get access to element table
         FE = self.symbols.element_table(tabledata, self.entitytype, mt.restriction)
-        ic = self.symbols.coefficient_dof_sum_index()
+        ic = self.symbols.coefficient_dof_sum_index
 
         code = []
         pre_code = []
@@ -134,17 +134,11 @@ class FFCXBackendDefinitions(object):
 
         # Get access to element table
         FE = self.symbols.element_table(tabledata, self.entitytype, mt.restriction)
-        ic = self.symbols.coefficient_dof_sum_index()
-        dof_access = L.Symbol("coordinate_dofs", dtype=L.DataType.REAL)
-
-        # coordinate dofs is always 3d
-        dim = 3
-        offset = 0
-        if mt.restriction == "-":
-            offset = num_scalar_dofs * dim
+        ic = self.symbols.coefficient_dof_sum_index
+        dof_access = self.symbols.domain_dof_access(ic, begin, 3, num_scalar_dofs, mt.restriction)
 
         code = []
-        body = [L.AssignAdd(access, dof_access[ic * dim + begin + offset] * FE[ic])]
+        body = [L.AssignAdd(access, dof_access * FE[ic])]
         code += [L.VariableDecl(access, 0.0)]
         code += [L.ForRange(ic, 0, num_scalar_dofs, body)]
 

--- a/ffcx/codegeneration/expression_generator.py
+++ b/ffcx/codegeneration/expression_generator.py
@@ -118,7 +118,7 @@ class ExpressionGenerator:
             # Could happen for integral with everything zero and optimized away
             quadparts = []
         else:
-            iq = self.backend.symbols.quadrature_loop_index()
+            iq = self.backend.symbols.quadrature_loop_index
             num_points = self.quadrature_rule.points.shape[0]
             quadparts = [L.ForRange(iq, 0, num_points, body=body)]
 
@@ -192,8 +192,8 @@ class ExpressionGenerator:
 
         num_points = self.quadrature_rule.points.shape[0]
         A_shape = [num_points, components] + self.ir.tensor_shape
-        A = self.backend.symbols.element_tensor()
-        iq = self.backend.symbols.quadrature_loop_index()
+        A = self.backend.symbols.element_tensor
+        iq = self.backend.symbols.quadrature_loop_index
 
         # Check if DOFs in dofrange are equally spaced.
         expand_loop = False

--- a/ffcx/codegeneration/expression_generator.py
+++ b/ffcx/codegeneration/expression_generator.py
@@ -86,7 +86,7 @@ class ExpressionGenerator:
         for name in table_names:
             table = tables[name]
             symbol = L.Symbol(name, dtype=L.DataType.REAL)
-            self.backend.symbols[name] = symbol
+            self.backend.symbols.element_tables[name] = symbol
             decl = L.ArrayDecl(symbol, sizes=table.shape, values=table, const=True)
             parts += [decl]
 

--- a/ffcx/codegeneration/expression_generator.py
+++ b/ffcx/codegeneration/expression_generator.py
@@ -86,6 +86,7 @@ class ExpressionGenerator:
         for name in table_names:
             table = tables[name]
             symbol = L.Symbol(name, dtype=L.DataType.REAL)
+            self.backend.symbols[name] = symbol
             decl = L.ArrayDecl(symbol, sizes=table.shape, values=table, const=True)
             parts += [decl]
 

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -247,7 +247,7 @@ class IntegralGenerator(object):
             quadparts = []
         else:
             num_points = quadrature_rule.points.shape[0]
-            iq = self.backend.symbols.quadrature_loop_index()
+            iq = self.backend.symbols.quadrature_loop_index
             quadparts = [L.ForRange(iq, 0, num_points, body=body)]
 
         return pre_definitions, preparts, quadparts
@@ -445,7 +445,7 @@ class IntegralGenerator(object):
         block_rank = len(blockmap)
         blockdims = tuple(len(dofmap) for dofmap in blockmap)
 
-        iq = self.backend.symbols.quadrature_loop_index()
+        iq = self.backend.symbols.quadrature_loop_index
 
         # Override dof index with quadrature loop index for arguments
         # with quadrature element, to index B like B[iq*num_dofs + iq]

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -559,7 +559,7 @@ class IntegralGenerator(object):
 
         body: List[LNode] = []
 
-        A = self.backend.symbols.element_tensor()
+        A = self.backend.symbols.element_tensor
         A_shape = self.ir.tensor_shape
         for indices in keep:
             multi_index = L.MultiIndex(list(indices), A_shape)

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -474,7 +474,7 @@ class IntegralGenerator(object):
 
             # Quadrature weight was removed in representation, add it back now
             if self.ir.integral_type in ufl.custom_integral_types:
-                weights = self.backend.symbols.custom_weights_table()
+                weights = self.backend.symbols.custom_weights_table
                 weight = weights[iq]
             else:
                 weights = self.backend.symbols.weights_table(quadrature_rule)

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -226,6 +226,7 @@ class IntegralGenerator(object):
 
         """
         table_symbol = L.Symbol(name, dtype=L.DataType.REAL)
+        self.backend.symbols.element_tables[name] = table_symbol
         return [L.ArrayDecl(table_symbol, values=table, const=True)]
 
     def generate_quadrature_loop(self, quadrature_rule: QuadratureRule):

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -68,8 +68,9 @@ class FFCXBackendSymbols(object):
 
         self.original_constant_offsets = original_constant_offsets
 
-        # Keep tabs on tables, so the symbol can be reused
+        # Keep tabs on tables, so the symbols can be reused
         self.quadrature_weight_tables = {}
+        self.element_tables = {}
 
         # Reusing a single symbol for all quadrature loops, assumed not to be nested.
         self.quadrature_loop_index = L.Symbol("iq", dtype=L.DataType.INT)
@@ -187,7 +188,7 @@ class FFCXBackendSymbols(object):
         if tabledata.is_piecewise:
             iq = 0
         else:
-            iq = self.quadrature_loop_index()
+            iq = self.quadrature_loop_index
 
         if tabledata.is_permuted:
             qp = self.quadrature_permutation(0)
@@ -196,5 +197,8 @@ class FFCXBackendSymbols(object):
         else:
             qp = 0
 
-        # Return direct access to element table
-        return L.Symbol(tabledata.name, dtype=L.DataType.REAL)[qp][entity][iq]
+        # Return direct access to element table, reusing symbol if possible
+        if tabledata.name not in self.element_tables.keys():
+            self.element_tables[tabledata.name] = L.Symbol(tabledata.name,
+                                                           dtype=L.DataType.REAL)
+        return self.element_tables[tabledata.name][qp][entity][iq]

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -192,7 +192,7 @@ class FFCXBackendSymbols(object):
             qp = 0
 
         # Return direct access to element table, reusing symbol if possible
-        if tabledata.name not in self.element_tables.keys():
+        if tabledata.name not in self.element_tables:
             self.element_tables[tabledata.name] = L.Symbol(tabledata.name,
                                                            dtype=L.DataType.REAL)
         return self.element_tables[tabledata.name][qp][entity][iq]

--- a/test/test_lnodes.py
+++ b/test/test_lnodes.py
@@ -64,7 +64,7 @@ def test_gemv(scalar):
     y = L.Symbol("y", dtype=L.DataType.SCALAR)
     A = L.Symbol("A", dtype=L.DataType.SCALAR)
     x = L.Symbol("x", dtype=L.DataType.SCALAR)
-    code = [L.Comment(f"Matrix multiply y({p}) = A{p,q} * x({q})")]
+    code = [L.Comment(f"Matrix-vector multiply y({p}) = A{p,q} * x({q})")]
 
     i = L.Symbol("i", dtype=L.DataType.INT)
     j = L.Symbol("j", dtype=L.DataType.INT)
@@ -79,8 +79,6 @@ def test_gemv(scalar):
     decl = f"void gemm({scalar} *y, {scalar} *A, {scalar} *x)"
     c_code = decl + "{\n" + \
         Q.c_format(L.StatementList(code)) + "\n}\n"
-
-    print(c_code)
 
     ffibuilder = FFI()
     ffibuilder.cdef(decl + ";")

--- a/test/test_lnodes.py
+++ b/test/test_lnodes.py
@@ -1,0 +1,108 @@
+
+from ffcx.codegeneration import lnodes as L
+from ffcx.codegeneration.C.c_implementation import CFormatter
+from cffi import FFI
+import numpy as np
+import pytest
+import importlib
+
+
+@pytest.mark.parametrize("scalar", ("float", "double", "int"))
+def test_gemm(scalar):
+    # Test LNodes simple matrix-matrix multiply in C
+    p, q, r = 5, 16, 12
+
+    A = L.Symbol("A", dtype=L.DataType.SCALAR)
+    B = L.Symbol("B", dtype=L.DataType.SCALAR)
+    C = L.Symbol("C", dtype=L.DataType.SCALAR)
+    code = [L.Comment(f"Matrix multiply A{p,r} = B{p,q} * C{q,r}")]
+
+    i = L.Symbol("i", dtype=L.DataType.INT)
+    j = L.Symbol("j", dtype=L.DataType.INT)
+    k = L.Symbol("k", dtype=L.DataType.INT)
+    m_ij = L.MultiIndex([i, j], [p, q])
+    m_ik = L.MultiIndex([i, k], [p, r])
+    m_jk = L.MultiIndex([j, k], [q, r])
+
+    body = [L.AssignAdd(A[m_ik], B[m_ij] * C[m_jk])]
+    body = [L.ForRange(i, 0, p, body=body)]
+    body = [L.ForRange(j, 0, q, body=body)]
+    code += [L.ForRange(k, 0, r, body=body)]
+
+    # Format into C and compile with CFFI
+    Q = CFormatter(scalar=scalar)
+    decl = f"void gemm({scalar} *A, {scalar} *B, {scalar} *C)"
+    c_code = decl + "{\n" + \
+        Q.c_format(L.StatementList(code)) + "\n}\n"
+
+    ffibuilder = FFI()
+    ffibuilder.cdef(decl + ";")
+    ffibuilder.set_source(f"_gemm_{scalar}", c_code)
+    ffibuilder.compile(verbose=True)
+    _gemm = importlib.import_module(f"_gemm_{scalar}")
+    gemm = _gemm.lib.gemm
+    ffi = _gemm.ffi
+
+    c_to_np = {"double": np.float64, "float": np.float32, "int": np.int32}
+    np_scalar = c_to_np.get(scalar)
+    A = np.zeros((p, r), dtype=np_scalar)
+    B = np.ones((p, q), dtype=np_scalar)
+    C = np.ones((q, r), dtype=np_scalar)
+    pA = ffi.cast(f"{scalar} *", A.ctypes.data)
+    pB = ffi.cast(f"{scalar} *", B.ctypes.data)
+    pC = ffi.cast(f"{scalar} *", C.ctypes.data)
+
+    gemm(pA, pB, pC)
+    assert np.all(A == q)
+
+
+@pytest.mark.parametrize("scalar", ("float", "double", "int"))
+def test_gemv(scalar):
+    # Test LNodes simple matvec multiply in C
+    p, q = 5, 16
+
+    y = L.Symbol("y", dtype=L.DataType.SCALAR)
+    A = L.Symbol("A", dtype=L.DataType.SCALAR)
+    x = L.Symbol("x", dtype=L.DataType.SCALAR)
+    code = [L.Comment(f"Matrix multiply y({p}) = A{p,q} * x({q})")]
+
+    i = L.Symbol("i", dtype=L.DataType.INT)
+    j = L.Symbol("j", dtype=L.DataType.INT)
+    m_ij = L.MultiIndex([i, j], [p, q])
+
+    body = [L.AssignAdd(y[i], A[m_ij] * x[j])]
+    body = [L.ForRange(i, 0, p, body=body)]
+    code += [L.ForRange(j, 0, q, body=body)]
+
+    # Format into C and compile with CFFI
+    Q = CFormatter(scalar=scalar)
+    decl = f"void gemm({scalar} *y, {scalar} *A, {scalar} *x)"
+    c_code = decl + "{\n" + \
+        Q.c_format(L.StatementList(code)) + "\n}\n"
+
+    print(c_code)
+
+    ffibuilder = FFI()
+    ffibuilder.cdef(decl + ";")
+    ffibuilder.set_source(f"_gemv_{scalar}", c_code)
+    ffibuilder.compile(verbose=True)
+    _gemv = importlib.import_module(f"_gemv_{scalar}")
+    gemv = _gemv.lib.gemm
+    ffi = _gemv.ffi
+
+    c_to_np = {"double": np.float64, "float": np.float32, "int": np.int32}
+    np_scalar = c_to_np.get(scalar)
+    y = np.arange(p, dtype=np_scalar)
+    x = np.arange(q, dtype=np_scalar)
+    A = np.outer(y, x)
+
+    py = ffi.cast(f"{scalar} *", y.ctypes.data)
+    pA = ffi.cast(f"{scalar} *", A.ctypes.data)
+    px = ffi.cast(f"{scalar} *", x.ctypes.data)
+
+    # Compute expected result
+    s2 = q * (q - 1) * (2 * q - 1) // 6 + 1
+    result = np.arange(p, dtype=np_scalar) * s2
+
+    gemv(py, pA, px)
+    assert np.all(y == result)


### PR DESCRIPTION
Adds a test for LNode functionality and reuses more symbols in the generators,
which should make it easier to apply optimisations, as they will now have the same `id()` throughout.