### PR TITLE
Remove quadrature permutation on element tables of codim-1

### DIFF
--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -366,7 +366,7 @@ def build_optimized_tables(
         # differently to their global orientation
         if integral_type == "interior_facet" or (is_mixed_dim and codim == 0):
 
-            if tdim == 1 or codim ==1:
+            if tdim == 1 or codim == 1:
                 # Do not add permutations if codim-1 as facets have already gotten a global
                 # orientation in DOLFINx
                 t = get_ffcx_table_values(

--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -365,7 +365,6 @@ def build_optimized_tables(
         # needed because a cell may see its sub-entities as being oriented
         # differently to their global orientation
         if integral_type == "interior_facet" or (is_mixed_dim and codim == 0):
-
             if tdim == 1 or codim == 1:
                 # Do not add permutations if codim-1 as facets have already gotten a global
                 # orientation in DOLFINx

--- a/ffcx/ir/elementtables.py
+++ b/ffcx/ir/elementtables.py
@@ -365,7 +365,10 @@ def build_optimized_tables(
         # needed because a cell may see its sub-entities as being oriented
         # differently to their global orientation
         if integral_type == "interior_facet" or (is_mixed_dim and codim == 0):
-            if tdim == 1:
+
+            if tdim == 1 or codim ==1:
+                # Do not add permutations if codim-1 as facets have already gotten a global
+                # orientation in DOLFINx
                 t = get_ffcx_table_values(
                     quadrature_rule.points,
                     cell,


### PR DESCRIPTION
The input already has a consistent orientation due to: https://github.com/FEniCS/dolfinx/pull/3209