### PR TITLE
Support `numba>=0.66.0` and tidy optional dependency

### DIFF
--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2026 Michal Habera, Chris Richardson, Garth N. Wells and Paul T. Kühner
+# Copyright (C) 2020-2024 Michal Habera, Chris Richardson and Garth N. Wells
 #
 # This file is part of FFCx.(https://www.fenicsproject.org)
 #

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Utilities."""
 
-
 import numpy as np
 import numpy.typing as npt
 
@@ -13,6 +12,8 @@ try:
     import numba
 except ImportError:
     numba = None
+
+
 def dtype_to_c_type(dtype: npt.DTypeLike | str) -> str:
     """For a NumPy dtype, return the corresponding C type.
 

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -95,10 +95,10 @@ if find_spec("numba") is not None:
         """
 
         def codegen(context, builder, signature, args):
-            null_ptr = context.get_constant(numba.types.voidptr, 0)
+            null_ptr = context.get_constant(types.voidptr, 0)
             return null_ptr
 
-        sig = numba.types.voidptr()
+        sig = types.voidptr()
         return sig, codegen
 
     @numba.extending.intrinsic
@@ -122,7 +122,7 @@ if find_spec("numba") is not None:
             the raw data pointer to the first element of the of the contiguous block of memory
             of the NumPy array to void*.
         """
-        if not isinstance(arr, numba.types.Array):
+        if not isinstance(arr, types.Array):
             raise TypeError("Expected a NumPy array")
 
         def codegen(context, builder, signature, args):
@@ -143,8 +143,8 @@ if find_spec("numba") is not None:
             """
             [arr] = args
             raw_ptr = numba.core.cgutils.alloca_once_value(builder, arr)
-            void_ptr = builder.bitcast(raw_ptr, context.get_value_type(numba.types.voidptr))
+            void_ptr = builder.bitcast(raw_ptr, context.get_value_type(types.voidptr))
             return void_ptr
 
-        sig = numba.types.voidptr(arr)
+        sig = types.voidptr(arr)
         return sig, codegen

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -56,38 +56,29 @@ def dtype_to_scalar_dtype(dtype: npt.DTypeLike | str) -> np.dtype:
         raise RuntimeError(f"Cannot get value dtype for '{dtype}'. ")
 
 
-def numba_ufcx_kernel_signature(dtype: npt.DTypeLike, xdtype: npt.DTypeLike):
-    """Return a Numba C signature for the UFCx ``tabulate_tensor`` interface.
+if find_spec("numba") is not None:
+    import numba
+    from numba.core import types
 
-    Args:
-        dtype: The scalar type for the finite element data.
-        xdtype: The geometry float type.
+    def numba_ufcx_kernel_signature(dtype: npt.DTypeLike, xdtype: npt.DTypeLike):
+        """Return a Numba C signature for the UFCx ``tabulate_tensor`` interface.
 
-    Returns:
-        A Numba signature (``numba.core.typing.templates.Signature``).
+        Args:
+            dtype: The scalar type for the finite element data.
+            xdtype: The geometry float type.
 
-    Raises:
-        ImportError: If ``numba`` cannot be imported.
-    """
-    try:
-        from numba import from_dtype
-        from numba.core import types
-
+        Returns:
+            A Numba signature (``numba.core.typing.templates.Signature``).
+        """
         return types.void(
-            types.CPointer(from_dtype(dtype)),
-            types.CPointer(from_dtype(dtype)),
-            types.CPointer(from_dtype(dtype)),
-            types.CPointer(from_dtype(xdtype)),
+            types.CPointer(numba.from_dtype(dtype)),
+            types.CPointer(numba.from_dtype(dtype)),
+            types.CPointer(numba.from_dtype(dtype)),
+            types.CPointer(numba.from_dtype(xdtype)),
             types.CPointer(types.intc),
             types.CPointer(types.uint8),
             types.CPointer(types.void),
         )
-    except ImportError as e:
-        raise e
-
-
-if find_spec("numba") is not None:
-    import numba
 
     @numba.extending.intrinsic
     def empty_void_pointer(typingctx):

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -11,7 +11,7 @@ import numpy.typing as npt
 try:
     import numba
 except ImportError:
-    numba = None
+    numba = None  # type: ignore
 
 
 def dtype_to_c_type(dtype: npt.DTypeLike | str) -> str:

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -60,7 +60,6 @@ def dtype_to_scalar_dtype(dtype: npt.DTypeLike | str) -> np.dtype:
 
 
 if numba is not None:
-    from numba.core import types
 
     def numba_ufcx_kernel_signature(dtype: npt.DTypeLike, xdtype: npt.DTypeLike):
         """Return a Numba C signature for the UFCx ``tabulate_tensor`` interface.
