### PR TITLE
Add rank and shape of constants to UFCx

### DIFF
--- a/ffcx/codegeneration/C/c_implementation.py
+++ b/ffcx/codegeneration/C/c_implementation.py
@@ -205,7 +205,7 @@ class CFormatter:
             body = body[:-2] + "}\n"
 
         body += "// ------------------------ \n"
-        return comments + declarations + body
+        return str(comments + declarations + body)
 
     def format_comment(self, c: L.Comment) -> str:
         """Format a comment."""

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -82,9 +82,9 @@ def generator(ir: FormIR, options):
         d["constant_shapes_init"] = "\n".join(result0)
         d["constant_shapes"] = f"constant_shapes_{ir.name}"
     else:
-        d["constant_ranks_init"] = "NULL"
+        d["constant_ranks_init"] = ""
         d["constant_ranks"] = "NULL"
-        d["constant_shapes_init"] = "NULL"
+        d["constant_shapes_init"] = ""
         d["constant_shapes"] = "NULL"
 
     if len(ir.constant_names) > 0:

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -67,7 +67,6 @@ def generator(ir: FormIR, options):
         )
         d["constant_ranks"] = f"constant_ranks_{ir.name}"
 
-
         result0 = [
             f"static const int constant_shapes_{ir.name}_{i}[{len(shape)}] = "
             f"{str(shape).replace('(', '{').replace(')', '}')};"
@@ -76,7 +75,7 @@ def generator(ir: FormIR, options):
         names = [f"constant_shapes_{ir.name}_{i}" for i in range(ir.num_constants)]
         result1 = f"static const int* constant_shapes_{ir.name}[{ir.num_constants}] = " + "{"
         for name in names:
-            result1 += f"{name},"
+            result1 += f"{name},\n"
         result1 += "};"
         result0.append(result1)
 

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -82,9 +82,9 @@ def generator(ir: FormIR, options):
         d["constant_shapes_init"] = "\n".join(result0)
         d["constant_shapes"] = f"constant_shapes_{ir.name}"
     else:
-        d["constant_ranks_init"] = ""
+        d["constant_ranks_init"] = "NULL"
         d["constant_ranks"] = "NULL"
-        d["constant_shapes_init"] = ""
+        d["constant_shapes_init"] = "NULL"
         d["constant_shapes"] = "NULL"
 
     if len(ir.constant_names) > 0:

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -24,7 +24,7 @@ logger = logging.getLogger("ffcx")
 
 
 def generator(ir: FormIR, options):
-    """Generate UFC code for a form."""
+    """Generate UFCx code for a form."""
     logger.info("Generating code for form:")
     logger.info(f"--- rank: {ir.rank}")
     logger.info(f"--- name: {ir.name}")
@@ -79,7 +79,7 @@ def generator(ir: FormIR, options):
             if rank > 0:
                 result1 += f"{name},\n"
             else:
-                result1 += f"NULL,\n"
+                result1 += "NULL,\n"
         result1 += "};"
         result0.append(result1)
 

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -61,23 +61,32 @@ def generator(ir: FormIR, options):
 
     d["num_constants"] = ir.num_constants
     if ir.num_constants > 0:
-        result = str(ir.constants_ranks).replace("[", "{").replace("]", "}")
-        d["constants_ranks"] = result
-        # result = ','.join(str(x0) for x0 in x for x in ir.constants_shapes)
-        # print(result)
-        print(str(ir.constants_shapes))
-        result = (
-            str(ir.constants_shapes)
-            .replace("[", "{")
-            .replace("]", "}")
-            .replace("(", "{")
-            .replace(")", "}")
+        result = str(ir.constant_ranks).replace("[", "{").replace("]", "}")
+        d["constant_ranks_init"] = (
+            f"static const int constant_ranks_{ir.name}[{ir.num_constants}] = {result};"
         )
-        print(result)
-        d["constants_shapes"] = result
+        d["constant_ranks"] = f"constant_ranks_{ir.name}"
+
+
+        result0 = [
+            f"static const int constant_shapes_{ir.name}_{i}[{len(shape)}] = "
+            f"{str(shape).replace('(', '{').replace(')', '}')};"
+            for i, shape in enumerate(ir.constant_shapes)
+        ]
+        names = [f"constant_shapes_{ir.name}_{i}" for i in range(ir.num_constants)]
+        result1 = f"static const int* constant_shapes_{ir.name}[{ir.num_constants}] = " + "{"
+        for name in names:
+            result1 += f"{name},"
+        result1 += "};"
+        result0.append(result1)
+
+        d["constant_shapes_init"] = "\n".join(result0)
+        d["constant_shapes"] = f"constant_shapes_{ir.name}"
     else:
-        d["constants_ranks"] = "NULL"
-        d["constants_shapes"] = "NULL"
+        d["constant_ranks_init"] = ""
+        d["constant_ranks"] = "NULL"
+        d["constant_shapes_init"] = ""
+        d["constant_shapes"] = "NULL"
 
     if len(ir.constant_names) > 0:
         values = ", ".join(f'"{name}"' for name in ir.constant_names)

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -35,7 +35,6 @@ def generator(ir: FormIR, options):
     d["signature"] = f'"{ir.signature}"'
     d["rank"] = ir.rank
     d["num_coefficients"] = ir.num_coefficients
-    d["num_constants"] = ir.num_constants
 
     if len(ir.original_coefficient_positions) > 0:
         values = ", ".join(str(i) for i in ir.original_coefficient_positions)
@@ -59,6 +58,22 @@ def generator(ir: FormIR, options):
     else:
         d["coefficient_names_init"] = ""
         d["coefficient_names"] = "NULL"
+
+    d["num_constants"] = ir.num_constants
+    result = str(ir.constants_ranks).replace("[", "{").replace("]", "}")
+    print(result)
+    d["constants_ranks"] = result
+    # result = ','.join(str(x0) for x0 in x for x in ir.constants_shapes)
+    # print(result)
+    print(str(ir.constants_shapes))
+    result = (
+        str(ir.constants_shapes)
+        .replace("[", "{")
+        .replace("]", "}")
+        .replace("(", "{")
+        .replace(")", "}")
+    )
+    d["constants_shapes"] = result
 
     if len(ir.constant_names) > 0:
         values = ", ".join(f'"{name}"' for name in ir.constant_names)

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -71,11 +71,15 @@ def generator(ir: FormIR, options):
             f"static const int constant_shapes_{ir.name}_{i}[{len(shape)}] = "
             f"{str(shape).replace('(', '{').replace(')', '}')};"
             for i, shape in enumerate(ir.constant_shapes)
+            if len(shape) > 0
         ]
         names = [f"constant_shapes_{ir.name}_{i}" for i in range(ir.num_constants)]
         result1 = f"static const int* constant_shapes_{ir.name}[{ir.num_constants}] = " + "{"
-        for name in names:
-            result1 += f"{name},\n"
+        for rank, name in zip(ir.constant_ranks, names):
+            if rank > 0:
+                result1 += f"{name},\n"
+            else:
+                result1 += f"NULL,\n"
         result1 += "};"
         result0.append(result1)
 

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -60,20 +60,24 @@ def generator(ir: FormIR, options):
         d["coefficient_names"] = "NULL"
 
     d["num_constants"] = ir.num_constants
-    result = str(ir.constants_ranks).replace("[", "{").replace("]", "}")
-    print(result)
-    d["constants_ranks"] = result
-    # result = ','.join(str(x0) for x0 in x for x in ir.constants_shapes)
-    # print(result)
-    print(str(ir.constants_shapes))
-    result = (
-        str(ir.constants_shapes)
-        .replace("[", "{")
-        .replace("]", "}")
-        .replace("(", "{")
-        .replace(")", "}")
-    )
-    d["constants_shapes"] = result
+    if ir.num_constants > 0:
+        result = str(ir.constants_ranks).replace("[", "{").replace("]", "}")
+        d["constants_ranks"] = result
+        # result = ','.join(str(x0) for x0 in x for x in ir.constants_shapes)
+        # print(result)
+        print(str(ir.constants_shapes))
+        result = (
+            str(ir.constants_shapes)
+            .replace("[", "{")
+            .replace("]", "}")
+            .replace("(", "{")
+            .replace(")", "}")
+        )
+        print(result)
+        d["constants_shapes"] = result
+    else:
+        d["constants_ranks"] = "NULL"
+        d["constants_shapes"] = "NULL"
 
     if len(ir.constant_names) > 0:
         values = ", ".join(f'"{name}"' for name in ir.constant_names)

--- a/ffcx/codegeneration/C/form_template.py
+++ b/ffcx/codegeneration/C/form_template.py
@@ -26,6 +26,8 @@ factory = """
 
 {coefficient_names_init}
 {constant_names_init}
+{constant_ranks_init}
+{constant_shapes_init}
 
 ufcx_form {factory_name} =
 {{
@@ -38,8 +40,8 @@ ufcx_form {factory_name} =
   .coefficient_name_map = {coefficient_names},
 
   .num_constants = {num_constants},
-  .constants_ranks = {constants_ranks},
-  .constants_shapes = {constants_shapes},
+  .constant_ranks = {constant_ranks},
+  .constant_shapes = {constant_shapes},
   .constant_name_map = {constant_names},
 
   .finite_element_hashes = {finite_element_hashes},

--- a/ffcx/codegeneration/C/form_template.py
+++ b/ffcx/codegeneration/C/form_template.py
@@ -32,11 +32,14 @@ ufcx_form {factory_name} =
 
   .signature = {signature},
   .rank = {rank},
-  .num_coefficients = {num_coefficients},
-  .num_constants = {num_constants},
-  .original_coefficient_positions = {original_coefficient_positions},
 
+  .num_coefficients = {num_coefficients},
+  .original_coefficient_positions = {original_coefficient_positions},
   .coefficient_name_map = {coefficient_names},
+
+  .num_constants = {num_constants},
+  .constants_ranks = {constants_ranks},
+  .constants_shapes = {constants_shapes},
   .constant_name_map = {constant_names},
 
   .finite_element_hashes = {finite_element_hashes},

--- a/ffcx/codegeneration/ufcx.h
+++ b/ffcx/codegeneration/ufcx.h
@@ -236,10 +236,10 @@ extern "C"
     int num_constants;
 
     /// Ranks of constants
-    int* constants_rank;
+    const int* constant_ranks;
 
     /// Shapes of constants
-    int** constants_shape;
+    const int** constant_shapes;
 
     /// List of names of constants
     const char** constant_name_map;

--- a/ffcx/codegeneration/ufcx.h
+++ b/ffcx/codegeneration/ufcx.h
@@ -21,7 +21,7 @@
 #else
 #define UFCX_VERSION                                                           \
   UFCX_VERSION_MAJOR "." UFCX_VERSION_MINOR "." UFCX_VERSION_MAINTENANCE ".de" \
-                                                                         "v0"
+                     "v0"
 #endif
 
 #include <stdbool.h>
@@ -86,15 +86,14 @@ extern "C"
   /// For integrals not on interior facets, this argument has no effect and a
   /// null pointer can be passed. For interior facets the array will have size 2
   /// (one permutation for each cell adjacent to the facet).
-  /// @param[in] custom_data Custom user data passed to the tabulate function. 
-  /// For example, a struct with additional data needed for the tabulate function.
-  /// See the implementation of runtime integrals for further details.
+  /// @param[in] custom_data Custom user data passed to the tabulate function.
+  /// For example, a struct with additional data needed for the tabulate
+  /// function. See the implementation of runtime integrals for further details.
   typedef void(ufcx_tabulate_tensor_float32)(
       float* restrict A, const float* restrict w, const float* restrict c,
       const float* restrict coordinate_dofs,
       const int* restrict entity_local_index,
-      const uint8_t* restrict quadrature_permutation,
-      void* custom_data);
+      const uint8_t* restrict quadrature_permutation, void* custom_data);
 
   /// Tabulate integral into tensor A with compiled
   /// quadrature rule and double precision
@@ -104,8 +103,7 @@ extern "C"
       double* restrict A, const double* restrict w, const double* restrict c,
       const double* restrict coordinate_dofs,
       const int* restrict entity_local_index,
-      const uint8_t* restrict quadrature_permutation,
-      void* custom_data);
+      const uint8_t* restrict quadrature_permutation, void* custom_data);
 
 #ifndef __STDC_NO_COMPLEX__
   /// Tabulate integral into tensor A with compiled
@@ -116,8 +114,7 @@ extern "C"
       float _Complex* restrict A, const float _Complex* restrict w,
       const float _Complex* restrict c, const float* restrict coordinate_dofs,
       const int* restrict entity_local_index,
-      const uint8_t* restrict quadrature_permutation,
-      void* custom_data);
+      const uint8_t* restrict quadrature_permutation, void* custom_data);
 #endif // __STDC_NO_COMPLEX__
 
 #ifndef __STDC_NO_COMPLEX__
@@ -129,8 +126,7 @@ extern "C"
       double _Complex* restrict A, const double _Complex* restrict w,
       const double _Complex* restrict c, const double* restrict coordinate_dofs,
       const int* restrict entity_local_index,
-      const uint8_t* restrict quadrature_permutation,
-      void* custom_data);
+      const uint8_t* restrict quadrature_permutation, void* custom_data);
 #endif // __STDC_NO_COMPLEX__
 
   typedef struct ufcx_integral
@@ -230,14 +226,20 @@ extern "C"
     /// Number of coefficients (n)
     int num_coefficients;
 
-    /// Number of constants
-    int num_constants;
-
     /// Original coefficient position for each coefficient
     int* original_coefficient_positions;
 
     /// List of names of coefficients
     const char** coefficient_name_map;
+
+    /// Number of constants
+    int num_constants;
+
+    /// Ranks of constants
+    int* constants_rank;
+
+    /// Shapes of constants
+    int** constants_shape;
 
     /// List of names of constants
     const char** constant_name_map;

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -91,10 +91,12 @@ class FormIR(typing.NamedTuple):
     signature: str
     rank: int
     num_coefficients: int
-    num_constants: int
     name_from_uflfile: str
     original_coefficient_positions: list[int]
     coefficient_names: list[str]
+    num_constants: int
+    constants_ranks: list[int]
+    constants_shapes: list[list[int]]
     constant_names: list[str]
     finite_element_hashes: list[int]
     integral_names: dict[str, list[str]]
@@ -454,11 +456,14 @@ def _compute_form_ir(
 
     ir["rank"] = len(form_data.original_form.arguments())
     ir["num_coefficients"] = len(form_data.reduced_coefficients)
-    ir["num_constants"] = len(form_data.original_form.constants())
 
     ir["coefficient_names"] = [
         object_names.get(id(obj), f"w{j}") for j, obj in enumerate(form_data.reduced_coefficients)
     ]
+
+    ir["num_constants"] = len(form_data.original_form.constants())
+    ir["constants_ranks"] = [len(obj.ufl_shape) for obj in form_data.original_form.constants()]
+    ir["constants_shapes"] = [obj.ufl_shape for obj in form_data.original_form.constants()]
 
     ir["constant_names"] = [
         object_names.get(id(obj), f"c{j}")

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -95,8 +95,8 @@ class FormIR(typing.NamedTuple):
     original_coefficient_positions: list[int]
     coefficient_names: list[str]
     num_constants: int
-    constants_ranks: list[int]
-    constants_shapes: list[list[int]]
+    constant_ranks: list[int]
+    constant_shapes: list[list[int]]
     constant_names: list[str]
     finite_element_hashes: list[int]
     integral_names: dict[str, list[str]]
@@ -462,8 +462,8 @@ def _compute_form_ir(
     ]
 
     ir["num_constants"] = len(form_data.original_form.constants())
-    ir["constants_ranks"] = [len(obj.ufl_shape) for obj in form_data.original_form.constants()]
-    ir["constants_shapes"] = [obj.ufl_shape for obj in form_data.original_form.constants()]
+    ir["constant_ranks"] = [len(obj.ufl_shape) for obj in form_data.original_form.constants()]
+    ir["constant_shapes"] = [obj.ufl_shape for obj in form_data.original_form.constants()]
 
     ir["constant_names"] = [
         object_names.get(id(obj), f"c{j}")


### PR DESCRIPTION
`ufcx.h` held the number of constants in a form and the names of the constants, but not the rank and shape. This meant that runtime consistency checking for constants was not possible, which could (and did!) lead to bugs.

This PR added the rank and shape of each constant in a form.