### PR TITLE
remove ufcx_integral_type

### DIFF
--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -86,7 +86,6 @@ def generator(ir: FormIR, options):
     integrals = []
     integral_ids = []
     integral_offsets = [0]
-    # Note: the order of this list is defined by the enum ufcx_integral_type in ufcx.h
     for itg_type in ("cell", "exterior_facet", "interior_facet"):
         unsorted_integrals = []
         unsorted_ids = []

--- a/ffcx/codegeneration/ufcx.h
+++ b/ffcx/codegeneration/ufcx.h
@@ -42,17 +42,6 @@ extern "C"
 #endif // restrict
 #endif // __cplusplus
 
-  // <HEADER_DECL>
-
-  typedef enum
-  {
-    cell = 0,
-    exterior_facet = 1,
-    interior_facet = 2
-  } ufcx_integral_type;
-
-  // </HEADER_DECL>
-
   /// Tabulate integral into tensor A with compiled quadrature rule
   ///
   /// @param[out] A


### PR DESCRIPTION
Looks like it isn't used anywhere