### PR TITLE
Roll out fenicsx-refs.env system to CI workflows

### DIFF
--- a/.github/workflows/dolfinx-tests.yml
+++ b/.github/workflows/dolfinx-tests.yml
@@ -8,19 +8,6 @@ on:
   merge_group:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      dolfinx_ref:
-        description: "DOLFINx branch or tag"
-        default: "main"
-        type: string
-      basix_ref:
-        description: "Basix branch or tag"
-        default: "main"
-        type: string
-      ufl_ref:
-        description: "UFL branch or tag"
-        default: "main"
-        type: string
   # Weekly build on Mondays at 8 am
   schedule:
     - cron: "0 8 * * 1"
@@ -38,33 +25,21 @@ jobs:
       OMPI_MCA_rmaps_base_oversubscribe: true                 # Older OpenMPI
     steps:
       - uses: actions/checkout@v6
-      - name: Install UFL and Basix (default branches/tags)
-        if: github.event_name != 'workflow_dispatch'
+      - name: Load environment variables
+        run: cat .github/workflows/fenicsx-refs.env >> $GITHUB_ENV
+      - name: Install UFL and Basix
         run: |
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ufl.git
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/basix.git
-      - name: Install UFL and Basix (specified branches/tags)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/ufl.git@${{ github.event.inputs.ufl_ref }}
-          python3 -m pip install --break-system-packages git+https://github.com/FEniCS/basix.git@${{ github.event.inputs.basix_ref }}
+          python3 -m pip install --break-system-packages git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
+          python3 -m pip install --break-system-packages git+https://github.com/${{ env.basix_repository }}.git@${{ env.basix_ref }}
       - name: Install FFCx
         run: |
           pip3 install --break-system-packages .
-      - name: Get DOLFINx source (default branch/tag)
-        if: github.event_name != 'workflow_dispatch'
+      - name: Get DOLFINx source
         uses: actions/checkout@v6
         with:
           path: ./dolfinx
-          repository: FEniCS/dolfinx
-          ref: main
-      - name: Get DOLFINx source (specified branch/tag)
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v6
-        with:
-          path: ./dolfinx
-          repository: FEniCS/dolfinx
-          ref: ${{ github.event.inputs.dolfinx_ref }}
+          repository: ${{ env.dolfinx_repository }}
+          ref: ${{ env.dolfinx_ref }}
       - name: Install DOLFINx (C++)
         run: |
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Developer -DBUILD_TESTING=true -B build -S dolfinx/cpp/

--- a/.github/workflows/fenicsx-refs.env
+++ b/.github/workflows/fenicsx-refs.env
@@ -1,0 +1,6 @@
+ufl_repository=FEniCS/ufl
+ufl_ref=main
+basix_repository=FEniCS/basix
+basix_ref=main
+dolfinx_repository=FEniCS/dolfinx
+dolfinx_ref=main

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -32,8 +32,12 @@ jobs:
       - name: Checkout FFCx
         uses: actions/checkout@v6
 
-      - name: Load environment variables
+      - name: Load environment variables (Unix)
+        if: runner.os != 'Windows'
         run: cat .github/workflows/fenicsx-refs.env >> $GITHUB_ENV
+      - name: Load environment variables (Windows)
+        if: runner.os == 'Windows'
+        run: cat .github/workflows/fenicsx-refs.env >> $env:GITHUB_ENV
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Checkout FFCx
         uses: actions/checkout@v6
 
+      - name: Load environment variables
+        run: cat .github/workflows/fenicsx-refs.env >> $GITHUB_ENV
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -62,16 +65,16 @@ jobs:
       - name: Install FEniCS dependencies (Python, Unix)
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
-          pip install git+https://github.com/FEniCS/ufl.git
-          pip install git+https://github.com/FEniCS/basix.git
+          pip install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
+          pip install git+https://github.com/${{ env.basix_repository }}.git@${{ env.basix_ref }}
 
       - name: Install FEniCS dependencies (Python, Windows)
         if: runner.os == 'Windows'
         env:
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         run: |
-          pip install git+https://github.com/FEniCS/ufl.git
-          pip install -v git+https://github.com/FEniCS/basix.git --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          pip install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
+          pip install -v git+https://github.com/${{ env.basix_repository }}.git@${{ env.basix_ref }} --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 
       - name: Install FFCx (Linux, with optional dependencies)
         if: runner.os == 'Linux'


### PR DESCRIPTION
The current system with many hard-coded refs makes releases very difficult. This rolls out the `fenicsx-refs.env` system across the workflows.