### PR TITLE
Vertex integrals

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -81,7 +81,7 @@ jobs:
           ctest -V --output-on-failure -R unittests
 
       - name: Install Python demo/test dependencies
-        run: python3 -m pip install --break-system-packages matplotlib numba pyamg pytest pytest-xdist "scipy<=1.15"
+        run: python3 -m pip install --break-system-packages matplotlib numba pyamg pytest pytest-xdist "scipy<=1.15" pyvista
       - name: Run DOLFINx Python unit tests
         run: python3 -m pytest -n auto dolfinx/python/test/unit
       - name: Run DOLFINx Python demos

--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -81,7 +81,7 @@ jobs:
           ctest -V --output-on-failure -R unittests
 
       - name: Install Python demo/test dependencies
-        run: python3 -m pip install --break-system-packages matplotlib numba pyamg pytest pytest-xdist "scipy<=1.15" pyvista
+        run: python3 -m pip install --break-system-packages matplotlib numba pyamg pytest pytest-xdist "scipy<=1.15" pyvista networkx
       - name: Run DOLFINx Python unit tests
         run: python3 -m pytest -n auto dolfinx/python/test/unit
       - name: Run DOLFINx Python demos

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -203,6 +203,13 @@ def _analyze_form(
 
         for i, integral in enumerate(integral_data.integrals):
             metadata = integral.metadata()
+
+            # Vertex integrals do not support discontinuous integrands.
+            if integral.integral_type() == "vertex":
+                elements = ufl.algorithms.extract_elements(integral)
+                if any(e.discontinuous for e in elements):
+                    raise TypeError("Vertex integrals not supported for discontinuous elements.")
+
             # If form contains a quadrature element, use the custom quadrature scheme
             custom_q = None
             for e in ufl.algorithms.extract_elements(integral):

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -89,7 +89,7 @@ def generator(ir: FormIR, options):
     integral_offsets = [0]
     integral_domains = []
     # Note: the order of this list is defined by the enum ufcx_integral_type in ufcx.h
-    for itg_type in ("cell", "exterior_facet", "interior_facet"):
+    for itg_type in ("cell", "exterior_facet", "interior_facet", "vertex"):
         unsorted_integrals = []
         unsorted_ids = []
         unsorted_domains = []

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -182,7 +182,8 @@ class IntegralGenerator:
 
         # No quadrature tables for custom (given argument) or point
         # (evaluation in single vertex)
-        skip = ufl.custom_integral_types + ufl.measure.point_integral_types
+        # skip = ufl.custom_integral_types + ufl.measure.point_integral_types
+        skip = ufl.custom_integral_types
         if self.ir.expression.integral_type in skip:
             return parts
 

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -180,8 +180,7 @@ class IntegralGenerator:
         """Generate static tables of quadrature points and weights."""
         parts: list[L.LNode] = []
 
-        # No quadrature tables for custom (given argument) or point
-        # (evaluation in single vertex)
+        # No quadrature tables for custom (given argument)
         skip = ufl.custom_integral_types
         if self.ir.expression.integral_type in skip:
             return parts

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -182,7 +182,6 @@ class IntegralGenerator:
 
         # No quadrature tables for custom (given argument) or point
         # (evaluation in single vertex)
-        # skip = ufl.custom_integral_types + ufl.measure.point_integral_types
         skip = ufl.custom_integral_types
         if self.ir.expression.integral_type in skip:
             return parts

--- a/ffcx/codegeneration/ufcx.h
+++ b/ffcx/codegeneration/ufcx.h
@@ -49,7 +49,8 @@ extern "C"
   {
     cell = 0,
     exterior_facet = 1,
-    interior_facet = 2
+    interior_facet = 2,
+    vertex = 3,
   } ufcx_integral_type;
 
   // </HEADER_DECL>

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -478,7 +478,7 @@ def _compute_form_ir(
     # Store names of integrals and subdomain_ids for this form, grouped
     # by integral types since form points to all integrals it contains,
     # it has to know their names for codegen phase
-    ufcx_integral_types = ("cell", "exterior_facet", "interior_facet")
+    ufcx_integral_types = ("cell", "exterior_facet", "interior_facet", "vertex")
     ir["subdomain_ids"] = {itg_type: [] for itg_type in ufcx_integral_types}
     ir["integral_names"] = {itg_type: [] for itg_type in ufcx_integral_types}
     ir["integral_domains"] = {itg_type: [] for itg_type in ufcx_integral_types}

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1491,6 +1491,6 @@ def test_vertex_integral(compile_args, geometry, rank, dtype, element_type):
                 ffi.NULL,
             )
             idx = (rank > 0) * vertex + (rank > 1) * vertex * vertex_count
-            assert np.isclose(coords[vertex * 3], J[idx], atol=1e-6)
+            assert np.isclose(coords[vertex * 3], J[idx], atol=1e2 * np.finfo(dtype).eps)
             # Check all other entries are not touched
             assert np.allclose(np.delete(J, [idx]), 0)

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+import os
 import sys
 
 import basix.ufl
@@ -1408,7 +1409,25 @@ def test_ds_prism(compile_args, dtype):
 
 @pytest.mark.parametrize("geometry", [("interval", 1), ("triangle", 2), ("tetrahedron", 3)])
 @pytest.mark.parametrize("rank", [0, 1, 2])
-@pytest.mark.parametrize("dtype", [np.float32, np.float64, np.complex64, np.complex128])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.float32,
+        np.float64,
+        pytest.param(
+            np.complex64,
+            marks=pytest.mark.skipif(
+                os.name == "nt", reason="win32 platform does not support C99 _Complex numbers"
+            ),
+        ),
+        pytest.param(
+            np.complex128,
+            marks=pytest.mark.skipif(
+                os.name == "nt", reason="win32 platform does not support C99 _Complex numbers"
+            ),
+        ),
+    ],
+)
 def test_point_measure(compile_args, geometry, rank, dtype):
     cell, gdim = geometry
     rdtype = np.real(dtype(0)).dtype

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1444,13 +1444,13 @@ def test_point_measure_rank_0(compile_args, gdim, dtype):
             assert np.isclose(J[0], coords[3 * i], atol=1e2 * np.finfo(dtype).eps)
 
 
