### PR TITLE
Start adding some typing and documentation

### DIFF
--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -13,6 +13,7 @@ import basix.ufl
 import ufl
 
 import ffcx.codegeneration.lnodes as L
+from ffcx.definitions import entity_types
 from ffcx.ir.analysis.modified_terminals import ModifiedTerminal
 from ffcx.ir.elementtables import UniqueTableReferenceT
 from ffcx.ir.representationutils import QuadratureRule
@@ -23,7 +24,9 @@ logger = logging.getLogger("ffcx")
 class FFCXBackendAccess:
     """FFCx specific formatter class."""
 
-    def __init__(self, entity_type: str, integral_type: str, symbols, options):
+    entity_type: entity_types
+
+    def __init__(self, entity_type: entity_types, integral_type: str, symbols, options):
         """Initialise."""
         # Store ir and options
         self.entity_type = entity_type
@@ -399,7 +402,7 @@ class FFCXBackendAccess:
     def table_access(
         self,
         tabledata: UniqueTableReferenceT,
-        entity_type: str,
+        entity_type: entity_types,
         restriction: str,
         quadrature_index: L.MultiIndex,
         dof_index: L.MultiIndex,
@@ -408,7 +411,7 @@ class FFCXBackendAccess:
 
         Args:
             tabledata: Table data object
-            entity_type: Entity type ("cell", "facet", "vertex")
+            entity_type: Entity type
             restriction: Restriction ("+", "-")
             quadrature_index: Quadrature index
             dof_index: Dof index

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -11,6 +11,7 @@ from typing import Union
 import ufl
 
 import ffcx.codegeneration.lnodes as L
+from ffcx.definitions import entity_types
 from ffcx.ir.analysis.modified_terminals import ModifiedTerminal
 from ffcx.ir.elementtables import UniqueTableReferenceT
 from ffcx.ir.representationutils import QuadratureRule
@@ -50,7 +51,9 @@ def create_dof_index(tabledata, dof_index_symbol):
 class FFCXBackendDefinitions:
     """FFCx specific code definitions."""
 
-    def __init__(self, entity_type: str, integral_type: str, access, options):
+    entity_type: entity_types
+
+    def __init__(self, entity_type: entity_types, integral_type: str, access, options):
         """Initialise."""
         # Store ir and options
         self.integral_type = integral_type

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -10,6 +10,7 @@ import logging
 import ufl
 
 import ffcx.codegeneration.lnodes as L
+from ffcx.definitions import entity_types
 
 logger = logging.getLogger("ffcx")
 
@@ -95,7 +96,7 @@ class FFCXBackendSymbols:
         # Table for chunk of custom quadrature points (physical coordinates).
         self.custom_points_table = L.Symbol("points_chunk", dtype=L.DataType.REAL)
 
-    def entity(self, entity_type, restriction):
+    def entity(self, entity_type: entity_types, restriction):
         """Entity index for lookup in element tables."""
         if entity_type == "cell":
             # Always 0 for cells (even with restriction)
@@ -175,7 +176,7 @@ class FFCXBackendSymbols:
         return c[offset + index]
 
     # TODO: Remove this, use table_access instead
-    def element_table(self, tabledata, entity_type, restriction):
+    def element_table(self, tabledata, entity_type: entity_types, restriction):
         """Get an element table."""
         entity = self.entity(entity_type, restriction)
 

--- a/ffcx/definitions.py
+++ b/ffcx/definitions.py
@@ -1,0 +1,5 @@
+"""Module for storing type definitions used in the FFCx code base."""
+
+from typing import Literal
+
+entity_types = Literal["cell", "facet", "vertex"]

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -16,6 +16,7 @@ from ufl.algorithms.balancing import balance_modifiers
 from ufl.checks import is_cellwise_constant
 from ufl.classes import QuadratureWeight
 
+from ffcx.definitions import entity_types
 from ffcx.ir.analysis.factorization import compute_argument_factorization
 from ffcx.ir.analysis.graph import build_scalar_graph
 from ffcx.ir.analysis.modified_terminals import analyse_modified_terminal, is_modified_terminal
@@ -46,7 +47,9 @@ class BlockDataT(typing.NamedTuple):
     is_permuted: bool  # Do quad points on facets need to be permuted?
 
 
-def compute_integral_ir(cell, integral_type, entity_type, integrands, argument_shape, p, visualise):
+def compute_integral_ir(
+    cell, integral_type: str, entity_type: entity_types, integrands, argument_shape, p, visualise
+):
     """Compute intermediate representation for an integral."""
     # The intermediate representation dict we're building and returning
     # here


### PR DESCRIPTION
Start using `typing.Literal` for string-types, as there is so much implicit logic on the expected type.

Also add some doc-strings when needed.