### PR TITLE
Declare jn/yn in generated C, fixing wrong Bessel values

### DIFF
--- a/demo/test_demos.py
+++ b/demo/test_demos.py
@@ -61,9 +61,7 @@ def test_C(file, scalar_type):
             )
     else:
         cc = os.environ.get("CC", "cc")
-        extra_flags = (
-            "-std=c17 -Wunused-variable -Werror -fPIC -Wno-error=implicit-function-declaration"
-        )
+        extra_flags = "-std=c17 -Wunused-variable -Werror -fPIC"
         subprocess.run(
             [
                 cc,

--- a/ffcx/codegeneration/C/file_template.py
+++ b/ffcx/codegeneration/C/file_template.py
@@ -36,6 +36,13 @@ implementation_pre = """
 //
 {options}
 
+// The integer-order Bessel functions jn/yn are XSI extensions rather than ISO
+// C, and glibc's <math.h> hides them in strict ISO mode (e.g. -std=c17). Ask
+// for the XSI declarations before any system header is included.
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
+#endif
+
 #include <math.h>
 #include <stdalign.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Summary

Compiling generated code that uses the integer-order Bessel functions produced

```
demo/MathFunctions.c:179:24: warning: implicit declaration of function ‘jn’ [-Wimplicit-function-declaration]
  179 |     double sv_39d_84 = jn(1, w0);
demo/MathFunctions.c:187:24: warning: implicit declaration of function ‘yn’ [-Wimplicit-function-declaration]
```

(see e.g. [this job](https://github.com/FEniCS/ffcx/actions/runs/32019129565/job/95354881157)).

## Cause

`jn`/`yn` are XSI extensions rather than ISO C, and glibc's `<math.h>` hides them
in strict ISO mode. The demo test compiles with `-std=c17`, so the calls were left
implicitly declared. macOS does not hide them, which is why only the Ubuntu jobs
warned.

## This was not only a warning

An implicit declaration returns `int`, so the `double` result in `xmm0` was never
read. The generated code computed the wrong answer:

```
implicit: jn(1,x)=0        jn(0.0,x)=0        yn(1,x)=0
declared: jn(1,x)=0.557937 jn(0.0,x)=0.511828 yn(1,x)=-0.412309
```

Generated code also emits a floating-point literal for the order, e.g.
`jn(0.0, sv_39d_6)`. Without a prototype that `double` was passed in an SSE
register while `jn` read the integer register, so the order argument was garbage
too. Both are correct once the declaration is visible.

The JIT path was unaffected in practice: cffi compiles with the default `gnu17`,
where the declarations are visible.

## Fix

- Request `_XOPEN_SOURCE 700` (guarded by `#ifndef`) at the top of the generated
  implementation preamble, before any system header is included.
- Drop `-Wno-error=implicit-function-declaration` from the demo test, which was
  masking this, so it stays enforced.

## Testing

- Regenerated and compiled all 29 demos with
  `-std=c17 -Wunused-variable -Werror -fPIC` and no suppression, for `float64`
  and `complex128` (skipping the combinations the test suite skips), under both
  gcc 13 and clang 18 — all clean.
- `ruff check` and `ruff format --check` pass.
- macOS and Windows were not tested locally: macOS already declares `jn`
  unconditionally, and the Windows job compiles without `/WX`, so neither should
  regress — CI will confirm.

AI assistance: I used Claude Code (Opus 5) to draft parts of this PR. I
reviewed, edited, tested, and take responsibility for the final contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)