-@pytest.mark.parametrize("gdim", [1, 2, 3])
+@pytest.mark.parametrize("geometry", [("interval", 1), ("triangle", 2), ("tetrahedron", 3)])
 @pytest.mark.parametrize("rank", [0, 1, 2])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_point_measure(compile_args, gdim, rank, dtype):
-    geometry = "interval" if gdim == 1 else ("triangle" if gdim == 2 else "tetrahedron")
-    domain = ufl.Mesh(basix.ufl.element("Lagrange", geometry, 1, shape=(gdim,), dtype=dtype))
-    element = basix.ufl.element("Lagrange", geometry, 1)
+def test_point_measure(compile_args, geometry, rank, dtype):
+    cell, gdim = geometry
+    domain = ufl.Mesh(basix.ufl.element("Lagrange", cell, 1, shape=(gdim,), dtype=dtype))
+    element = basix.ufl.element("Lagrange", cell, 1)
     dP = ufl.Measure("dP")
     x = ufl.SpatialCoordinate(domain)
     V = ufl.FunctionSpace(domain, element)

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1437,6 +1437,7 @@ def test_point_measure(compile_args, geometry, rank, dtype):
     x = ufl.SpatialCoordinate(domain)
     V = ufl.FunctionSpace(domain, element)
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
+    # With a Lagrange space for test and trial functions, all these forms should evaluate as the x-coordinate times an indicator for alignment between the argument(s) and the vertices .
     if rank == 0:
         F = x[0] * dP
     elif rank == 1:
