### PR TITLE
Introduce integral type and try to separate ufl concepts from FFCx concepts

### DIFF
--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -93,8 +93,8 @@ def analyze_ufl_objects(
 
     form_data = tuple(_analyze_form(form, scalar_type) for form in forms)
     for data in form_data:
-        elements += data.unique_sub_elements  # type: ignore
-        coordinate_elements += data.coordinate_elements  # type: ignore
+        elements += data.unique_sub_elements
+        coordinate_elements += data.coordinate_elements
 
     for original_expression, points in expressions:
         elements += ufl.algorithms.extract_elements(original_expression)
@@ -190,7 +190,7 @@ def _analyze_form(
 
     # Determine unique quadrature degree and quadrature scheme
     # per each integral data
-    for id, integral_data in enumerate(form_data.integral_data):  # type: ignore
+    for id, integral_data in enumerate(form_data.integral_data):
         # Iterate through groups of integral data. There is one integral
         # data for all integrals with same domain, itype, subdomain_id
         # (but possibly different metadata).

--- a/ffcx/codegeneration/C/form.py
+++ b/ffcx/codegeneration/C/form.py
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 #
-# Modified by Chris Richardson and Jørgen S. Dokken 2023
+# Modified by Chris Richardson and Jørgen S. Dokken 2023-2025
 #
 # Note: Most of the code in this file is a direct translation from the
 # old implementation in FFC
@@ -17,6 +17,7 @@ import logging
 import numpy as np
 
 from ffcx.codegeneration.C import form_template
+from ffcx.definitions import IntegralType
 from ffcx.ir.representation import FormIR
 
 logger = logging.getLogger("ffcx")
@@ -119,7 +120,13 @@ def generator(ir: FormIR, options):
     integral_offsets = [0]
     integral_domains = []
     # Note: the order of this list is defined by the enum ufcx_integral_type in ufcx.h
-    for itg_type in ("cell", "exterior_facet", "interior_facet", "vertex", "ridge"):
+    for itg_type in (
+        IntegralType(codim=0),
+        IntegralType(codim=1, num_neighbours=1),
+        IntegralType(codim=1, num_neighbours=2),
+        IntegralType(codim=-1),
+        IntegralType(codim=2),
+    ):
         unsorted_integrals = []
         unsorted_ids = []
         unsorted_domains = []

--- a/ffcx/codegeneration/access.py
+++ b/ffcx/codegeneration/access.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2017 Martin Sandve Alnæs
+# Copyright (C) 2011-2025 Martin Sandve Alnæs, Jørgen S. Dokken
 #
 # This file is part of FFCx. (https://www.fenicsproject.org)
 #
@@ -12,7 +12,7 @@ import basix.ufl
 import ufl
 
 import ffcx.codegeneration.lnodes as L
-from ffcx.definitions import entity_types
+from ffcx.definitions import IntegralType
 from ffcx.ir.analysis.modified_terminals import ModifiedTerminal
 from ffcx.ir.elementtables import UniqueTableReferenceT
 from ffcx.ir.representationutils import QuadratureRule
@@ -23,12 +23,11 @@ logger = logging.getLogger("ffcx")
 class FFCXBackendAccess:
     """FFCx specific formatter class."""
 
-    entity_type: entity_types
+    integral_type: IntegralType
 
-    def __init__(self, entity_type: entity_types, integral_type: str, symbols, options):
+    def __init__(self, integral_type: IntegralType, symbols, options):
         """Initialise."""
         # Store ir and options
-        self.entity_type = entity_type
         self.integral_type = integral_type
         self.symbols = symbols
         self.options = options
@@ -65,7 +64,7 @@ class FFCXBackendAccess:
         """Format a terminal."""
         e = mt.terminal
         # Call appropriate handler, depending on the type of e
-        handler = self.call_lookup.get(type(e), False)  # type: ignore
+        handler = self.call_lookup.get(type(e), False)
 
         if not handler:
             # Look for parent class types instead
@@ -74,7 +73,7 @@ class FFCXBackendAccess:
                     handler = self.call_lookup[k]
                     break
         if handler:
-            return handler(mt, tabledata, quadrature_rule)
+            return handler(mt, tabledata, quadrature_rule)  # type: ignore
         else:
             raise RuntimeError(f"Not handled: {type(e)}")
 
@@ -122,27 +121,28 @@ class FFCXBackendAccess:
         if mt.averaged is not None:
             raise RuntimeError("Not expecting average of SpatialCoordinates.")
 
-        if self.integral_type in ufl.custom_integral_types:
-            if mt.local_derivatives:
-                raise RuntimeError("FIXME: Jacobian in custom integrals is not implemented.")
+        match self.integral_type:
+            case IntegralType(is_custom=True):
+                if mt.local_derivatives:
+                    raise RuntimeError("FIXME: Jacobian in custom integrals is not implemented.")
 
-            # Access predefined quadrature points table
-            x = self.symbols.custom_points_table
-            iq = self.symbols.quadrature_loop_index
-            (gdim,) = mt.terminal.ufl_shape
-            if gdim == 1:
-                index = iq
-            else:
-                index = iq * gdim + mt.flat_component
-            return x[index]
-        elif self.integral_type == "expression":
-            # Physical coordinates are computed by code generated in
-            # definitions
-            return self.symbols.x_component(mt)
-        else:
-            # Physical coordinates are computed by code generated in
-            # definitions
-            return self.symbols.x_component(mt)
+                # Access predefined quadrature points table
+                x = self.symbols.custom_points_table
+                iq = self.symbols.quadrature_loop_index
+                (gdim,) = mt.terminal.ufl_shape
+                if gdim == 1:
+                    index = iq
+                else:
+                    index = iq * gdim + mt.flat_component
+                return x[index]
+            case IntegralType(is_expression=True):
+                # Physical coordinates are computed by code generated in
+                # definitions
+                return self.symbols.x_component(mt)
+            case _:
+                # Physical coordinates are computed by code generated in
+                # definitions
+                return self.symbols.x_component(mt)
 
     def cell_coordinate(self, mt, tabledata, num_points):
         """Access a cell coordinate."""
@@ -181,7 +181,7 @@ class FFCXBackendAccess:
         if mt.restriction:
             raise RuntimeError("Not expecting restriction of FacetCoordinate.")
 
-        if self.integral_type in ("interior_facet", "exterior_facet"):
+        if self.integral_type in ("interior_facet", "facet"):
             (tdim,) = mt.terminal.ufl_shape
             if tdim == 0:
                 raise RuntimeError("Vertices have no facet coordinates.")
@@ -233,7 +233,7 @@ class FFCXBackendAccess:
         cellname = ufl.domain.extract_unique_domain(mt.terminal).ufl_cell().cellname()
         if cellname in ("interval", "triangle", "tetrahedron", "quadrilateral", "hexahedron"):
             table = L.Symbol(f"{cellname}_reference_normals", dtype=L.DataType.REAL)
-            facet = self.symbols.entity("facet", mt.restriction)
+            facet = self.symbols.entity(IntegralType(codim=1), mt.restriction)
             return table[facet][mt.component[0]]
         else:
             raise RuntimeError(f"Unhandled cell types {cellname}.")
@@ -250,7 +250,7 @@ class FFCXBackendAccess:
             "pyramid",
         ):
             table = L.Symbol(f"{cellname}_cell_facet_jacobian", dtype=L.DataType.REAL)
-            facet = self.symbols.entity("facet", mt.restriction)
+            facet = self.symbols.entity(IntegralType(codim=1), mt.restriction)
             return table[facet][mt.component[0]][mt.component[1]]
         elif cellname == "interval":
             raise RuntimeError("The reference facet jacobian doesn't make sense for interval cell.")
@@ -262,7 +262,7 @@ class FFCXBackendAccess:
         cellname = ufl.domain.extract_unique_domain(mt.terminal).ufl_cell().cellname()
         if cellname in ("tetrahedron", "prism", "hexahedron"):
             table = L.Symbol(f"{cellname}_cell_ridge_jacobian", dtype=L.DataType.REAL)
-            ridge = self.symbols.entity("ridge", mt.restriction)
+            ridge = self.symbols.entity(IntegralType(codim=2), mt.restriction)
             return table[ridge][mt.component[0]][mt.component[1]]
         elif cellname in ["triangle", "quadrilateral"]:
             raise RuntimeError("The ridge jacobian doesn't make sense for 2D cells.")
@@ -422,7 +422,7 @@ class FFCXBackendAccess:
     def table_access(
         self,
         tabledata: UniqueTableReferenceT,
-        entity_type: entity_types,
+        integral_type: IntegralType,
         restriction: str,
         quadrature_index: L.MultiIndex,
         dof_index: L.MultiIndex,
@@ -431,12 +431,12 @@ class FFCXBackendAccess:
 
         Args:
             tabledata: Table data object
-            entity_type: Entity type
+            integral_type: Integral type
             restriction: Restriction ("+", "-")
             quadrature_index: Quadrature index
             dof_index: Dof index
         """
-        entity = self.symbols.entity(entity_type, restriction)
+        entity = self.symbols.entity(integral_type, restriction)
         iq_global_index = quadrature_index.global_index
         ic_global_index = dof_index.global_index
         qp = 0  # quadrature permutation

--- a/ffcx/codegeneration/backend.py
+++ b/ffcx/codegeneration/backend.py
@@ -26,9 +26,5 @@ class FFCXBackend:
         self.symbols = FFCXBackendSymbols(
             coefficient_numbering, coefficient_offsets, original_constant_offsets
         )
-        self.access = FFCXBackendAccess(
-            ir.expression.entity_type, ir.expression.integral_type, self.symbols, options
-        )
-        self.definitions = FFCXBackendDefinitions(
-            ir.expression.entity_type, ir.expression.integral_type, self.access, options
-        )
+        self.access = FFCXBackendAccess(ir.expression.integral_type, self.symbols, options)
+        self.definitions = FFCXBackendDefinitions(ir.expression.integral_type, self.access, options)

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2023 Martin Sandve Alnæs, Igor A. Baratta
+# Copyright (C) 2011-2025 Martin Sandve Alnæs, Igor A. Baratta and Jørgen S. Dokken
 #
 # This file is part of FFCx. (https://www.fenicsproject.org)
 #
@@ -10,7 +10,7 @@ import logging
 import ufl
 
 import ffcx.codegeneration.lnodes as L
-from ffcx.definitions import entity_types
+from ffcx.definitions import IntegralType
 from ffcx.ir.analysis.modified_terminals import ModifiedTerminal
 from ffcx.ir.elementtables import UniqueTableReferenceT
 from ffcx.ir.representationutils import QuadratureRule
@@ -50,13 +50,12 @@ def create_dof_index(tabledata, dof_index_symbol):
 class FFCXBackendDefinitions:
     """FFCx specific code definitions."""
 
-    entity_type: entity_types
+    integral_type: IntegralType
 
-    def __init__(self, entity_type: entity_types, integral_type: str, access, options):
+    def __init__(self, integral_type: IntegralType, access, options):
         """Initialise."""
         # Store ir and options
         self.integral_type = integral_type
-        self.entity_type = entity_type
         self.access = access
         self.options = options
 
@@ -102,13 +101,13 @@ class FFCXBackendDefinitions:
             ttype = ttype.__bases__[0]
 
         # Get the handler from the lookup, or None if not found
-        handler = self.handler_lookup.get(ttype)  # type: ignore
+        handler = self.handler_lookup.get(ttype)
 
         if handler is None:
             raise NotImplementedError(f"No handler for terminal type: {ttype}")
 
         # Call the handler
-        return handler(mt, tabledata, quadrature_rule, access)  # type: ignore
+        return handler(mt, tabledata, quadrature_rule, access) 
 
     def coefficient(
         self,
@@ -148,7 +147,7 @@ class FFCXBackendDefinitions:
         assert begin < end
 
         # Get access to element table
-        FE, tables = self.access.table_access(tabledata, self.entity_type, mt.restriction, iq, ic)
+        FE, tables = self.access.table_access(tabledata, self.integral_type, mt.restriction, iq, ic)
         dof_access: L.ArrayAccess = self.symbols.coefficient_dof_access(
             mt.terminal, (ic.global_index) * bs + begin
         )
@@ -197,7 +196,7 @@ class FFCXBackendDefinitions:
         iq_symbol = self.symbols.quadrature_loop_index
         ic = create_dof_index(tabledata, ic_symbol)
         iq = create_quadrature_index(quadrature_rule, iq_symbol)
-        FE, tables = self.access.table_access(tabledata, self.entity_type, mt.restriction, iq, ic)
+        FE, tables = self.access.table_access(tabledata, self.integral_type, mt.restriction, iq, ic)
 
         dof_access = L.Symbol("coordinate_dofs", dtype=L.DataType.REAL)
 

--- a/ffcx/codegeneration/expression_generator.py
+++ b/ffcx/codegeneration/expression_generator.py
@@ -77,7 +77,7 @@ class ExpressionGenerator:
                 mt = attr.get("mt")
                 if mt is not None:
                     t = type(mt.terminal)
-                    if self.ir.expression.entity_type == "cell" and issubclass(
+                    if self.ir.expression.integral_type.codim == 0 and issubclass(
                         t, ufl.geometry.GeometricFacetQuantity
                     ):
                         raise RuntimeError(f"Expressions for cells do not support {t}.")
@@ -302,7 +302,7 @@ class ExpressionGenerator:
             ]
 
             table = self.backend.symbols.element_table(
-                td, self.ir.expression.entity_type, mt.restriction
+                td, self.ir.expression.integral_type, mt.restriction
             )
 
             assert td.ttype != "zeros"

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -417,13 +417,12 @@ class IntegralGenerator:
             #       now because it assumes too much about indices.
 
             assert td.ttype != "zeros"
-
             if td.ttype == "ones":
                 arg_factor = 1
             else:
                 # Assuming B sparsity follows element table sparsity
                 arg_factor, arg_tables = self.backend.access.table_access(
-                    td, self.ir.expression.entity_type, mt.restriction, iq, indices[i]
+                    td, self.ir.expression.integral_type, mt.restriction, iq, indices[i]
                 )
 
             tables += arg_tables

--- a/ffcx/codegeneration/jit.py
+++ b/ffcx/codegeneration/jit.py
@@ -229,7 +229,7 @@ def compile_forms(
 
 
 def compile_expressions(
-    expressions: list[tuple[ufl.Expr, npt.NDArray[np.floating]]],  # type: ignore
+    expressions: list[tuple[ufl.Expr, npt.NDArray[np.floating]]],
     options: dict = {},
     cache_dir: Path | None = None,
     timeout: int = 10,

--- a/ffcx/codegeneration/ufcx.h
+++ b/ffcx/codegeneration/ufcx.h
@@ -48,7 +48,7 @@ extern "C"
   typedef enum
   {
     cell = 0,
-    exterior_facet = 1,
+    facet = 1,
     interior_facet = 2,
     vertex = 3,
     ridge = 4,

--- a/ffcx/definitions.py
+++ b/ffcx/definitions.py
@@ -1,5 +1,39 @@
+# Copyright (C) 2025 Jørgen S. Dokken
+#
+# This file is part of FFCx. (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
 """Module for storing type definitions used in the FFCx code base."""
 
-from typing import Literal
+from typing import NamedTuple
 
-entity_types = Literal["cell", "facet", "vertex", "ridge"]
+
+class IntegralType(NamedTuple):
+    """Class for storing information about an integral type."""
+
+    codim: int  # Codimension of integral with respect to the topological dimension of the domain
+    num_neighbours: int = 1  # Number of neighbouring cells
+    is_expression: bool = (
+        False  # True if the integral is an Expression (integrand) rather than an integral
+    )
+    is_custom: bool = False  # True if the integral uses the custom ufl integral measure.
+
+
+def convert_to_integral_type(integral_type: str) -> IntegralType:
+    """Convert UFL integral type string to IntegralType."""
+    match integral_type:
+        case "cell":
+            return IntegralType(codim=0, num_neighbours=1)
+        case "exterior_facet":
+            return IntegralType(codim=1, num_neighbours=1)
+        case "interior_facet":
+            return IntegralType(codim=1, num_neighbours=2)
+        case "ridge":
+            return IntegralType(codim=2, num_neighbours=1)
+        case "vertex":
+            return IntegralType(codim=-1, num_neighbours=1)
+        case "custom":
+            return IntegralType(codim=0, num_neighbours=1, is_custom=True)
+        case _:
+            raise ValueError(f"Unknown integral type:{integral_type}")

--- a/ffcx/ir/representation.py
+++ b/ffcx/ir/representation.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2009-2020 Anders Logg, Martin Sandve Alnæs, Marie E. Rognes,
+# Copyright (C) 2009-2025 Anders Logg, Martin Sandve Alnæs, Marie E. Rognes,
 # Kristian B. Oelgaard, Matthew W. Scroggs, Chris Richardson, and others
 #
 # This file is part of FFCx. (https://www.fenicsproject.org)
@@ -32,6 +32,7 @@ from ufl.sorting import sorted_expr_sum
 
 from ffcx import naming
 from ffcx.analysis import UFLData
+from ffcx.definitions import IntegralType, convert_to_integral_type
 from ffcx.ir.integral import CommonExpressionIR, compute_integral_ir
 from ffcx.ir.representationutils import QuadratureRule, create_quadrature_points_and_weights
 
@@ -78,9 +79,9 @@ class FormIR(typing.NamedTuple):
     constant_shapes: list[list[int]]
     constant_names: list[str]
     finite_element_hashes: list[int]
-    integral_names: dict[str, list[str]]
-    integral_domains: dict[str, list[basix.CellType]]
-    subdomain_ids: dict[str, list[int]]
+    integral_names: dict[IntegralType, list[str]]
+    integral_domains: dict[IntegralType, list[basix.CellType]]
+    subdomain_ids: dict[IntegralType, list[int]]
 
 
 class QuadratureIR(typing.NamedTuple):
@@ -136,16 +137,15 @@ def compute_ir(
     integral_names = {}
     form_names = {}
     for fd_index, fd in enumerate(analysis.form_data):
-        form_names[fd_index] = naming.form_name(fd.original_form, fd_index, prefix)  # type: ignore
-        for itg_index, itg_data in enumerate(fd.integral_data):  # type: ignore
+        form_names[fd_index] = naming.form_name(fd.original_form, fd_index, prefix)
+        for itg_index, itg_data in enumerate(fd.integral_data):
             integral_names[(fd_index, itg_index)] = naming.integral_name(
-                fd.original_form,  # type: ignore
+                fd.original_form,
                 itg_data.integral_type,
                 fd_index,
                 itg_data.subdomain_id,
                 prefix,
             )
-
     irs = [
         _compute_integral_ir(
             fd,
@@ -205,15 +205,6 @@ def _compute_integral_ir(
     visualise,
 ) -> list[IntegralIR]:
     """Compute intermediate representation for form integrals."""
-    _entity_types = {
-        "cell": "cell",
-        "exterior_facet": "facet",
-        "interior_facet": "facet",
-        "vertex": "vertex",
-        "custom": "cell",
-        "ridge": "ridge",
-    }
-
     # Iterate over groups of integrals
     irs = []
     for itg_data_index, itg_data in enumerate(form_data.integral_data):
@@ -221,15 +212,14 @@ def _compute_integral_ir(
         expression_ir = {}
 
         # Compute representation
-        entity_type = _entity_types[itg_data.integral_type]
+        integral_type = convert_to_integral_type(itg_data.integral_type)
         ufl_cell = itg_data.domain.ufl_cell()
         cell_type = basix_cell_from_string(ufl_cell.cellname())
         tdim = ufl_cell.topological_dimension()
         assert all(tdim == itg.ufl_domain().topological_dimension() for itg in itg_data.integrals)
 
         expression_ir = {
-            "integral_type": itg_data.integral_type,
-            "entity_type": entity_type,
+            "integral_type": integral_type,
             "shape": (),
             "coordinate_element_hash": itg_data.domain.ufl_coordinate_element().basix_hash(),
         }
@@ -251,12 +241,12 @@ def _compute_integral_ir(
         ]
 
         # Compute shape of element tensor
-        if expression_ir["integral_type"] == "interior_facet":
-            expression_ir["tensor_shape"] = [2 * dim for dim in argument_dimensions]
-        else:
-            expression_ir["tensor_shape"] = argument_dimensions
-
-        integral_type = itg_data.integral_type
+        match expression_ir["integral_type"]:
+            case IntegralType(codim=1, num_neighbours=2):
+                # If interior facet integral, double the shape in the first index
+                expression_ir["tensor_shape"] = [2 * dim for dim in argument_dimensions]
+            case _:
+                expression_ir["tensor_shape"] = argument_dimensions
 
         # Group integrands with the same quadrature rule
         grouped_integrands: dict[
@@ -282,14 +272,15 @@ def _compute_integral_ir(
                 # prescribed in certain cases.
 
                 degree = md["quadrature_degree"]
-                if "facet" in integral_type:
-                    facet_types = basix.cell.subentity_types(cell_type)[-2]
-                    assert len(set(facet_types)) == 1
-                    cell_type = facet_types[0]
-                elif integral_type == "ridge":
-                    ridge_types = basix.cell.subentity_types(cell_type)[-3]
-                    assert len(set(ridge_types)) == 1
-                    cell_type = ridge_types[0]
+                match integral_type:
+                    case IntegralType(codim=1):
+                        facet_types = basix.cell.subentity_types(cell_type)[-2]
+                        assert len(set(facet_types)) == 1
+                        cell_type = facet_types[0]
+                    case IntegralType(codim=2):
+                        ridge_types = basix.cell.subentity_types(cell_type)[-3]
+                        assert len(set(ridge_types)) == 1
+                        cell_type = ridge_types[0]
 
                 if degree > 1:
                     warnings.warn(
@@ -360,7 +351,13 @@ def _compute_integral_ir(
 
         index_to_coeff = sorted([(v, k) for k, v in coefficient_numbering.items()])
         offsets = {}
-        width = 2 if integral_type in ("interior_facet") else 1
+        match integral_type:
+            case IntegralType(codim=1, num_neighbours=2):
+                # Double width for interior facet integrals
+                width = 2
+            case _:
+                width = 1
+
         _offset = 0
         for k, el in zip(index_to_coeff, form_data.coefficient_elements):
             offsets[k[1]] = _offset
@@ -387,8 +384,7 @@ def _compute_integral_ir(
         # Build more specific intermediate representation
         integral_ir = compute_integral_ir(
             itg_data.domain.ufl_cell(),
-            itg_data.integral_type,
-            expression_ir["entity_type"],
+            integral_type,
             integrand_map,
             expression_ir["tensor_shape"],
             options,
@@ -454,14 +450,20 @@ def _compute_form_ir(
     # Store names of integrals and subdomain_ids for this form, grouped
     # by integral types since form points to all integrals it contains,
     # it has to know their names for codegen phase
-    ufcx_integral_types = ("cell", "exterior_facet", "interior_facet", "vertex", "ridge")
+    ufcx_integral_types = (
+        IntegralType(codim=0),
+        IntegralType(codim=1, num_neighbours=1),
+        IntegralType(codim=1, num_neighbours=2),
+        IntegralType(codim=2),
+        IntegralType(codim=-1),
+    )
     ir["subdomain_ids"] = {itg_type: [] for itg_type in ufcx_integral_types}
     ir["integral_names"] = {itg_type: [] for itg_type in ufcx_integral_types}
     ir["integral_domains"] = {itg_type: [] for itg_type in ufcx_integral_types}
     for itg_index, itg_data in enumerate(form_data.integral_data):
         # UFL is using "otherwise" for default integrals (over whole mesh)
         # but FFCx needs integers, so otherwise = -1
-        integral_type = itg_data.integral_type
+        integral_type = convert_to_integral_type(itg_data.integral_type)
         subdomain_ids = [sid if sid != "otherwise" else -1 for sid in itg_data.subdomain_id]
 
         if min(subdomain_ids) < -1:
@@ -563,12 +565,11 @@ def _compute_expression_ir(
     # Copy offsets also into IR
     base_ir["coefficient_offsets"] = offsets
 
-    base_ir["integral_type"] = "expression"
     if cell is not None:
         if (tdim := cell.topological_dimension()) == (pdim := points.shape[1]):
-            base_ir["entity_type"] = "cell"
+            base_ir["integral_type"] = IntegralType(codim=0, is_expression=True)
         elif tdim - 1 == pdim:
-            base_ir["entity_type"] = "facet"
+            base_ir["integral_type"] = IntegralType(codim=1, is_expression=True)
         else:
             raise ValueError(
                 f"Expression on domain with topological dimension {tdim}"
@@ -576,7 +577,7 @@ def _compute_expression_ir(
             )
     else:
         # For spatially invariant expressions, all expressions are evaluated in the cell
-        base_ir["entity_type"] = "cell"
+        base_ir["integral_type"] = IntegralType(codim=0, is_expression=True)
 
     # Build offsets for Constants
     original_constant_offsets = {}
@@ -605,7 +606,6 @@ def _compute_expression_ir(
     expression_ir = compute_integral_ir(
         cell,
         base_ir["integral_type"],
-        base_ir["entity_type"],
         integrands,
         tensor_shape,
         options,

--- a/ffcx/ir/representationutils.py
+++ b/ffcx/ir/representationutils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2017 Marie Rognes
+# Copyright (C) 2012-2025 Marie Rognes and Jørgen S. Dokken
 #
 # This file is part of FFCx.(https://www.fenicsproject.org)
 #
@@ -8,10 +8,13 @@
 import hashlib
 import itertools
 import logging
+import typing
 
-import numpy as np
 import ufl
+import numpy as np
+from basix.ufl import _ElementBase
 
+from ffcx.definitions import IntegralType
 from ffcx.element_interface import (
     create_quadrature,
     map_edge_points,
@@ -55,77 +58,80 @@ class QuadratureRule:
 
 
 def create_quadrature_points_and_weights(
-    integral_type, cell, degree, rule, elements, use_tensor_product=False
+    integral_type: IntegralType,
+    cell: ufl.Cell,
+    degree: int,
+    rule: str,
+    elements: list[_ElementBase],
+    use_tensor_product: bool = False,
 ):
     """Create quadrature rule and return points and weights."""
     pts = {}
     wts = {}
     tensor_factors = {}
-    if integral_type == "cell":
-        cell_name = cell.cellname()
-        if cell_name in ["quadrilateral", "hexahedron"] and use_tensor_product:
-            if cell_name == "quadrilateral":
-                tensor_factors[cell_name] = [
-                    create_quadrature("interval", degree, rule, elements) for _ in range(2)
-                ]
-            elif cell_name == "hexahedron":
-                tensor_factors[cell_name] = [
-                    create_quadrature("interval", degree, rule, elements) for _ in range(3)
-                ]
-            pts[cell_name] = np.array(
-                [
-                    tuple(i[0] for i in p)
-                    for p in itertools.product(*[f[0] for f in tensor_factors[cell_name]])
-                ]
+    match integral_type:
+        case IntegralType(is_expression=True):
+            pass
+        case IntegralType(codim=0):
+            cell_name = cell.cellname()
+            if cell_name in ["quadrilateral", "hexahedron"] and use_tensor_product:
+                if cell_name == "quadrilateral":
+                    tensor_factors[cell_name] = [
+                        create_quadrature("interval", degree, rule, elements) for _ in range(2)
+                    ]
+                elif cell_name == "hexahedron":
+                    tensor_factors[cell_name] = [
+                        create_quadrature("interval", degree, rule, elements) for _ in range(3)
+                    ]
+                pts[cell_name] = np.array(
+                    [
+                        tuple(i[0] for i in p)  # type: ignore
+                        for p in itertools.product(*[f[0] for f in tensor_factors[cell_name]])  # type: ignore
+                    ]
+                )
+                wts[cell_name] = np.array(
+                    [
+                        np.prod(p)  # type: ignore
+                        for p in itertools.product(*[f[1] for f in tensor_factors[cell_name]])  # type: ignore
+                    ]
+                )
+            else:
+                pts[cell_name], wts[cell_name] = create_quadrature( # type: ignore
+                    cell_name, degree, rule, elements
+                )
+        case IntegralType(codim=1):
+            for ft in cell.facet_types():
+                pts[ft.cellname()], wts[ft.cellname()] = create_quadrature( # type: ignore
+                    ft.cellname(),
+                    degree,
+                    rule,
+                    elements,
+                )
+        case IntegralType(codim=2):
+            for rt in cell.ridge_types():
+                pts[rt.cellname()], wts[rt.cellname()] = create_quadrature( # type: ignore
+                    rt.cellname(),
+                    degree,
+                    rule,
+                    elements,
+                )
+        case IntegralType(codim=-1):
+            pts["vertex"], wts["vertex"] = create_quadrature("vertex", degree, rule, elements) # type: ignore
+        case _:
+            raise RuntimeError(
+                f"Unknown integral_type {integral_type} in quadrature rule creation."
             )
-            wts[cell_name] = np.array(
-                [np.prod(p) for p in itertools.product(*[f[1] for f in tensor_factors[cell_name]])]
-            )
-        else:
-            pts[cell_name], wts[cell_name] = create_quadrature(cell_name, degree, rule, elements)
-    elif integral_type in ufl.measure.facet_integral_types:
-        for ft in cell.facet_types():
-            pts[ft.cellname()], wts[ft.cellname()] = create_quadrature(
-                ft.cellname(),
-                degree,
-                rule,
-                elements,
-            )
-    elif integral_type in ufl.measure.ridge_integral_types:
-        for rt in cell.ridge_types():
-            pts[rt.cellname()], wts[rt.cellname()] = create_quadrature(
-                rt.cellname(),
-                degree,
-                rule,
-                elements,
-            )
-    elif integral_type in ufl.measure.point_integral_types:
-        pts["vertex"], wts["vertex"] = create_quadrature("vertex", degree, rule, elements)
-    elif integral_type == "expression":
-        pass
-    else:
-        logger.exception(f"Unknown integral type: {integral_type}")
-
     return pts, wts, tensor_factors
 
 
-def integral_type_to_entity_dim(integral_type, tdim):
+def integral_type_to_entity_dim(integral_type: IntegralType, tdim: int):
     """Given integral_type and domain tdim, return the tdim of the integration entity."""
-    if integral_type == "cell":
-        entity_dim = tdim
-    elif integral_type in ufl.measure.facet_integral_types:
-        entity_dim = tdim - 1
-    elif integral_type in ufl.measure.ridge_integral_types:
-        entity_dim = tdim - 2
-    elif integral_type in ufl.measure.point_integral_types:
-        entity_dim = 0
-    elif integral_type in ufl.custom_integral_types:
-        entity_dim = tdim
-    elif integral_type == "expression":
-        entity_dim = tdim
+    if integral_type.codim == -1:
+        return 0
+    elif integral_type.codim >= 0:
+        return tdim - integral_type.codim
     else:
-        raise RuntimeError(f"Unknown integral_type: {integral_type}")
-    return entity_dim
+        raise NotImplementedError(f"Cannot handle codim {integral_type.codim} < -1")
 
 
 def map_integral_points(points, integral_type, cell, entity):

--- a/test/test_add_mode.py
+++ b/test/test_add_mode.py
@@ -56,7 +56,7 @@ def test_additive_facet_integral(dtype, compile_args):
     form0 = compiled_forms[0]
 
     integral_offsets = form0.form_integral_offsets
-    ex = module.lib.exterior_facet
+    ex = module.lib.facet
     assert integral_offsets[ex + 1] - integral_offsets[ex] == 1
     integral_id = form0.form_integral_ids[integral_offsets[ex]]
     assert integral_id == -1

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -391,7 +391,7 @@ def test_subdomains(compile_args):
     form3 = compiled_forms[3]
     offsets = form3.form_integral_offsets
     assert offsets[cell + 1] - offsets[cell] == 0
-    exf = module.lib.exterior_facet
+    exf = module.lib.facet
     ids = [form3.form_integral_ids[j] for j in range(offsets[exf], offsets[exf + 1])]
     assert ids[0] == 0 and ids[1] == 210
 
@@ -1028,7 +1028,7 @@ def test_facet_vertex_quadrature(compile_args):
     solutions = []
     for form in compiled_forms:
         offsets = form.form_integral_offsets
-        exf = module.lib.exterior_facet
+        exf = module.lib.facet
         assert offsets[exf + 1] - offsets[exf] == 1
 
         default_integral = form.form_integrals[offsets[exf]]
@@ -1311,7 +1311,7 @@ def test_ds_prism(compile_args, dtype):
 
     offsets = form0.form_integral_offsets
     cell = module.lib.cell
-    exterior_facet = module.lib.exterior_facet
+    exterior_facet = module.lib.facet
     interior_facet = module.lib.interior_facet
     assert offsets[cell + 1] - offsets[cell] == 0
     assert offsets[exterior_facet + 1] - offsets[exterior_facet] == 2


### PR DESCRIPTION
Following the discussion in: https://github.com/FEniCS/dolfinx/pull/3900
here follows an attempt of separate `UFL` concepts from `FFCx`/`DOLFINx` concepts.

This starts with replacing the `integral_type`, which we are just taking directly from ufl as a string, with a `NamedTuple` that contains:
- `codim`: An integer that is either 0, 1, ...., tdim to represent cells, facets, ridges and peaks, or -1 to represent vertices (for now as they are introduced in FFCx. I believe they should be replaced with peak integrals).
- `num_neighbours`: Number of neighbouring cells. This indicates if we have an "interior" or "exterior" quantity. Currently this is not used to do anything in UFCx.h, but i believe this is something we should store there, rather than the enum we are currently using (`facet`, `exterior_facet`, `cell`, `ridge`, `vertex`). Default value for any IntegralType is 1 neighbour
- `is_expression`: As the integral-ir of Expression and Integrands are the same, we store this information as an optional bool.
- `is_custom`: If anyone wants to implement a custom element, it should go through the custom measure (none of the other custom types) for now.