### PR TITLE
Expose cancelling of J@K from UFL

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -83,7 +83,14 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           pip install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
-          pip install -v git+https://github.com/${{ env.basix_repository }}.git@${{ env.basix_ref }} --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          $maxAttempts = 3
+          for ($i = 1; $i -le $maxAttempts; $i++) {
+            pip install -v git+https://github.com/${{ env.basix_repository }}.git@${{ env.basix_ref }} --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($i -eq $maxAttempts) { exit $LASTEXITCODE }
+            Write-Host "basix build failed (attempt $i/$maxAttempts), likely a transient Windows file-lock error during wheel build cleanup. Retrying..."
+            Start-Sleep -Seconds 10
+          }
 
       - name: Install FFCx (Linux, with optional dependencies)
         if: runner.os == 'Linux'

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -50,7 +50,7 @@ def analyze_ufl_objects(
         | tuple[ufl.core.expr.Expr, npt.NDArray[np.floating]]
     ],
     scalar_type: npt.DTypeLike,
-    do_cancel_jacobian_products: bool = False,
+    do_cancel_jacobian_products: bool = True,
 ) -> UFLData:
     """Analyze ufl object(s).
 

--- a/ffcx/analysis.py
+++ b/ffcx/analysis.py
@@ -50,12 +50,14 @@ def analyze_ufl_objects(
         | tuple[ufl.core.expr.Expr, npt.NDArray[np.floating]]
     ],
     scalar_type: npt.DTypeLike,
+    do_cancel_jacobian_products: bool = False,
 ) -> UFLData:
     """Analyze ufl object(s).
 
     Args:
         ufl_objects: UFL objects
         scalar_type: Scalar type that should be used for the analysis
+        do_cancel_jacobian_products: Whether to cancel jacobian products.
 
     Returns:
         A named tuple :class:`UFLData`.
