### PR TITLE
Disable Windows test.

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -23,8 +23,6 @@ jobs:
         os: [ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12']
         include:
-          - os: windows-latest
-            python-version: '3.11'
           - os: macos-latest
             python-version: '3.12'
 


### PR DESCRIPTION
Basix cannot be built due to a compiler bug MSVC.