@@ -72,14 +71,14 @@ if numba is not None:
         Returns:
             A Numba signature (``numba.core.typing.templates.Signature``).
         """
-        return types.void(
-            types.CPointer(numba.from_dtype(dtype)),
-            types.CPointer(numba.from_dtype(dtype)),
-            types.CPointer(numba.from_dtype(dtype)),
-            types.CPointer(numba.from_dtype(xdtype)),
-            types.CPointer(types.intc),
-            types.CPointer(types.uint8),
-            types.CPointer(types.void),
+        return numba.types.void(
+            numba.types.CPointer(numba.from_dtype(dtype)),
+            numba.types.CPointer(numba.from_dtype(dtype)),
+            numba.types.CPointer(numba.from_dtype(dtype)),
+            numba.types.CPointer(numba.from_dtype(xdtype)),
+            numba.types.CPointer(numba.types.intc),
+            numba.types.CPointer(numba.types.uint8),
+            numba.types.CPointer(numba.types.void),
         )
 
     @numba.extending.intrinsic
@@ -97,10 +96,10 @@ if numba is not None:
         """
 
         def codegen(context, builder, signature, args):
-            null_ptr = context.get_constant(types.voidptr, 0)
+            null_ptr = context.get_constant(numba.types.voidptr, 0)
             return null_ptr
 
-        sig = types.voidptr()
+        sig = numba.types.voidptr()
         return sig, codegen
 
     @numba.extending.intrinsic
@@ -124,7 +123,7 @@ if numba is not None:
             the raw data pointer to the first element of the of the contiguous block of memory
             of the NumPy array to void*.
         """
-        if not isinstance(arr, types.Array):
+        if not isinstance(arr, numba.types.Array):
             raise TypeError("Expected a NumPy array")
 
         def codegen(context, builder, signature, args):
@@ -145,8 +144,8 @@ if numba is not None:
             """
             [arr] = args
             raw_ptr = numba.core.cgutils.alloca_once_value(builder, arr)
-            void_ptr = builder.bitcast(raw_ptr, context.get_value_type(types.voidptr))
+            void_ptr = builder.bitcast(raw_ptr, context.get_value_type(numba.types.voidptr))
             return void_ptr
 
-        sig = types.voidptr(arr)
+        sig = numba.types.voidptr(arr)
         return sig, codegen

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Utilities."""
 
-from importlib import import_module
 from importlib.util import find_spec
 
 import numpy as np
@@ -71,11 +70,8 @@ def numba_ufcx_kernel_signature(dtype: npt.DTypeLike, xdtype: npt.DTypeLike):
         ImportError: If ``numba`` cannot be imported.
     """
     try:
-        types = import_module(
-            "numba" + (".core" if numba.__version__ >= (0, 66, 0) else "") + ".types"
-        )
-
         from numba import from_dtype
+        from numba.core import types
 
         return types.void(
             types.CPointer(from_dtype(dtype)),

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -5,12 +5,14 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Utilities."""
 
-from importlib.util import find_spec
 
 import numpy as np
 import numpy.typing as npt
 
-
+try:
+    import numba
+except ImportError:
+    numba = None
 def dtype_to_c_type(dtype: npt.DTypeLike | str) -> str:
     """For a NumPy dtype, return the corresponding C type.
 

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -1,17 +1,15 @@
-# Copyright (C) 2020-2024 Michal Habera, Chris Richardson and Garth N. Wells
+# Copyright (C) 2020-2026 Michal Habera, Chris Richardson, Garth N. Wells and Paul T. Kühner
 #
 # This file is part of FFCx.(https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 """Utilities."""
 
+from importlib import import_module
+from importlib.util import find_spec
+
 import numpy as np
 import numpy.typing as npt
-
-try:
-    import numba
-except ImportError:
-    numba = None
 
 
 def dtype_to_c_type(dtype: npt.DTypeLike | str) -> str:
@@ -73,7 +71,10 @@ def numba_ufcx_kernel_signature(dtype: npt.DTypeLike, xdtype: npt.DTypeLike):
         ImportError: If ``numba`` cannot be imported.
     """
     try:
-        import numba.types as types
+        types = import_module(
+            "numba" + (".core" if numba.__version__ >= (0, 66, 0) else "") + ".types"
+        )
+
         from numba import from_dtype
 
         return types.void(
@@ -89,7 +90,8 @@ def numba_ufcx_kernel_signature(dtype: npt.DTypeLike, xdtype: npt.DTypeLike):
         raise e
 
 
-if numba is not None:
+if find_spec("numba") is not None:
+    import numba
 
     @numba.extending.intrinsic
     def empty_void_pointer(typingctx):

--- a/ffcx/codegeneration/utils.py
+++ b/ffcx/codegeneration/utils.py
@@ -59,8 +59,7 @@ def dtype_to_scalar_dtype(dtype: npt.DTypeLike | str) -> np.dtype:
         raise RuntimeError(f"Cannot get value dtype for '{dtype}'. ")
 
 
-if find_spec("numba") is not None:
-    import numba
+if numba is not None:
     from numba.core import types
 
     def numba_ufcx_kernel_signature(dtype: npt.DTypeLike, xdtype: npt.DTypeLike):


### PR DESCRIPTION
- `numba.types` has been a redirect to `numba.core.types` for 6 years https://github.com/numba/numba/commit/09a570e1efe6fb45c01fc8dc96d64a799ab879ee, replaced - caught by type checkers.
- numba related functionality is now consistently not declared if `import numba` fails (`numba_ufcx_kernel_signature` was previously defined and raised, while others not defined)