### PR TITLE
Remove unused functions and convert list of strings to static data

### DIFF
--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -43,7 +43,6 @@ def generator(ir, options):
         d["original_coefficient_position_init"] = ""
         d["original_coefficient_position"] = "NULL"
 
-
     if len(ir.coefficient_names) > 0:
         values = ", ".join(f'"{name}"' for name in ir.coefficient_names)
         sizes = len(ir.coefficient_names)
@@ -61,7 +60,7 @@ def generator(ir, options):
     else:
         d["constant_names_init"] = ""
         d["constant_names"] = "NULL"
-    
+
     if len(ir.finite_elements) > 0:
         d["finite_elements"] = f"finite_elements_{ir.name}"
         values = ", ".join(f"&{el}" for el in ir.finite_elements)

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -43,25 +43,25 @@ def generator(ir, options):
         d["original_coefficient_position_init"] = ""
         d["original_coefficient_position"] = "NULL"
 
-    cnames = ir.coefficient_names
-    assert ir.num_coefficients == len(cnames)
-    if len(cnames) == 0:
-        code = ["return NULL;"]
-    else:
-        values = ", ".join(f'"{name}"' for name in cnames)
-        code = [f"static const char* names[{len(cnames)}] = {{{values}}};",
-                "return names;"]
-    d["coefficient_name_map"] = "\n".join(code)
 
-    cstnames = ir.constant_names
-    if len(cstnames) == 0:
-        code = ["return NULL;"]
+    if len(ir.coefficient_names) > 0:
+        values = ", ".join(f'"{name}"' for name in ir.coefficient_names)
+        sizes = len(ir.coefficient_names)
+        d["coefficient_names_init"] = f"static const char* coefficient_names_{ir.name}[{sizes}] = {{{values}}};"
+        d["coefficient_names"] = f"coefficient_names_{ir.name}"
     else:
-        values = ", ".join(f'"{name}"' for name in cstnames)
-        code = [f"static const char* names[{len(cstnames)}] = {{{values}}};",
-                "return names;"]
-    d["constant_name_map"] = "\n".join(code)
+        d["coefficient_names_init"] = ""
+        d["coefficient_names"] = "NULL"
 
+    if len(ir.constant_names) > 0:
+        values = ", ".join(f'"{name}"' for name in ir.constant_names)
+        sizes = len(ir.constant_names)
+        d["constant_names_init"] = f"static const char* constant_names_{ir.name}[{sizes}] = {{{values}}};"
+        d["constant_names"] = f"constant_names_{ir.name}"
+    else:
+        d["constant_names_init"] = ""
+        d["constant_names"] = "NULL"
+    
     if len(ir.finite_elements) > 0:
         d["finite_elements"] = f"finite_elements_{ir.name}"
         values = ", ".join(f"&{el}" for el in ir.finite_elements)

--- a/ffcx/codegeneration/C/form_template.py
+++ b/ffcx/codegeneration/C/form_template.py
@@ -28,17 +28,8 @@ factory = """
 {form_integrals_init}
 {form_integral_ids_init}
 
-// Return a list of the coefficient names.
-const char** coefficient_name_{factory_name}(void)
-{{
-{coefficient_name_map}
-}}
-
-// Return a list of the constant names.
-const char** constant_name_{factory_name}(void)
-{{
-{constant_name_map}
-}}
+{coefficient_names_init}
+{constant_names_init}
 
 ufcx_form {factory_name} =
 {{
@@ -49,8 +40,8 @@ ufcx_form {factory_name} =
   .num_constants = {num_constants},
   .original_coefficient_position = {original_coefficient_position},
 
-  .coefficient_name_map = coefficient_name_{factory_name},
-  .constant_name_map = constant_name_{factory_name},
+  .coefficient_name_map = {coefficient_names},
+  .constant_name_map = {constant_names},
 
   .finite_elements = {finite_elements},
   .dofmaps = {dofmaps},

--- a/ffcx/codegeneration/ufcx.h
+++ b/ffcx/codegeneration/ufcx.h
@@ -205,7 +205,6 @@ extern "C"
 
   typedef struct ufcx_dofmap
   {
-
     /// String identifying the dofmap
     const char* signature;
 
@@ -230,18 +229,6 @@ extern "C"
 
     /// Offset for closure dofs of each entity in entity_closure_dofs
     int *entity_closure_dof_offsets;
-
-    /// Number of dofs associated with each cell entity of dimension d
-    int *num_entity_dofs;
-
-    /// Tabulate the local-to-local mapping of dofs on entity (d, i)
-    void (*tabulate_entity_dofs)(int* restrict dofs, int d, int i);
-
-    /// Number of dofs associated with the closure of each cell entity of dimension d
-    int *num_entity_closure_dofs;
-
-    /// Tabulate the local-to-local mapping of dofs on the closure of entity (d, i)
-    void (*tabulate_entity_closure_dofs)(int* restrict dofs, int d, int i);
 
     /// Number of sub dofmaps (for a mixed element)
     int num_sub_dofmaps;

--- a/ffcx/codegeneration/ufcx.h
+++ b/ffcx/codegeneration/ufcx.h
@@ -420,11 +420,11 @@ extern "C"
     /// Original coefficient position for each coefficient
     int* original_coefficient_position;
 
-    /// Return list of names of coefficients
-    const char** (*coefficient_name_map)(void);
+    /// List of names of coefficients
+    const char** coefficient_name_map;
 
-    /// Return list of names of constants
-    const char** (*constant_name_map)(void);
+    /// List of names of constants
+    const char** constant_name_map;
 
     /// Get a finite element for the i-th argument function, where 0 <=
     /// i < r + n.


### PR DESCRIPTION

Removes some unused functions from `ufcx.h` and changes some function calls to static data for constant and coefficient names. Requires a minor change to dolfinx