### PR TITLE
Make numba test execution depend on avail. numba install

### DIFF
--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -17,6 +17,7 @@ from ffcx.codegeneration.utils import dtype_to_scalar_dtype, numba_ufcx_kernel_s
 
 numba = pytest.importorskip("numba")
 
+
 def wrap_kernel(scalar_type, real_type):
     c_signature = numba_ufcx_kernel_signature(scalar_type, real_type)
     return numba.cfunc(c_signature, nopython=True)


### PR DESCRIPTION
Ensures in the absence of numba we still get a valid set of unit tests.

Ref. https://github.com/FEniCS/spack-fenics/pull/21