### PR TITLE
Unpin scipy

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -70,7 +70,7 @@ jobs:
           cmake --install build
       - name: Run DOLFINx C++ unit tests
         working-directory: build
-        run: ctest -V --output-on-failure -R unittests_np_1
+        run: ctest -V --output-on-failure -R unittests
       - name: Install DOLFINx (Python)
         run: |
           python3 -m pip -v install --break-system-packages nanobind scikit-build-core[pyproject]


### PR DESCRIPTION
Reverts pin from https://github.com/FEniCS/ffcx/pull/771 - fixed with release of https://github.com/pyamg/pyamg/releases/tag/v5.3.0