### PR TITLE
Avoid nesting conditions and statements with many operands

### DIFF
--- a/ffcx/codegeneration/C/c_implementation.py
+++ b/ffcx/codegeneration/C/c_implementation.py
@@ -156,6 +156,8 @@ class CFormatter(object):
             return dtype_to_c_type(self.real_type)
         if dtype == L.DataType.INT:
             return "int"
+        if dtype == L.DataType.BOOL:
+            return "bool"
         raise ValueError(f"Invalid dtype: {dtype}")
 
     def _format_number(self, x):

--- a/ffcx/codegeneration/expression_generator.py
+++ b/ffcx/codegeneration/expression_generator.py
@@ -306,8 +306,6 @@ class ExpressionGenerator:
         pre_definitions = dict()
         intermediates = []
 
-        use_symbol_array = True
-
         for i, attr in F.nodes.items():
             if attr['status'] != mode:
                 continue
@@ -365,13 +363,9 @@ class ExpressionGenerator:
                 else:
                     # Record assignment of vexpr to intermediate variable
                     j = len(intermediates)
-                    if use_symbol_array:
-                        vaccess = symbol[j]
-                        intermediates.append(L.Assign(vaccess, vexpr))
-                    else:
-                        scalar_type = dtype_to_c_type(self.backend.access.options["scalar_type"])
-                        vaccess = L.Symbol("%s_%d" % (symbol.name, j), dtype=L.DataType.SCALAR)
-                        intermediates.append(L.VariableDecl(f"const {scalar_type}", vaccess, vexpr))
+                    scalar_type = dtype_to_c_type(self.backend.access.options["scalar_type"])
+                    vaccess = L.Symbol("%s_%d" % (symbol.name, j), dtype=L.DataType.SCALAR)
+                    intermediates.append(L.VariableDecl(f"const {scalar_type}", vaccess, vexpr))
 
             # Store access node for future reference
             self.scope[v] = vaccess
@@ -386,8 +380,6 @@ class ExpressionGenerator:
         if definitions:
             parts += definitions
 
-        if intermediates:
-            if use_symbol_array:
-                parts += [L.ArrayDecl(symbol, sizes=len(intermediates))]
-            parts += intermediates
+        parts += intermediates
+
         return parts

--- a/ffcx/codegeneration/expression_generator.py
+++ b/ffcx/codegeneration/expression_generator.py
@@ -14,7 +14,6 @@ import ufl
 from ffcx.codegeneration import geometry
 from ffcx.codegeneration.backend import FFCXBackend
 from ffcx.codegeneration.lnodes import LNode
-from ffcx.codegeneration.utils import dtype_to_c_type
 from ffcx.ir.representation import ExpressionIR
 
 logger = logging.getLogger("ffcx")

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -315,13 +315,14 @@ class IntegralGenerator(object):
                 else:
                     # Get previously visited operands
                     vops = [self.get_var(quadrature_rule, op) for op in v.ufl_operands]
+                    dtypes = [op.dtype for op in vops]
 
                     # Mapping UFL operator to target language
                     self._ufl_names.add(v._ufl_handler_name_)
                     vexpr = L.ufl_to_lnodes(v, *vops)
 
                     is_cond = isinstance(v, ufl.classes.Condition)
-                    dtype = L.DataType.BOOL if is_cond else L.DataType.SCALAR
+                    dtype = L.DataType.BOOL if is_cond else L.merge_dtypes(dtypes)
 
                     j = len(intermediates)
                     vaccess = L.Symbol(f"{symbol.name}_{j}", dtype=dtype)

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -318,44 +318,16 @@ class IntegralGenerator(object):
                     # Get previously visited operands
                     vops = [self.get_var(quadrature_rule, op) for op in v.ufl_operands]
 
-                    # get parent operand
-                    pid = F.in_edges[i][0] if F.in_edges[i] else -1
-                    if pid and pid > i:
-                        parent_exp = F.nodes.get(pid)['expression']
-                    else:
-                        parent_exp = None
-
                     # Mapping UFL operator to target language
                     self._ufl_names.add(v._ufl_handler_name_)
                     vexpr = L.ufl_to_lnodes(v, *vops)
 
