### PR TITLE
Remove unused/unnecessary items from `IntegralIR`

### DIFF
--- a/ffcx/codegeneration/C/integrals.py
+++ b/ffcx/codegeneration/C/integrals.py
@@ -14,11 +14,12 @@ from ffcx.codegeneration.C import integrals_template as ufcx_integrals
 from ffcx.codegeneration.C.c_implementation import CFormatter
 from ffcx.codegeneration.integral_generator import IntegralGenerator
 from ffcx.codegeneration.utils import dtype_to_c_type, dtype_to_scalar_dtype
+from ffcx.ir.representation import IntegralIR
 
 logger = logging.getLogger("ffcx")
 
 
-def generator(ir, options):
+def generator(ir: IntegralIR, options):
     """Generate C code for an integral."""
     logger.info("Generating code for integral:")
     logger.info(f"--- type: {ir.integral_type}")

--- a/ffcx/codegeneration/C/integrals.py
+++ b/ffcx/codegeneration/C/integrals.py
@@ -58,7 +58,6 @@ def generator(ir: IntegralIR, options):
         code["enabled_coefficients_init"] = ""
         code["enabled_coefficients"] = "NULL"
 
-    code["additional_includes_set"] = set()  # FIXME: Get this out of code[]
     code["tabulate_tensor"] = body
 
     code["tabulate_tensor_float32"] = "NULL"

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -52,9 +52,6 @@ def compute_integral_ir(cell, integral_type, entitytype, integrands, argument_sh
     # here
     ir = {}
 
-    # Pass on options for consumption in code generation
-    ir["options"] = p
-
     # Shared unique tables for all quadrature loops
     ir["unique_tables"] = {}
     ir["unique_table_types"] = {}

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -128,21 +128,20 @@ class DofMapIR(typing.NamedTuple):
 class IntegralIR(typing.NamedTuple):
     """Intermediate representation of an integral."""
 
-    integral_type: str  #
-    rank: int  #
-    entitytype: str  #
-    enabled_coefficients: list[bool]  #
+    integral_type: str
+    rank: int
+    entitytype: str
+    enabled_coefficients: list[bool]
     tensor_shape: list[int]
-    coefficient_numbering: dict[ufl.Coefficient, int]  #
-    coefficient_offsets: dict[ufl.Coefficient, int]  #
-    original_constant_offsets: dict[ufl.Constant, int]  #
+    coefficient_numbering: dict[ufl.Coefficient, int]
+    coefficient_offsets: dict[ufl.Coefficient, int]
+    original_constant_offsets: dict[ufl.Constant, int]
     unique_tables: dict[str, npt.NDArray[np.float64]]
     unique_table_types: dict[str, str]
-    integrand: dict[QuadratureRule, dict]  #
-    name: str  #
-    needs_facet_permutations: bool  #
-    coordinate_element: str  #
-    sum_factorization: bool
+    integrand: dict[QuadratureRule, dict]
+    name: str
+    needs_facet_permutations: bool
+    coordinate_element: str
 
 
 class ExpressionIR(typing.NamedTuple):
@@ -403,9 +402,8 @@ def _compute_integral_ir(
             "entitytype": entitytype,
             "enabled_coefficients": itg_data.enabled_coefficients,
             "coordinate_element": finite_element_names[itg_data.domain.ufl_coordinate_element()],
-            "sum_factorization": options["sum_factorization"] and itg_data.integral_type == "cell",
         }
-
+        use_sum_factorization = options["sum_factorization"] and itg_data.integral_type == "cell"
         # Get element space dimensions
         unique_elements = element_numbers.keys()
         element_dimensions = {
@@ -514,7 +512,7 @@ def _compute_integral_ir(
                     degree,
                     scheme,
                     form_data.argument_elements,
-                    ir["sum_factorization"],
+                    use_sum_factorization,
                 )
 
             points = np.asarray(points)

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -403,7 +403,7 @@ def _compute_integral_ir(
             "enabled_coefficients": itg_data.enabled_coefficients,
             "coordinate_element": finite_element_names[itg_data.domain.ufl_coordinate_element()],
         }
-        use_sum_factorization = options["sum_factorization"] and itg_data.integral_type == "cell"
+
         # Get element space dimensions
         unique_elements = element_numbers.keys()
         element_dimensions = {
@@ -427,6 +427,7 @@ def _compute_integral_ir(
 
         # Group integrands with the same quadrature rule
         grouped_integrands: dict[QuadratureRule, list[ufl.core.expr.Expr]] = {}
+        use_sum_factorization = options["sum_factorization"] and itg_data.integral_type == "cell"
         for integral in itg_data.integrals:
             md = integral.metadata() or {}
             scheme = md["quadrature_rule"]


### PR DESCRIPTION
Removing the usage of `ir` as temporary storage of variables.