### PR TITLE
Enable running tests from any directory

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,7 +22,7 @@ def add_cwd_to_syspath():
     """
     cwd = os.getcwd()
     if cwd not in sys.path:
-        sys.path.insert(0, cwd)
+        sys.path.append(cwd)
 
 
 @pytest.fixture(scope="module")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,9 +16,9 @@ def add_cwd_to_syspath():
     """Ensure the current working directory is in sys.path.
 
     CFFI and ffcx.main compile/generate files into CWD by default. Without
-    this, importlib.import_module cannot find those files when pytest is invoked
-    from a directory that is not already on sys.path (e.g. the project root
-    rather than the test/ subdirectory).
+    this, importlib.import_module cannot find those files when ``pytest``
+    is invoked from a directory that is not already on sys.path
+    (e.g. the project root rather than the test/ subdirectory).
     """
     cwd = os.getcwd()
     if cwd not in sys.path:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,9 +5,24 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Test configuration."""
 
+import os
 import sys
 
 import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def add_cwd_to_syspath():
+    """Ensure the current working directory is in sys.path.
+
+    CFFI and ffcx.main compile/generate files into CWD by default. Without
+    this, importlib.import_module cannot find those files when pytest is invoked
+    from a directory that is not already on sys.path (e.g. the project root
+    rather than the test/ subdirectory).
+    """
+    cwd = os.getcwd()
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Adds current directory to path to ensure that .so can be imported - fixes `py.test test/`.