@@ -88,7 +90,9 @@ def analyze_ufl_objects(
         else:
             raise TypeError("UFL objects not recognised.")
 
-    form_data = tuple(_analyze_form(form, scalar_type) for form in forms)
+    form_data = tuple(
+        _analyze_form(form, scalar_type, do_cancel_jacobian_products) for form in forms
+    )
     for data in form_data:
         elements += data.unique_sub_elements
         coordinate_elements += data.coordinate_elements
@@ -143,13 +147,16 @@ def _analyze_expression(
     return expression
 
 
-def _analyze_form(form: ufl.Form, scalar_type: npt.DTypeLike) -> FormData:
+def _analyze_form(
+    form: ufl.Form, scalar_type: npt.DTypeLike, do_cancel_jacobian_products: bool
+) -> FormData:
     """Analyzes UFL form and attaches metadata.
 
     Args:
         form: forms
         scalar_type: Scalar type used for form. This is used to simplify
             real valued forms.
+        do_cancel_jacobian_products: Whether to cancel jacobian products.
 
     Returns:
         Form data computed by UFL with metadata attached
@@ -180,6 +187,7 @@ def _analyze_form(form: ufl.Form, scalar_type: npt.DTypeLike) -> FormData:
         preserve_geometry_types=(ufl.classes.Jacobian,),
         do_apply_restrictions=True,
         do_append_everywhere_integrals=False,  # do not add dx integrals to dx(i) in UFL
+        do_cancel_jacobian_products=do_cancel_jacobian_products,
         complex_mode=complex_mode,
     )
 

--- a/ffcx/compiler.py
+++ b/ffcx/compiler.py
@@ -108,7 +108,11 @@ def compile_ufl_objects(
 
     # Stage 1: analysis
     cpu_time = time()
-    analysis = analyze_ufl_objects(ufl_objects, options["scalar_type"])  # type: ignore
+    analysis = analyze_ufl_objects(
+        ufl_objects,
+        options["scalar_type"],
+        do_cancel_jacobian_products=options.get("do_cancel_jacobian_products", False),
+    )  # type: ignore
     _print_timing(1, time() - cpu_time)
 
     # Stage 2: intermediate representation

--- a/ffcx/compiler.py
+++ b/ffcx/compiler.py
@@ -110,9 +110,9 @@ def compile_ufl_objects(
     cpu_time = time()
     analysis = analyze_ufl_objects(
         ufl_objects,
-        options["scalar_type"],
-        do_cancel_jacobian_products=options.get("do_cancel_jacobian_products", False),
-    )  # type: ignore
+        options["scalar_type"],  # type: ignore
+        do_cancel_jacobian_products=options.get("do_cancel_jacobian_products", False),  # type: ignore
+    )
     _print_timing(1, time() - cpu_time)
 
     # Stage 2: intermediate representation

--- a/ffcx/compiler.py
+++ b/ffcx/compiler.py
@@ -111,7 +111,7 @@ def compile_ufl_objects(
     analysis = analyze_ufl_objects(
         ufl_objects,
         options["scalar_type"],  # type: ignore
-        do_cancel_jacobian_products=options.get("do_cancel_jacobian_products", False),  # type: ignore
+        do_cancel_jacobian_products=options["do_cancel_jacobian_products"],  # type: ignore
     )
     _print_timing(1, time() - cpu_time)
 

--- a/ffcx/main.py
+++ b/ffcx/main.py
@@ -53,7 +53,10 @@ parser.add_argument("-p", "--profile", action="store_true", help="Enable profili
 for opt_name, (arg_type, opt_val, opt_desc, choices) in FFCX_DEFAULT_OPTIONS.items():
     if isinstance(opt_val, bool):
         parser.add_argument(
-            f"--{opt_name}", action="store_true", help=f"{opt_desc} (default={opt_val})"
+            f"--{opt_name}",
+            action=argparse.BooleanOptionalAction,
+            default=None,
+            help=f"{opt_desc} (default={opt_val})",
         )
     else:
         parser.add_argument(

--- a/ffcx/options.py
+++ b/ffcx/options.py
@@ -48,6 +48,12 @@ FFCX_DEFAULT_OPTIONS = {
         None,
     ),
     "part": (str, "full", "Part of bilinear tensor to assemble", ("full", "diagonal")),
+    "do_cancel_jacobian_products": (
+        bool,
+        True,
+        "Cancel contractions of the Jacobian with its inverse in form integrands.",
+        None,
+    ),
 }
 
 

--- a/test/test_cancel_jacobians.py
+++ b/test/test_cancel_jacobians.py
@@ -1,5 +1,3 @@
-import time
-
 import basix.ufl
 import numpy as np
 import pytest
@@ -7,6 +5,58 @@ import ufl
 
 import ffcx.codegeneration.jit
 from ffcx.codegeneration.utils import dtype_to_c_type, dtype_to_scalar_dtype
+
+
+def _tabulate_tensor(forms, shape, dtype, coords, compile_args, do_cancel_jacobian_products=None):
+    """Compile and tabulate the default integral of a form."""
+    options = {"scalar_type": dtype}
+    if do_cancel_jacobian_products is not None:
+        options["do_cancel_jacobian_products"] = do_cancel_jacobian_products
+    compiled_forms, module, _ = ffcx.codegeneration.jit.compile_forms(
+        forms,
+        options=options,
+        cffi_extra_compile_args=compile_args,
+    )
+
+    tensor = np.zeros(shape, dtype=dtype)
+    w = np.array([], dtype=dtype)
+    c = np.array([], dtype=dtype)
+    xdtype = dtype_to_scalar_dtype(dtype)
+    c_type, c_xtype = dtype_to_c_type(dtype), dtype_to_c_type(xdtype)
+
+    default_integral = compiled_forms[0].form_integrals[0]
+    kernel = getattr(default_integral, f"tabulate_tensor_{dtype}")
+    ffi = module.ffi
+    kernel(
+        ffi.cast(f"{c_type} *", tensor.ctypes.data),
+        ffi.cast(f"{c_type} *", w.ctypes.data),
+        ffi.cast(f"{c_type} *", c.ctypes.data),
+        ffi.cast(f"{c_xtype} *", coords.ctypes.data),
+        ffi.NULL,
+        ffi.NULL,
+        ffi.NULL,
+    )
+
+    return tensor
+
+
+def _triangle_coordinates(dtype):
+    """Return non-degenerate triangle coordinates in the scalar real dtype."""
+    xdtype = dtype_to_scalar_dtype(dtype)
+    return np.array([[0.0, 0.0, 0.0], [2.0, 0.1, 0.0], [0.3, 1.1, 0.0]], dtype=xdtype)
+
+
+def _assert_tensors_equal(tensor, reference, dtype):
+    """Check tensor equivalence with a tolerance appropriate for the scalar type."""
+    if dtype in ("float32", "complex64"):
+        # The algebraically equivalent paths evaluate J @ inv(J) in a different
+        # order, so the uncancelled path accumulates more single-precision round-off.
+        tol = 5e-4
+    elif dtype in ("float64", "complex128"):
+        tol = 1e-12
+    else:
+        raise ValueError(f"Unsupported {dtype=}")
+    np.testing.assert_allclose(tensor, reference, rtol=tol, atol=tol)
 
 
 @pytest.mark.parametrize(
@@ -19,7 +69,13 @@ from ffcx.codegeneration.utils import dtype_to_c_type, dtype_to_scalar_dtype
 @pytest.mark.parametrize("degree", [1, 3, 5])
 @pytest.mark.parametrize(
     "cell_type, gdim",
-    [("triangle", 2), ("tetrahedron", 3), ("quadrilateral", 2), ("hexahedron", 3)],
+    [
+        ("triangle", 2),
+        ("triangle", 3),
+        ("tetrahedron", 3),
+        ("quadrilateral", 2),
+        ("hexahedron", 3),
+    ],
 )
 def test_cancel_jacobians(dtype, compile_args, degree, cell_type, gdim):
     domain = ufl.Mesh(basix.ufl.element("Lagrange", cell_type, 1, shape=(gdim,)))
@@ -30,19 +86,9 @@ def test_cancel_jacobians(dtype, compile_args, degree, cell_type, gdim):
     form = ufl.inner(ufl.div(u), ufl.div(v)) * ufl.dx
 
     forms = [form]
-    compiled_forms, module, _code = ffcx.codegeneration.jit.compile_forms(
-        forms,
-        options={"scalar_type": dtype, "do_cancel_jacobian_products": True},
-        cffi_extra_compile_args=compile_args,
-    )
-
-    A = np.zeros((rt.dim, rt.dim), dtype=dtype)
-    w = np.array([], dtype=dtype)
-    c = np.array([], dtype=dtype)
-
     xdtype = dtype_to_scalar_dtype(dtype)
     if cell_type == "triangle":
-        coords = np.array([[0.0, 0.0, 0.0], [2.0, 0.1, 0.0], [0.3, 1.1, 0.0]], dtype=xdtype)
+        coords = _triangle_coordinates(dtype)
     elif cell_type == "quadrilateral":
         coords = np.array(
             [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [-0.1, 1.3, 0.0], [1.2, 1.2, 0.0]], dtype=xdtype
@@ -68,57 +114,40 @@ def test_cancel_jacobians(dtype, compile_args, degree, cell_type, gdim):
     else:
         raise ValueError(f"Unsupported {cell_type=}")
 
-    c_type, c_xtype = dtype_to_c_type(dtype), dtype_to_c_type(xdtype)
-    ffi = module.ffi
-    form = compiled_forms[0]
-    default_integral = form.form_integrals[0]
-    kernel = getattr(default_integral, f"tabulate_tensor_{dtype}")
+    A = _tabulate_tensor(forms, (rt.dim, rt.dim), dtype, coords, compile_args)
+    A_ref = _tabulate_tensor(forms, (rt.dim, rt.dim), dtype, coords, compile_args, False)
+    _assert_tensors_equal(A, A_ref, dtype)
 
-    new_start = time.perf_counter()
-    kernel(
-        ffi.cast(f"{c_type} *", A.ctypes.data),
-        ffi.cast(f"{c_type} *", w.ctypes.data),
-        ffi.cast(f"{c_type} *", c.ctypes.data),
-        ffi.cast(f"{c_xtype} *", coords.ctypes.data),
-        ffi.NULL,
-        ffi.NULL,
-        ffi.NULL,
-    )
-    new_end = time.perf_counter()
 
-    old_compiled_forms, old_module, _code_old = ffcx.codegeneration.jit.compile_forms(
-        forms,
-        options={"scalar_type": dtype, "do_cancel_jacobian_products": False},
-        cffi_extra_compile_args=compile_args,
-    )
+@pytest.mark.parametrize("dtype", ["complex64", "complex128"])
+def test_cancel_jacobians_complex(dtype, compile_args):
+    """Test cancellation for complex-valued RT div-div kernels."""
+    domain = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 1, shape=(2,)))
+    rt = basix.ufl.element("Raviart-Thomas", "triangle", 3)
+    space = ufl.FunctionSpace(domain, rt)
+    u, v = ufl.TrialFunction(space), ufl.TestFunction(space)
+    form = ufl.inner(ufl.div(u), ufl.div(v)) * ufl.dx
 
-    A_ref = np.zeros((rt.dim, rt.dim), dtype=dtype)
+    coords = _triangle_coordinates(dtype)
+    A = _tabulate_tensor([form], (rt.dim, rt.dim), dtype, coords, compile_args)
+    A_ref = _tabulate_tensor([form], (rt.dim, rt.dim), dtype, coords, compile_args, False)
+    _assert_tensors_equal(A, A_ref, dtype)
 
-    c_type, c_xtype = dtype_to_c_type(dtype), dtype_to_c_type(xdtype)
-    ffi = old_module.ffi
-    form = old_compiled_forms[0]
-    default_integral = form.form_integrals[0]
-    kernel = getattr(default_integral, f"tabulate_tensor_{dtype}")
 
-    old_start = time.perf_counter()
-    kernel(
-        ffi.cast(f"{c_type} *", A_ref.ctypes.data),
-        ffi.cast(f"{c_type} *", w.ctypes.data),
-        ffi.cast(f"{c_type} *", c.ctypes.data),
-        ffi.cast(f"{c_xtype} *", coords.ctypes.data),
-        ffi.NULL,
-        ffi.NULL,
-        ffi.NULL,
-    )
-    old_end = time.perf_counter()
-    if dtype == "float32":
-        tol = 5e-4
-    elif dtype == "float64":
-        tol = 1e-12
-    else:
-        raise ValueError(f"Unsupported {dtype=}")
-    np.testing.assert_allclose(A, A_ref, rtol=tol, atol=tol)
+@pytest.mark.parametrize("dtype", ["float64", "complex128"])
+def test_cancel_both_jacobian_product_orders(dtype, compile_args):
+    """Test both J @ inv(J) and inv(J) @ J contractions."""
+    domain = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 1, shape=(2,)))
+    element = basix.ufl.element("Lagrange", "triangle", 1)
+    space = ufl.FunctionSpace(domain, element)
+    u, v = ufl.TrialFunction(space), ufl.TestFunction(space)
+    J = ufl.Jacobian(domain)
+    K = ufl.JacobianInverse(domain)
+    i, k = ufl.indices(2)
+    jacobian_products = J[i, k] * K[k, i] + K[i, k] * J[k, i]
+    form = jacobian_products * ufl.inner(u, v) * ufl.dx
 
-    print(f"Time with cancel_jacobian_products: {new_end - new_start:.6e} seconds")
-    print(f"Time without cancel_jacobian_products: {old_end - old_start:.6e} seconds")
-    print(f"Speedup: {(old_end - old_start) / (new_end - new_start):.5f}x")
+    coords = _triangle_coordinates(dtype)
+    A = _tabulate_tensor([form], (element.dim, element.dim), dtype, coords, compile_args)
+    A_ref = _tabulate_tensor([form], (element.dim, element.dim), dtype, coords, compile_args, False)
+    _assert_tensors_equal(A, A_ref, dtype)

--- a/test/test_cancel_jacobians.py
+++ b/test/test_cancel_jacobians.py
@@ -112,7 +112,7 @@ def test_cancel_jacobians(dtype, compile_args, degree, cell_type, gdim):
     )
     old_end = time.perf_counter()
     if dtype == "float32":
-        tol = 1e-5
+        tol = 5e-4
     elif dtype == "float64":
         tol = 1e-12
     else:

--- a/test/test_cancel_jacobians.py
+++ b/test/test_cancel_jacobians.py
@@ -22,10 +22,10 @@ from ffcx.codegeneration.utils import dtype_to_c_type, dtype_to_scalar_dtype
     [("triangle", 2), ("tetrahedron", 3), ("quadrilateral", 2), ("hexahedron", 3)],
 )
 def test_cancel_jacobians(dtype, compile_args, degree, cell_type, gdim):
-    basix.cell
     domain = ufl.Mesh(basix.ufl.element("Lagrange", cell_type, 1, shape=(gdim,)))
     rt = basix.ufl.element("Raviart-Thomas", cell_type, degree)
     space = ufl.FunctionSpace(domain, rt)
+
     u, v = ufl.TrialFunction(space), ufl.TestFunction(space)
     form = ufl.inner(ufl.div(u), ufl.div(v)) * ufl.dx
 
@@ -111,10 +111,13 @@ def test_cancel_jacobians(dtype, compile_args, degree, cell_type, gdim):
         ffi.NULL,
     )
     old_end = time.perf_counter()
-
-    np.testing.assert_allclose(
-        A, A_ref, rtol=np.finfo(dtype).eps * 1000, atol=np.finfo(dtype).eps * 1000
-    )
+    if dtype == "float32":
+        tol = 1e-5
+    elif dtype == "float64":
+        tol = 1e-12
+    else:
+        raise ValueError(f"Unsupported {dtype=}")
+    np.testing.assert_allclose(A, A_ref, rtol=tol, atol=tol)
 
     print(f"Time with cancel_jacobian_products: {new_end - new_start:.6e} seconds")
     print(f"Time without cancel_jacobian_products: {old_end - old_start:.6e} seconds")

--- a/test/test_cancel_jacobians.py
+++ b/test/test_cancel_jacobians.py
@@ -1,3 +1,5 @@
+import sys
+
 import basix.ufl
 import numpy as np
 import pytest
@@ -119,7 +121,27 @@ def test_cancel_jacobians(dtype, compile_args, degree, cell_type, gdim):
     _assert_tensors_equal(A, A_ref, dtype)
 
 
-@pytest.mark.parametrize("dtype", ["complex64", "complex128"])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(
+            "complex64",
+            marks=pytest.mark.xfail(
+                sys.platform.startswith("win32"),
+                raises=NotImplementedError,
+                reason="missing _Complex",
+            ),
+        ),
+        pytest.param(
+            "complex128",
+            marks=pytest.mark.xfail(
+                sys.platform.startswith("win32"),
+                raises=NotImplementedError,
+                reason="missing _Complex",
+            ),
+        ),
+    ],
+)
 def test_cancel_jacobians_complex(dtype, compile_args):
     """Test cancellation for complex-valued RT div-div kernels."""
     domain = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 1, shape=(2,)))
@@ -134,7 +156,20 @@ def test_cancel_jacobians_complex(dtype, compile_args):
     _assert_tensors_equal(A, A_ref, dtype)
 
 
-@pytest.mark.parametrize("dtype", ["float64", "complex128"])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float64",
+        pytest.param(
+            "complex128",
+            marks=pytest.mark.xfail(
+                sys.platform.startswith("win32"),
+                raises=NotImplementedError,
+                reason="missing _Complex",
+            ),
+        ),
+    ],
+)
 def test_cancel_both_jacobian_product_orders(dtype, compile_args):
     """Test both J @ inv(J) and inv(J) @ J contractions."""
     domain = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 1, shape=(2,)))

--- a/test/test_cancel_jacobians.py
+++ b/test/test_cancel_jacobians.py
@@ -1,0 +1,121 @@
+import time
+
+import basix.ufl
+import numpy as np
+import pytest
+import ufl
+
+import ffcx.codegeneration.jit
+from ffcx.codegeneration.utils import dtype_to_c_type, dtype_to_scalar_dtype
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "float32",
+        "float64",
+    ],
+)
+@pytest.mark.parametrize("degree", [1, 3, 5])
+@pytest.mark.parametrize(
+    "cell_type, gdim",
+    [("triangle", 2), ("tetrahedron", 3), ("quadrilateral", 2), ("hexahedron", 3)],
+)
+def test_cancel_jacobians(dtype, compile_args, degree, cell_type, gdim):
+    basix.cell
+    domain = ufl.Mesh(basix.ufl.element("Lagrange", cell_type, 1, shape=(gdim,)))
+    rt = basix.ufl.element("Raviart-Thomas", cell_type, degree)
+    space = ufl.FunctionSpace(domain, rt)
+    u, v = ufl.TrialFunction(space), ufl.TestFunction(space)
+    form = ufl.inner(ufl.div(u), ufl.div(v)) * ufl.dx
+
+    forms = [form]
+    compiled_forms, module, _code = ffcx.codegeneration.jit.compile_forms(
+        forms,
+        options={"scalar_type": dtype, "do_cancel_jacobian_products": True},
+        cffi_extra_compile_args=compile_args,
+    )
+
+    A = np.zeros((rt.dim, rt.dim), dtype=dtype)
+    w = np.array([], dtype=dtype)
+    c = np.array([], dtype=dtype)
+
+    xdtype = dtype_to_scalar_dtype(dtype)
+    if cell_type == "triangle":
+        coords = np.array([[0.0, 0.0, 0.0], [2.0, 0.1, 0.0], [0.3, 1.1, 0.0]], dtype=xdtype)
+    elif cell_type == "quadrilateral":
+        coords = np.array(
+            [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [-0.1, 1.3, 0.0], [1.2, 1.2, 0.0]], dtype=xdtype
+        )
+    elif cell_type == "tetrahedron":
+        coords = np.array(
+            [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [-0.1, -0.2, 0.8]], dtype=xdtype
+        )
+    elif cell_type == "hexahedron":
+        coords = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.1, 0.0, 0.0],
+                [0.0, 0.9, 0.0],
+                [1.2, 1.1, 0.0],
+                [0.0, 0.0, 0.8],
+                [1.0, 0.0, 1.0],
+                [0.0, 1.0, 1.0],
+                [1.0, 1.0, 1.0],
+            ],
+            dtype=xdtype,
+        )
+    else:
+        raise ValueError(f"Unsupported {cell_type=}")
+
+    c_type, c_xtype = dtype_to_c_type(dtype), dtype_to_c_type(xdtype)
+    ffi = module.ffi
+    form = compiled_forms[0]
+    default_integral = form.form_integrals[0]
+    kernel = getattr(default_integral, f"tabulate_tensor_{dtype}")
+
+    new_start = time.perf_counter()
+    kernel(
+        ffi.cast(f"{c_type} *", A.ctypes.data),
+        ffi.cast(f"{c_type} *", w.ctypes.data),
+        ffi.cast(f"{c_type} *", c.ctypes.data),
+        ffi.cast(f"{c_xtype} *", coords.ctypes.data),
+        ffi.NULL,
+        ffi.NULL,
+        ffi.NULL,
+    )
+    new_end = time.perf_counter()
+
+    old_compiled_forms, old_module, _code_old = ffcx.codegeneration.jit.compile_forms(
+        forms,
+        options={"scalar_type": dtype, "do_cancel_jacobian_products": False},
+        cffi_extra_compile_args=compile_args,
+    )
+
+    A_ref = np.zeros((rt.dim, rt.dim), dtype=dtype)
+
+    c_type, c_xtype = dtype_to_c_type(dtype), dtype_to_c_type(xdtype)
+    ffi = old_module.ffi
+    form = old_compiled_forms[0]
+    default_integral = form.form_integrals[0]
+    kernel = getattr(default_integral, f"tabulate_tensor_{dtype}")
+
+    old_start = time.perf_counter()
+    kernel(
+        ffi.cast(f"{c_type} *", A_ref.ctypes.data),
+        ffi.cast(f"{c_type} *", w.ctypes.data),
+        ffi.cast(f"{c_type} *", c.ctypes.data),
+        ffi.cast(f"{c_xtype} *", coords.ctypes.data),
+        ffi.NULL,
+        ffi.NULL,
+        ffi.NULL,
+    )
+    old_end = time.perf_counter()
+
+    np.testing.assert_allclose(
+        A, A_ref, rtol=np.finfo(dtype).eps * 1000, atol=np.finfo(dtype).eps * 1000
+    )
+
+    print(f"Time with cancel_jacobian_products: {new_end - new_start:.6e} seconds")
+    print(f"Time without cancel_jacobian_products: {old_end - old_start:.6e} seconds")
+    print(f"Speedup: {(old_end - old_start) / (new_end - new_start):.5f}x")


### PR DESCRIPTION
option from https://github.com/FEniCS/ufl/pull/496 to check that we get the same matrices for a div-div operator on RT. For higher order elements this really matters.
I think we should always have this option on, as it should accumulate less floating point errors (then this PR can be simplified to simply setting it to true in compute_form_data).

For the temporary test to check for correctness, we can't do a floating-point tolerance equivalence, as there is some accumulation when calling J @ (J^-1)