### PR TITLE
Pad the shared Spack install tree

### DIFF
--- a/.github/workflows/spack-config/gh-actions-env.yml
+++ b/.github/workflows/spack-config/gh-actions-env.yml
@@ -1,4 +1,10 @@
 spack:
+  view: /opt/view
+  config:
+    install_tree:
+      root: /opt/spack
+      padded_length: 128
+
   concretizer:
     unify: true
     reuse: false


### PR DESCRIPTION
## Summary
- `.github/workflows/spack-config/gh-actions-env.yml` builds against the shared `oci://ghcr.io/fenics/spack-buildcache` mirror but, unlike Basix's and DOLFINx's equivalent configs, has no padded install tree. Packages built here (e.g. `py-numpy`) get relocation prefixes based on this repo's actual GitHub Actions workspace path (`/__w/ffcx/ffcx/...`) with zero reserved padding.
- Any consumer of the shared cache that *does* pad (a longer prefix, e.g. Basix's `/opt/spack/<128 chars of padding>/...`) can never relocate those binaries -- Spack can shrink a padded path to fit a shorter one, but can't grow an unpadded one. Once a bad build lands in the mirror under a given spec hash, every future consumer of that exact hash keeps hitting the same failure, since buildcache push doesn't overwrite existing hash-matching entries.
- FEniCS/basix#1059 hit exactly this: a `py-numpy` binary built here under `/__w/ffcx/ffcx/...` failed to relocate into Basix's padded install tree with `spack.relocate_text.CannotGrowString`.
- Adds the same `view: /opt/view` + `install_tree: {root: /opt/spack, padded_length: 128}` block that Basix's and DOLFINx's configs already use, so binaries built here stay relocatable by any other padded consumer of the shared mirror.

## Test plan
- [ ] CI run of `dolfinx.yml` builds and pushes to the shared mirror successfully
- [ ] A downstream consumer (e.g. Basix's `dolfinx.yml`) can pull FFCx-built packages from the shared mirror without a relocation error