### PR TITLE
Change to INTERFACE in C17 requirement for ufcx target

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -9,7 +9,7 @@ file(SHA1 ${PROJECT_SOURCE_DIR}/../ffcx/codegeneration/ufcx.h UFCX_HASH)
 message("Test hash: ${UFCX_HASH}")
 
 add_library(${PROJECT_NAME} INTERFACE)
-target_compile_features(${PROJECT_NAME} PUBLIC c_std_17)
+target_compile_features(${PROJECT_NAME} INTERFACE c_std_17)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME}
   INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>


### PR DESCRIPTION
Fixes #709 - unsure why we didn't pick this up on CI.

The purpose of this change is so that consuming C++ libraries don't have to enable the C17 standard manually themselves.