### PR TITLE
Pin scipy version in CI due to pyamg issue

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -81,7 +81,7 @@ jobs:
           ctest -V --output-on-failure -R unittests
 
       - name: Install Python demo/test dependencies
-        run: python3 -m pip install --break-system-packages matplotlib numba pyamg pytest pytest-xdist scipy
+        run: python3 -m pip install --break-system-packages matplotlib numba pyamg pytest pytest-xdist scipy<=1.15
       - name: Run DOLFINx Python unit tests
         run: python3 -m pytest -n auto dolfinx/python/test/unit
       - name: Run DOLFINx Python demos


### PR DESCRIPTION
Affects DOLFINx CI test.

See https://github.com/pyamg/pyamg/pull/449.