### PR TITLE
Fix I/O in `numba` unit test

### DIFF
--- a/test/test_numba.py
+++ b/test/test_numba.py
@@ -35,12 +35,14 @@ def test_external_module():
     assert ffcx.main.main([str(dir / "poisson.py"), *opts.split(" ")]) == 0
 
 
-@pytest.mark.parametrize("scalar_type", ["float32", "float64"])  # TODO: complex limited by ctypes
-def test_integral(scalar_type: str) -> None:
-    opts = f"--language numba --scalar_type {scalar_type}"
+@pytest.fixture
+def generate_poisson() -> None:
     dir = Path(__file__).parent
-    assert ffcx.main.main([str(dir / "poisson.py"), *opts.split(" ")]) == 0
+    assert ffcx.main.main([str(dir / "poisson.py"), "--language", "numba"]) == 0
 
+
+@pytest.mark.parametrize("scalar_type", ["float32", "float64"])  # TODO: complex limited by ctypes
+def test_integral(scalar_type: str, generate_poisson) -> None:
     poisson = importlib.import_module("poisson_numba")
 
     dtype = np.dtype(scalar_type).type
@@ -93,11 +95,7 @@ def test_integral(scalar_type: str) -> None:
 
 
 @pytest.mark.parametrize("scalar_type", ["float32", "float64"])  # TODO: complex limited by ctypes
-def test_expression(scalar_type: str) -> None:
-    opts = f"--language numba --scalar_type {scalar_type}"
-    dir = Path(__file__).parent
-    assert ffcx.main.main([str(dir / "poisson.py"), *opts.split(" ")]) == 0
-
+def test_expression(scalar_type: str, generate_poisson) -> None:
     poisson = importlib.import_module("poisson_numba")
 
     dtype = np.dtype(scalar_type).type


### PR DESCRIPTION
- `numba` kernel is type agnostic, should only be written once to disk
- I assume https://github.com/FEniCS/ffcx/issues/822 triggered by multi file writes/overwrites, which should be resolved with this - however, can no reproduce so this a bit of a lucky punch.

Fixes https://github.com/FEniCS/ffcx/issues/822.