### PR TITLE
Remove FFCx swallow all warnings

### DIFF
--- a/ffcx/__init__.py
+++ b/ffcx/__init__.py
@@ -17,4 +17,3 @@ from ffcx.options import get_options  # noqa: F401
 __version__ = importlib.metadata.version("fenics-ffcx")
 
 logger = logging.getLogger("ffcx")
-logging.captureWarnings(capture=True)

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -49,6 +49,8 @@ parser.add_argument("ufl_file", nargs="+", help="UFL file(s) to be compiled")
 
 def main(args: Optional[Sequence[str]] = None) -> int:
     """Run ffcx on a UFL file."""
+    logging.captureWarnings(capture=True)
+
     xargs = parser.parse_args(args)
 
     # Parse all other options


### PR DESCRIPTION
Moves `logging.captureWarnings(capture=True)` to `main()`. Therefore only executed in CLI usage of `FFCx` and should no longer swallow all warnings.

Fixes https://github.com/FEniCS/ffcx/issues/712