### PR TITLE
Remove `logging.basicConfig()` call in ``fcx/__init__.py``

### DIFF
--- a/ffcx/__init__.py
+++ b/ffcx/__init__.py
@@ -18,6 +18,5 @@ from ffcx.options import get_options  # noqa: F401
 
 __version__ = importlib.metadata.version("fenics-ffcx")
 
-logging.basicConfig()
 logger = logging.getLogger("ffcx")
 logging.captureWarnings(capture=True)


### PR DESCRIPTION
Fixes #567.