### PR TITLE
Adjust coordinate element map hash

### DIFF
--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -263,7 +263,7 @@ def _compute_integral_ir(
             "integral_type": itg_data.integral_type,
             "entity_type": entity_type,
             "shape": (),
-            "coordinate_element_hash": itg_data.domain.ufl_coordinate_element().basix_hash(),
+            "coordinate_element_hash": itg_data.domain.ufl_cargo().geometry.cmap.hash(),
         }
         ir = {
             "rank": form_data.rank,


### PR DESCRIPTION
The `ufl_coordinate_element()` is a blocked element, which will have a different hash than the one checked in: https://github.com/FEniCS/dolfinx/blob/76271e05809981e6402ddc735d5d9a39ae7b0544/cpp/dolfinx/fem/utils.h#L457-L465