### PR TITLE
Fix mypy errors from numba 0.67 type stubs

### DIFF
--- a/ffcx/codegeneration/numba/utils.py
+++ b/ffcx/codegeneration/numba/utils.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import Any
 
 import numba
+import numpy as np
 import numpy.typing as npt
 
 
@@ -22,11 +23,13 @@ def ufcx_kernel_signature(dtype: npt.DTypeLike, xdtype: npt.DTypeLike) -> Any:
     Returns:
         A Numba signature (``numba.core.typing.templates.Signature``).
     """
+    scalar_type = numba.from_dtype(np.dtype(dtype))
+    geom_type = numba.from_dtype(np.dtype(xdtype))
     return numba.types.void(
-        numba.types.CPointer(numba.from_dtype(dtype)),
-        numba.types.CPointer(numba.from_dtype(dtype)),
-        numba.types.CPointer(numba.from_dtype(dtype)),
-        numba.types.CPointer(numba.from_dtype(xdtype)),
+        numba.types.CPointer(scalar_type),
+        numba.types.CPointer(scalar_type),
+        numba.types.CPointer(scalar_type),
+        numba.types.CPointer(geom_type),
         numba.types.CPointer(numba.types.intc),
         numba.types.CPointer(numba.types.uint8),
         numba.types.CPointer(numba.types.void),


### PR DESCRIPTION
## Summary

CI is failing at the `mypy -p ffcx` step with four `arg-type` errors in
`ffcx/codegeneration/numba/utils.py`, e.g.
[this run](https://github.com/FEniCS/ffcx/actions/runs/32018114965/job/95351841286):

```
ffcx/codegeneration/numba/utils.py:26: error: Argument 1 to "from_dtype" has incompatible type
"type | str | dtype[Any] | _HasDType[dtype[Any]] | _HasNumPyDType[dtype[Any]] | tuple[Any, Any] | list[Any] | _DTypeDict";
expected "dtype[numpy.bool[builtins.bool]] | type[numpy.bool[builtins.bool]]"  [arg-type]
```

## Cause

numba 0.67.0 started shipping a `py.typed` marker and stub files. In
`numba/np/numpy_support.pyi`, `from_dtype` is declared as a set of overloads,
each taking `np.dtype[ScalarT] | type[ScalarT]` for a *concrete* scalar type:

```python
_ToDType: TypeAlias = np.dtype[_ScalarT] | type[_ScalarT]

@overload
def from_dtype(dtype: _ToDType[np.bool_]) -> types.Boolean: ...
@overload
def from_dtype(dtype: _ToDType[np.integer[Any]]) -> types.Integer: ...
...
```

`ufcx_kernel_signature` declares its parameters as `npt.DTypeLike`, a much wider
union that also admits `str`, `list`, `_DTypeDict`, etc., so no overload matches.
Before 0.67 numba was untyped and these calls simply returned `Any`.

## Fix

Normalise the argument with `np.dtype(...)` before calling `from_dtype`;
`np.dtype[Any]` matches the overloads. The public `DTypeLike` signature is
unchanged. The two conversions are hoisted out of the argument list, which also
drops three redundant `from_dtype` calls.

As a side effect, string dtypes such as `"float64"` now work at runtime — they
are valid `DTypeLike` but previously raised `NumbaNotImplementedError`.

## Testing

Checked against the exact versions used by the failing job (numba 0.67.0,
numpy 2.5.2, mypy 2.3.1):

- `mypy` reports no errors in the file.
- `ruff check` and `ruff format --check` pass.
- `ufcx_kernel_signature` produces the expected signatures for `np.float64`,
  `np.complex128`, `np.dtype("float32")` and `"float64"`.

Note only the `macos-latest, 3.14` job actually ran in that workflow — the other
eleven were fail-fast cancelled, but the error is platform- and
version-independent.

AI assistance: I used Claude Code (Opus 5) to draft parts of this PR. I
reviewed, edited, tested, and take responsibility for the final contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)