-                    # Create a new intermediate for each subexpression
-                    # except boolean conditions and its childs
-                    if isinstance(parent_exp, ufl.classes.Condition):
-                        # Skip intermediates for 'x' and 'y' in x<y
-                        # Avoid the creation of complex valued intermediates
-                        vaccess = vexpr
-                    elif isinstance(v, ufl.classes.Condition):
-                        # Inline the conditions x < y, condition values
-                        # This removes the need to handle boolean
-                        # intermediate variables. With tensor-valued
-                        # conditionals it may not be optimal but we let
-                        # the compiler take responsibility for
-                        # optimizing those cases.
-                        vaccess = vexpr
-                    elif any(op._ufl_is_literal_ for op in v.ufl_operands):
-                        # Skip intermediates for e.g. -2.0*x,
-                        # resulting in lines like z = y + -2.0*x
-                        vaccess = vexpr
-                    else:
-                        # Record assignment of vexpr to intermediate variable
-                        j = len(intermediates)
-                        if use_symbol_array:
-                            vaccess = symbol[j]
-                            intermediates.append(L.Assign(vaccess, vexpr))
-                        else:
-                            vaccess = L.Symbol("%s_%d" % (symbol.name, j))
-                            intermediates.append(L.VariableDecl(vaccess, vexpr))
+                    is_cond = isinstance(v, ufl.classes.Condition)
+                    dtype = L.DataType.BOOL if is_cond else L.DataType.SCALAR
+
+                    j = len(intermediates)
+                    vaccess = L.Symbol(f"{symbol.name}_{j}", dtype=dtype)
+                    intermediates.append(L.VariableDecl(vaccess, vexpr))
 
                 # Store access node for future reference
                 self.set_var(quadrature_rule, v, vaccess)
@@ -365,10 +337,8 @@ class IntegralGenerator(object):
         parts = []
         parts += self.fuse_loops(definitions)
 
-        if intermediates:
-            if use_symbol_array:
-                parts += [L.ArrayDecl(symbol, sizes=len(intermediates))]
-            parts += intermediates
+        parts += intermediates
+
         return pre_definitions, parts
 
     def generate_dofblock_partition(self, quadrature_rule: QuadratureRule):

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -285,8 +285,6 @@ class IntegralGenerator(object):
         pre_definitions = dict()
         intermediates = []
 
-        use_symbol_array = True
-
         for i, attr in F.nodes.items():
             if attr['status'] != mode:
                 continue

--- a/ffcx/codegeneration/lnodes.py
+++ b/ffcx/codegeneration/lnodes.py
@@ -115,8 +115,10 @@ def merge_dtypes(dtypes: typing.List[DataType]):
         return DataType.SCALAR
     elif DataType.REAL in dtypes:
         return DataType.REAL
-    elif all(dtype == DataType.INT for dtype in dtypes):
+    elif DataType.INT in dtypes:
         return DataType.INT
+    elif DataType.BOOL in dtypes:
+        return DataType.BOOL
     else:
         raise ValueError(f"Can't get dtype for operation with {dtypes}")
 

--- a/ffcx/codegeneration/lnodes.py
+++ b/ffcx/codegeneration/lnodes.py
@@ -103,7 +103,8 @@ class DataType(Enum):
     REAL = 0
     SCALAR = 1
     INT = 2
-    NONE = 3
+    BOOL = 3
+    NONE = 4
 
 
 def merge_dtypes(dtype0, dtype1):


### PR DESCRIPTION
This PR fixes issue [#2991](https://github.com/FEniCS/ffcx/issues/652).

Also it simplifies how we create statements with LNodes in the integral generator.
Before this PR, each statement could be nested and could be understood as a tree of statements:
```
A = OP1(OP2(X, OP3(Y, Z)), W)
```
With this PR we create statements with 2 operands and 1 destination:
```
A0 = OP3(Y, Z)
A1 = OP2(X, A0)
A2 = OP1(A1, W)
```