### PR TITLE
Ruff formatting fixes and checking that we can have constants from other meshes in the form

### DIFF
--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -247,7 +247,7 @@ class FFCXBackendDefinitions:
         if self.integral_type in ufl.custom_integral_types:
             # FIXME: Jacobian may need adjustment for custom_integral_types
             if mt.local_derivatives:
-                logger.exception("FIXME: Jacobian in custom integrals is not implemented.")
+                logger.error("FIXME: Jacobian in custom integrals is not implemented.")
             return []
         else:
             return self._define_coordinate_dofs_lincomb(mt, tabledata, quadrature_rule, access)

--- a/ffcx/codegeneration/symbols.py
+++ b/ffcx/codegeneration/symbols.py
@@ -112,7 +112,7 @@ class FFCXBackendSymbols:
         elif entity_type == "ridge":
             return self.entity_local_index[0]
         else:
-            logger.exception(f"Unknown entity_type {entity_type}")
+            logger.error(f"Unknown entity_type {entity_type}")
 
     def argument_loop_index(self, iarg):
         """Loop index for argument iarg."""

--- a/ffcx/ir/analysis/modified_terminals.py
+++ b/ffcx/ir/analysis/modified_terminals.py
@@ -40,8 +40,8 @@ class ModifiedTerminal:
         flat_component: int,
         global_derivatives: tuple[int, ...],
         local_derivatives: tuple[int, ...],
-        averaged: None | str,
-        restriction: None | str,
+        averaged: str | None,
+        restriction: str | None,
     ):
         """Initialise.
 

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -175,7 +175,7 @@ def _compute_integral_ir(
     coeffs_and_arguments = ufl.algorithms.analysis.extract_arguments(
         expression
     ) + ufl.algorithms.analysis.extract_coefficients(expression)
-    domains = [ufl.domain.extract_unique_domain(arg) for arg in coeffs_and_arguments]
+    domains = map(ufl.domain.extract_unique_domain, coeffs_and_arguments)
     for domain in domains:
         assert domain is not None
         if domain.topological_dimension != cell.topological_dimension:

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -169,9 +169,14 @@ def _compute_integral_ir(
         if is_modified_terminal(v["expression"])
     }
 
-    # Check if we have a mixed-dimensional integral
+    # Check if we have a mixed-dimensional integral.
+    # We allow for constants to be defined on other meshes, as they require no mapping.
     is_mixed_dim = False
-    for domain in ufl.domain.extract_domains(expression):
+    coeffs_and_arguments = ufl.algorithms.analysis.extract_arguments(
+        expression
+    ) + ufl.algorithms.analysis.extract_coefficients(expression)
+    domains = [arg.ufl_domain() for arg in coeffs_and_arguments]
+    for domain in domains:
         if domain.topological_dimension != cell.topological_dimension:
             is_mixed_dim = True
 

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -175,7 +175,7 @@ def _compute_integral_ir(
     coeffs_and_arguments = ufl.algorithms.analysis.extract_arguments(
         expression
     ) + ufl.algorithms.analysis.extract_coefficients(expression)
-    domains = [arg.ufl_domain() for arg in coeffs_and_arguments]
+    domains = [ufl.domain.extract_unique_domain(arg) for arg in coeffs_and_arguments]
     for domain in domains:
         if domain.topological_dimension != cell.topological_dimension:
             is_mixed_dim = True

--- a/ffcx/ir/integral.py
+++ b/ffcx/ir/integral.py
@@ -177,6 +177,7 @@ def _compute_integral_ir(
     ) + ufl.algorithms.analysis.extract_coefficients(expression)
     domains = [ufl.domain.extract_unique_domain(arg) for arg in coeffs_and_arguments]
     for domain in domains:
+        assert domain is not None
         if domain.topological_dimension != cell.topological_dimension:
             is_mixed_dim = True
 

--- a/ffcx/ir/representationutils.py
+++ b/ffcx/ir/representationutils.py
@@ -104,7 +104,7 @@ def create_quadrature_points_and_weights(
     elif integral_type == "expression":
         pass
     else:
-        logger.exception(f"Unknown integral type: {integral_type}")
+        logger.error(f"Unknown integral type: {integral_type}")
 
     return pts, wts, tensor_factors
 

--- a/test/test_jit_forms.py
+++ b/test/test_jit_forms.py
@@ -2253,3 +2253,60 @@ def test_ufl_complex_extraction(
         ffi.NULL,
     )
     assert np.isclose(J[0], val)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float64",
+        pytest.param(
+            "complex128",
+            marks=pytest.mark.xfail(
+                sys.platform.startswith("win32"),
+                raises=NotImplementedError,
+                reason="missing _Complex",
+            ),
+        ),
+    ],
+)
+def test_mixed_constants(compile_args, dtype):
+    """Check that you can use constants from different meshes in a single form."""
+    domain = ufl.Mesh(basix.ufl.element("Lagrange", "quadrilateral", 1, shape=(3,)))
+    domain2 = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 1, shape=(3,)))
+    domain3 = ufl.Mesh(basix.ufl.element("Lagrange", "tetrahedron", 1, shape=(3,)))
+
+    c = ufl.Constant(domain)
+    c2 = ufl.Constant(domain2)
+    c3 = ufl.Constant(domain3)
+    J = c * c2 * c3 * ufl.dx(domain=domain)
+    forms = [J]
+    compiled_forms, module, _ = ffcx.codegeneration.jit.compile_forms(
+        forms,
+        options={"scalar_type": dtype},
+        cffi_extra_compile_args=compile_args,
+    )
+
+    ffi = module.ffi
+    form = compiled_forms[0]
+    default_integral = form.form_integrals[0]
+
+    xdtype = dtype_to_scalar_dtype(dtype)
+
+    J = np.zeros(1, dtype=dtype)
+    coords = np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 1.0, 2.0, 0.0], dtype=xdtype)
+
+    c_type, c_xtype = dtype_to_c_type(dtype), dtype_to_c_type(xdtype)
+
+    c = np.array([4.0, 3.0, 2.1], dtype=dtype)
+
+    kernel = getattr(default_integral, f"tabulate_tensor_{dtype}")
+    kernel(
+        ffi.cast(f"{c_type} *", J.ctypes.data),
+        ffi.NULL,
+        ffi.cast(f"{c_type} *", c.ctypes.data),
+        ffi.cast(f"{c_xtype} *", coords.ctypes.data),
+        ffi.NULL,
+        ffi.NULL,
+        ffi.NULL,
+    )
+    assert np.isclose(J[0], 2 * np.prod(c))


### PR DESCRIPTION
Originally reported by @RemDelaporteMathurin and @ee-nn at https://github.com/festim-dev/FESTIM/pull/1216#issuecomment-5169213448

Context:
Some times (especially on manifolds), you would like to use `dx(submesh)` to get the correct spatial deriviatives of
a Coefficient or Argument defined on the submesh.
In these cases, you might want to include a constant defined on the parent domain. As Constants in DOLFINx shouldn't really have a mesh (as it serves no point, ref https://github.com/FEniCS/dolfinx/issues/4006, https://github.com/FEniCS/ufl/issues/313). The modification below allows you to use a constant from any mesh in your variational form.