### PR TITLE
Use up to date container in DOLFINx integration tests, and update OMPI environment variables for openmpi v5

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -25,17 +25,12 @@ jobs:
   build:
     name: Run DOLFINx tests
     runs-on: ubuntu-latest
-    container: fenicsproject/test-env:nightly-openmpi
+    container: ghcr.io/fenics/test-env:current-openmpi
 
     env:
       PETSC_ARCH: linux-gnu-complex-32
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-      OMPI_MCA_rmaps_base_oversubscribe: 1
-      OMPI_MCA_plm: isolated
-      OMPI_MCA_btl_vader_single_copy_mechanism: none
-      OMPI_MCA_mpi_yield_when_idle: 1
-      OMPI_MCA_hwloc_base_binding_policy: none
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -28,15 +28,12 @@ jobs:
     container: ghcr.io/fenics/test-env:current-openmpi
 
     env:
-      PETSC_ARCH: linux-gnu-complex-32
+      PETSC_ARCH: linux-gnu-complex64-32
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install dependencies (Python)
-        run: |
-          python3 -m pip install --upgrade pip
 
       - name: Install UFL and Basix (default branches/tags)
         if: github.event_name != 'workflow_dispatch'
@@ -75,7 +72,6 @@ jobs:
           cmake --install build
       - name: Install DOLFINx (Python)
         run: |
-          python3 -m pip install -r dolfinx/python/build-requirements.txt # TO REMOVE
           python3 -m pip -v install --check-build-dependencies --no-build-isolation dolfinx/python/
 
       - name: Build DOLFINx C++ unit tests


### PR DESCRIPTION
Branches made from current `main` may need to be updated with this change to restore working CI.