@@ -1467,6 +1468,10 @@ def test_point_measure(compile_args, geometry, rank, dtype):
     )
 
     for a, b in np.array([(0, 1), (1, 0), (2, 0), (5, -2)], dtype=dtype):
+        # General geometry for simplices of gdim 1,2 and 3.
+        # gdim 1: creates the interval (a, b)
+        # gdim 2: creates the triangle with vertices (a, 0), (b, 0), (0,0)
+        # gdim 3: creates the tetrahedron with vertices (a, 0, 0), (b, 0, 0), (0, 0, 0), (0, 0, 1)
         coords = np.array([a, 0.0, 0.0, b, 0.0, 0.0, 0, 0, 0, 0, 0, 1], dtype=rdtype)
 
         for vertex in range(gdim + 1):

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1437,7 +1437,8 @@ def test_point_measure(compile_args, geometry, rank, dtype):
     x = ufl.SpatialCoordinate(domain)
     V = ufl.FunctionSpace(domain, element)
     u, v = ufl.TrialFunction(V), ufl.TestFunction(V)
-    # With a Lagrange space for test and trial functions, all these forms should evaluate as the x-coordinate times an indicator for alignment between the argument(s) and the vertices .
+    # With a Lagrange space for test and trial functions, all these forms should evaluate as the
+    # x-coordinate times an indicator for alignment between the argument(s) and the vertices.
     if rank == 0:
         F = x[0] * dP
     elif rank == 1:
@@ -1450,21 +1451,10 @@ def test_point_measure(compile_args, geometry, rank, dtype):
     )
     assert form0.rank == rank
 
-    def np_to_str(type):
-        if type == np.float32:
-            return "float32"
-        if type == np.float64:
-            return "float64"
-        if type == np.complex64:
-            return "complex64"
-        if type == np.complex128:
-            return "complex128"
-        assert False
-
     ffi = module.ffi
     kernel = getattr(
         form0.form_integrals[0],
-        f"tabulate_tensor_{np_to_str(dtype)}",
+        f"tabulate_tensor_{dtype().dtype.name}",
     )
 
     for a, b in np.array([(0, 1), (1, 0), (2, 0), (5, -2)], dtype=dtype):

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2020 Garth N. Wells & Matthew Scroggs
+# Copyright (C) 2018-2025 Garth N. Wells, Matthew Scroggs and Paul T. Kühner
 #
 # This file is part of FFCx. (https://www.fenicsproject.org)
 #
@@ -1441,7 +1441,7 @@ def test_point_measure_rank_0(compile_args, gdim, dtype):
                 ffi.NULL,
                 ffi.NULL,
             )
-            assert np.isclose(J[0], coords[3 * i], atol=1e-6 if dtype == np.float32 else 1e-12)
+            assert np.isclose(J[0], coords[3 * i], atol=1e2 * np.finfo(dtype).eps)
 
 
 @pytest.mark.parametrize("gdim", [1, 2, 3])
@@ -1482,5 +1482,5 @@ def test_point_measure_rank_1(compile_args, gdim, dtype):
                 ffi.NULL,
                 ffi.NULL,
             )
-            assert np.isclose(J[i], coords[3 * i], atol=1e-6 if dtype == np.float32 else 1e-12)
+            assert np.isclose(J[i], coords[3 * i], atol=1e2 * np.finfo(dtype).eps)
             assert np.allclose(np.delete(J, [i]), 0)

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1479,7 +1479,7 @@ def test_vertex_integral(compile_args, geometry, rank, dtype):
                 ffi.NULL,
             )
             idx = (rank > 0) * vertex + (rank > 1) * vertex * vertex_count
-            assert np.isclose(J[idx], coords[vertex * 3], atol=1e2 * np.finfo(dtype).eps)
+            assert np.isclose(J[idx], coords[vertex * 3], rtol=1e2 * np.finfo(dtype).eps)
             assert np.allclose(np.delete(J, [idx]), 0)
 
 

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1406,44 +1406,6 @@ def test_ds_prism(compile_args, dtype):
     )
 
 
