### PR TITLE
Restrict to set() of unique elements in `build_optimized_tables`

### DIFF
--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -293,7 +293,7 @@ def build_optimized_tables(quadrature_rule, cell, integral_type, entitytype,
     # get priority
     all_elements = [res[0] for res in analysis.values()]
     unique_elements = ufl.algorithms.sort_elements(
-        ufl.algorithms.analysis.extract_sub_elements(all_elements))
+        set(ufl.algorithms.analysis.extract_sub_elements(all_elements)))
     element_numbers = {element: i for i, element in enumerate(unique_elements)}
     mt_tables = {}
 


### PR DESCRIPTION
# Description of the issue

Calls to `ufl.algorithms.sort_elements` should be made with a `set()` to remove repeated entries from the elements list. This prevents `ufl.utils.sorting.topological_sorting` from performing unnecessary work.

# Description of changes

This pull request updates `build_optimized_tables` with a call to `set()` to remove repeated entries from the elements list before calling `sort_elements`. This is consistent with the usage at https://github.com/FEniCS/ffcx/blob/main/ffcx/analysis.py#L99.