### PR TITLE
Fix iowrapper warning

### DIFF
--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -66,7 +66,8 @@ def get_cached_module(module_name, object_names, cache_dir, timeout):
 
     try:
         # Create C file with exclusive access
-        open(c_filename, "x")
+        with open(c_filename, "x"):
+            pass
         return None, None
     except FileExistsError:
         logger.info("Cached C file already exists: " + str(c_filename))


### PR DESCRIPTION
Avoid getting:
```python
  /root/shared/ffcx/ffcx/codegeneration/jit.py:69: ResourceWarning: unclosed file <_io.TextIOWrapper name='/root/.cache/fenics/libffcx_elements_3c34d6e913e7ee82cb1562136383f18dd61b39f3.c' mode='x' encoding='UTF-8'>
    open(c_filename, "x")
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```
when creating new files.
Ref: https://github.com/FEniCS/dolfinx/issues/2773#issuecomment-1896715275