-@pytest.mark.parametrize("gdim", [1, 2, 3])
-@pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_point_measure_rank_0(compile_args, gdim, dtype):
-    geometry = "interval" if gdim == 1 else ("triangle" if gdim == 2 else "tetrahedron")
-    domain = ufl.Mesh(basix.ufl.element("Lagrange", geometry, 1, shape=(gdim,), dtype=dtype))
-    dP = ufl.Measure("dP")
-    x = ufl.SpatialCoordinate(domain)
-    F = x[0] * dP
-
-    (form0,), module, _ = ffcx.codegeneration.jit.compile_forms(
-        [F], options={"scalar_type": dtype}, cffi_extra_compile_args=compile_args
-    )
-    assert form0.rank == 0
-
-    ffi = module.ffi
-    kernel = getattr(
-        form0.form_integrals[0],
-        f"tabulate_tensor_{'float32' if dtype == np.float32 else 'float64'}",
-    )
-
-    for a, b in np.array([(0, 1), (1, 0), (2, 0), (5, -2)], dtype=dtype):
-        coords = np.array([a, 0.0, 0.0, b, 0.0, 0.0, 0, 0, 0, 0, 0, 1], dtype=dtype)
-
-        for i in range(gdim):
-            J = np.zeros(1, dtype=dtype)
-            e = np.array([i], dtype=np.int32)
-            kernel(
-                ffi.cast(f"{'float' if dtype == np.float32 else 'double'} *", J.ctypes.data),
-                ffi.NULL,
-                ffi.NULL,
-                ffi.cast(f"{'float' if dtype == np.float32 else 'double'} *", coords.ctypes.data),
-                ffi.cast("int *", e.ctypes.data),
-                ffi.NULL,
-                ffi.NULL,
-            )
-            assert np.isclose(J[0], coords[3 * i], atol=1e2 * np.finfo(dtype).eps)
-
-
 @pytest.mark.parametrize("geometry", [("interval", 1), ("triangle", 2), ("tetrahedron", 3)])
 @pytest.mark.parametrize("rank", [0, 1, 2])
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1428,7 +1428,7 @@ def test_ds_prism(compile_args, dtype):
         ),
     ],
 )
-def test_point_measure(compile_args, geometry, rank, dtype):
+def test_vertex_integral(compile_args, geometry, rank, dtype):
     cell, gdim = geometry
     rdtype = np.real(dtype(0)).dtype
     domain = ufl.Mesh(basix.ufl.element("Lagrange", cell, 1, shape=(gdim,), dtype=rdtype))

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1479,7 +1479,7 @@ def test_vertex_integral(compile_args, geometry, rank, dtype):
                 ffi.NULL,
             )
             idx = (rank > 0) * vertex + (rank > 1) * vertex * vertex_count
-            assert np.isclose(J[idx], coords[vertex * 3], rtol=1e2 * np.finfo(dtype).eps)
+            assert np.isclose(coords[vertex * 3], J[idx], atol=1e-6)
             # Check all other entries are not touched
             assert np.allclose(np.delete(J, [idx]), 0)
 

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -1480,6 +1480,7 @@ def test_vertex_integral(compile_args, geometry, rank, dtype):
             )
             idx = (rank > 0) * vertex + (rank > 1) * vertex * vertex_count
             assert np.isclose(J[idx], coords[vertex * 3], rtol=1e2 * np.finfo(dtype).eps)
+            # Check all other entries are not touched
             assert np.allclose(np.delete(J, [idx]), 0)
 
 


### PR DESCRIPTION
Introduces vertex integral support for FFCx. This corresponds to the `ufl.dP` measure. 

Accompanying PR in dolfinx: https://github.com/FEniCS/dolfinx/pull/3726 (not depending on it)