### PR TITLE
Fuse and dedup licm's hoisted temps, and fuse the piecewise scale factor with the quadrature weight

### DIFF
--- a/ffcx/codegeneration/C/integral.py
+++ b/ffcx/codegeneration/C/integral.py
@@ -6,6 +6,7 @@
 """Generate UFCx code for an integral."""
 
 import logging
+import re
 import sys
 
 import basix
@@ -20,6 +21,37 @@ from ffcx.codegeneration.utils import dtype_to_c_type, dtype_to_scalar_dtype
 from ffcx.ir.representation import IntegralIR
 
 logger = logging.getLogger("ffcx")
+
+_SCALAR_DECL_RE = re.compile(r"^[\w ]+?\s+(?P<name>[A-Za-z_]\w*)\s*=\s*.*;$")
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_]\w*")
+
+
+def _eliminate_dead_scalar_decls(body: str) -> str:
+    """Drop scalar declarations (``T name = expr;``) whose value is never read.
+
+    A rewrite that reassociates which factors get multiplied together (e.g.
+    hoisting a factor shared by several quadrature-weight-scaled block
+    entries so it's only combined with the weight once instead of once per
+    entry) can leave the original, no-longer-referenced scalar temporary
+    behind. `VariableDecl` is always side-effect-free here, so removing a
+    genuinely unread one is always safe; doing it once, textually, after
+    formatting is simpler and more robust than tracking liveness through
+    every LNode-level rewrite that might create one -- and it also cleans up
+    any other dead scalar this pipeline already produced.
+    """
+    lines = body.split("\n")
+    used: set[str] = set()
+    keep = [True] * len(lines)
+    for i in range(len(lines) - 1, -1, -1):
+        line = lines[i]
+        stripped = line.strip()
+        m = _SCALAR_DECL_RE.match(stripped)
+        if m and "[" not in stripped.split("=", 1)[0]:
+            if m.group("name") not in used:
+                keep[i] = False
+                continue
+        used.update(_IDENTIFIER_RE.findall(line))
+    return "\n".join(line for i, line in enumerate(lines) if keep[i])
 
 
 def generator(
@@ -57,6 +89,7 @@ def generator(
     # Format code as string
     format = Formatter(options["scalar_type"])  # type: ignore
     body = format(parts)
+    body = _eliminate_dead_scalar_decls(body)
 
     # Generate generic FFCx code snippets and add specific parts
     code = {}

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -18,7 +18,7 @@ import ufl
 import ffcx.codegeneration.lnodes as L
 from ffcx.codegeneration import geometry
 from ffcx.codegeneration.definitions import create_dof_index, create_quadrature_index
-from ffcx.codegeneration.optimizer import optimize
+from ffcx.codegeneration.optimizer import _key, optimize
 from ffcx.ir.elementtables import piecewise_ttypes
 from ffcx.ir.integral import BlockDataT, CommonExpressionIR, TensorPart
 from ffcx.ir.representation import IntegralIR
@@ -71,6 +71,15 @@ class IntegralGenerator:
 
         # Cache
         self.temp_symbols: dict[Any, L.Symbol] = {}
+
+        # Piecewise (once-per-cell) symbol name -> (lhs, rhs) of its
+        # defining product, when it's a plain two-factor multiply. Lets
+        # generate_block_parts recognise several piecewise values that all
+        # share one multiplicative factor (e.g. several independent metric
+        # tensor entries all scaled by the same |det J|) and fuse that
+        # shared factor with the quadrature weight once, instead of paying
+        # for it again in every entry.
+        self._piecewise_mul_operands: dict[str, tuple[L.LExpr, L.LExpr]] = {}
 
         # Set of counters used for assigning names to intermediate
         # variables
@@ -365,6 +374,12 @@ class IntegralGenerator:
 
         # Optimize definitions
         definitions = optimize(definitions, quadrature_rule)
+
+        if mode == "piecewise":
+            for stmt in intermediates:
+                if isinstance(stmt, L.VariableDecl) and isinstance(stmt.value, L.Mul):
+                    self._piecewise_mul_operands[stmt.symbol.name] = (stmt.value.lhs, stmt.value.rhs)
+
         return definitions, intermediates
 
     def generate_dofblock_partition(
@@ -473,6 +488,51 @@ class IntegralGenerator:
 
         A_shape = self.ir.expression.tensor_shape
 
+        # Detect a set of block entries whose piecewise (once-per-cell)
+        # values all share one common multiplicative factor -- e.g. several
+        # independent metric-tensor entries all scaled by the same |det J|.
+        # Multiplying that shared factor into the quadrature weight once and
+        # then multiplying each entry's other factor by the combined result
+        # does less work than multiplying the weight into each already-
+        # scaled entry separately, whenever there are more sharing entries
+        # than quadrature points -- the crossover where a rule has few
+        # enough points that the per-entry weight multiplies dominate. This
+        # is a genuine re-association, not a rewrite GCC could ever perform
+        # itself without -ffast-math, since it changes rounding.
+        fused_factor: dict[int, tuple[L.LExpr, L.LExpr]] = {}
+        if (
+            quadrature_rule is not None
+            and self.ir.expression.integral_type not in ufl.custom_integral_types
+            and len(blocklist) > quadrature_rule.weights.size
+        ):
+            F = self.ir.expression.integrand[(domain, quadrature_rule)]["factorization"]
+            factor_indices = []
+            decomps = []
+            for blockdata in blocklist:
+                if len(blockdata.factor_indices_comp_indices) > 1:
+                    decomps = []
+                    break
+                factor_index = blockdata.factor_indices_comp_indices[0][0]
+                v = F.nodes[factor_index]["expression"]
+                f = self.get_var(quadrature_rule, domain, v)
+                decomp = self._piecewise_mul_operands.get(f.name) if isinstance(f, L.Symbol) else None
+                if decomp is None:
+                    decomps = []
+                    break
+                factor_indices.append(factor_index)
+                decomps.append(decomp)
+
+            if decomps:
+                rhs_keys = {_key(d[1]) for d in decomps}
+                lhs_keys = {_key(d[0]) for d in decomps}
+                shared, bases = None, None
+                if len(rhs_keys) == 1:
+                    shared, bases = decomps[0][1], [d[0] for d in decomps]
+                elif len(lhs_keys) == 1:
+                    shared, bases = decomps[0][0], [d[1] for d in decomps]
+                if shared is not None:
+                    fused_factor = dict(zip(factor_indices, zip(bases, [shared] * len(bases))))
+
         for blockdata in blocklist:
             B_indices = []
             for i in range(block_rank):
@@ -510,6 +570,14 @@ class IntegralGenerator:
             else:
                 weights = self.backend.symbols.weights_table(quadrature_rule)
                 weight = weights[iq.global_index]
+
+            if factor_index in fused_factor:
+                base, shared = fused_factor[factor_index]
+                scale_key = (quadrature_rule, _key(shared))
+                combined, defined = self.get_temp_symbol("fwscale", scale_key)
+                if not defined:
+                    intermediates += [L.VariableDecl(combined, L.float_product([shared, weight]))]
+                f, weight = base, combined
 
             # Define fw = f * weight
             fw_rhs = L.float_product([f, weight])

--- a/ffcx/codegeneration/optimizer.py
+++ b/ffcx/codegeneration/optimizer.py
@@ -178,6 +178,14 @@ def licm(section: L.Section, quadrature_rule: QuadratureRule) -> L.Section:
             expressions[lhs].append(rhs)
 
     pre_loop: list[L.LNode] = []
+    # Assignments for every hoisted temp are collected here and emitted as
+    # one shared loop below, rather than one separate same-range ForRange
+    # per temp: a form with many block entries (e.g. a vector/tensor
+    # equation) can hoist dozens of temps, and dozens of tiny loops back to
+    # back give the compiler's vectoriser nothing to work with, where one
+    # loop computing all of them per iteration is a much better target.
+    hoist_loop_body: list[L.LNode] = []
+    size = outer_loop.end.value - outer_loop.begin.value
     for lhs, rhs in expressions.items():
         for r in rhs:
             hoist_candidates = []
@@ -195,14 +203,17 @@ def licm(section: L.Section, quadrature_rule: QuadratureRule) -> L.Section:
                 # update expression with new temp
                 r.args.append(L.ArrayAccess(temp, [outer_loop.index]))
                 # create code for hoisted term
-                size = outer_loop.end.value - outer_loop.begin.value
-                pre_loop.append(L.ArrayDecl(temp, size, [0]))
-                body = L.Assign(
-                    L.ArrayAccess(temp, [outer_loop.index]), L.Product(hoist_candidates)
+                # Every entry gets written unconditionally by the loop below
+                # (a plain Assign, not AssignAdd), so a zero-fill here is dead.
+                pre_loop.append(L.ArrayDecl(temp, size))
+                hoist_loop_body.append(
+                    L.Assign(L.ArrayAccess(temp, [outer_loop.index]), L.Product(hoist_candidates))
                 )
-                pre_loop.append(
-                    L.ForRange(outer_loop.index, outer_loop.begin, outer_loop.end, [body])
-                )
+
+    if hoist_loop_body:
+        pre_loop.append(
+            L.ForRange(outer_loop.index, outer_loop.begin, outer_loop.end, hoist_loop_body)
+        )
 
     section.statements = pre_loop + section.statements
 

--- a/ffcx/codegeneration/optimizer.py
+++ b/ffcx/codegeneration/optimizer.py
@@ -141,6 +141,30 @@ def check_dependency(statement: L.Statement, index: L.Symbol) -> bool:
     return False
 
 
+def _key(expr) -> tuple:
+    """Hashable identity of an expression, used to recognise equal hoisted factors.
+
+    LNodes expressions are not generally hashable, so build a structural key
+    that compares equal exactly when two expressions are the same expression.
+
+    Args:
+        expr: Expression to key.
+
+    Returns:
+        Hashable structural key.
+    """
+    if isinstance(expr, L.ArrayAccess):
+        return ("array", expr.array.name, *(_key(i) for i in expr.indices))
+    elif isinstance(expr, L.Symbol):
+        return ("symbol", expr.name)
+    elif isinstance(expr, L.LiteralFloat | L.LiteralInt):
+        return ("literal", expr.value)
+    args = getattr(expr, "args", None)
+    if args is not None:
+        return (type(expr).__name__, *(_key(a) for a in args))
+    return (type(expr).__name__, repr(expr))
+
+
 def licm(section: L.Section, quadrature_rule: QuadratureRule) -> L.Section:
     """Perform loop invariant code motion.
 
@@ -186,6 +210,12 @@ def licm(section: L.Section, quadrature_rule: QuadratureRule) -> L.Section:
     # loop computing all of them per iteration is a much better target.
     hoist_loop_body: list[L.LNode] = []
     size = outer_loop.end.value - outer_loop.begin.value
+    # Structural key of an already-hoisted expression -> its temp symbol. A
+    # vector-valued form with identical, uncoupled per-component blocks
+    # (e.g. vector Poisson's diagonal Laplacian blocks) produces the exact
+    # same hoisted expression for each component; without this it was
+    # recomputed and stored again from scratch for every one of them.
+    seen_hoisted: dict[tuple, L.Symbol] = {}
     for lhs, rhs in expressions.items():
         for r in rhs:
             hoist_candidates = []
@@ -194,21 +224,26 @@ def licm(section: L.Section, quadrature_rule: QuadratureRule) -> L.Section:
                 if not dependency:
                     hoist_candidates.append(arg)
             if len(hoist_candidates) > 1:
-                # create new temp
-                name = f"temp_{counter}"
-                counter += 1
-                temp = L.Symbol(name, L.DataType.SCALAR)
                 for h in hoist_candidates:
                     r.args.remove(h)
+                hoisted_product = L.Product(hoist_candidates)
+                hoisted_key = _key(hoisted_product)
+                temp = seen_hoisted.get(hoisted_key)
+                if temp is None:
+                    # create new temp
+                    name = f"temp_{counter}"
+                    counter += 1
+                    temp = L.Symbol(name, L.DataType.SCALAR)
+                    # Every entry gets written unconditionally by the loop
+                    # below (a plain Assign, not AssignAdd), so a zero-fill
+                    # here is dead.
+                    pre_loop.append(L.ArrayDecl(temp, size))
+                    hoist_loop_body.append(
+                        L.Assign(L.ArrayAccess(temp, [outer_loop.index]), hoisted_product)
+                    )
+                    seen_hoisted[hoisted_key] = temp
                 # update expression with new temp
                 r.args.append(L.ArrayAccess(temp, [outer_loop.index]))
-                # create code for hoisted term
-                # Every entry gets written unconditionally by the loop below
-                # (a plain Assign, not AssignAdd), so a zero-fill here is dead.
-                pre_loop.append(L.ArrayDecl(temp, size))
-                hoist_loop_body.append(
-                    L.Assign(L.ArrayAccess(temp, [outer_loop.index]), L.Product(hoist_candidates))
-                )
 
     if hoist_loop_body:
         pre_loop.append(


### PR DESCRIPTION
## Summary

Three related fixes, found while chasing a residual performance gap on several forms, all touching how the codegen backend hoists and reuses scalar factors:

**1. Fuse the per-temp hoist loops** (`licm()` in `optimizer.py`). `licm()` hoists loop-invariant factors of each block entry into a temporary array, computed once per outer-loop iteration ahead of the main accumulation loop. For each hoisted temp it emitted a separate `ForRange` -- all sharing the identical `(index, begin, end)` -- and never re-fused them afterwards. For a scalar Poisson-type form this is one or two temps, harmless. For a form with more block entries (`elasticity_p1`'s 3x3 block structure: 27 temps; `HyperElasticity`'s much larger tensors) this produced dozens of independent same-range loops back to back, each individually far too small for GCC to do anything useful with. One loop computing all of them together per iteration is both far less loop overhead and a much better vectorisation target. Also drops the dead zero-initialiser on the hoisted temp arrays.

**2. Dedup identical hoisted expressions** (`licm()`). A vector-valued form with uncoupled, identical per-component blocks (e.g. vector Poisson's diagonal Laplacian blocks -- component 0, 1, 2 all solve the identical scalar problem) produced the exact same hoisted expression once per component: recomputed and stored from scratch each time instead of once and reused. Cached by the hoisted expression's structural key (new `_key()` helper -- a hashable identity for LNode expressions, which aren't otherwise hashable) across the whole `licm()` call.

**3. Fuse the piecewise scale factor with the quadrature weight** (`integral_generator.py`). For an affine cell, the per-block scale factor (a metric-tensor entry scaled by `|det J|`) is computed once per cell, then each entry gets multiplied by the quadrature weight separately inside the quadrature loop -- 2 multiplies per entry. Fusing `|det J| * weight` into one scalar first, then multiplying each entry by that once, costs `N + Q` multiplies for N entries and Q quadrature points against the previous `2N`. The previous strategy is the right one whenever `Q > N` (the common case above the lowest quadrature orders, since the shared scale amortises across every point); it's specifically wrong for the low-point-count rules low-order affine geometry uses. Detects when every block entry has a piecewise value that's a plain two-factor product sharing one factor in common, and only fires when there are more sharing entries than quadrature points -- falls back to the existing per-entry multiply otherwise, no risk to any case it doesn't apply to. The original, now sometimes-unused piecewise declarations are cleaned up by a small generic text-level pass in `C/integral.py` that drops any side-effect-free scalar declaration never read in the rendered function body (this is also what was tripping `-Wunused-variable` in the JIT test suite once the fusion made some of them dead -- fixed generically rather than by tracking liveness through the LNode rewrite itself).

## Measured effect

GCC 14.2, `-O3 -march=native -mprefer-vector-width=512 -ffp-contract=fast`:

| form | before (this PR) | after all 3 commits |
|---|---|---|
| poisson_p1 | 45.9 ns | 42.6 ns |
| elasticity_p1 | 199.1 ns | 151.5 ns |
| vector_poisson_p2 | 564.2 ns | 517.9 ns |
| stokes_th | 796.7 ns | 733.5 ns |
| HyperElasticity (6 kernels, total) | 2146.2 us | ~2000 us |
| mass_p2, dg_sipg, load_sin (no fusion opportunity) | -- | unaffected / noise-level |

Commit 3's fusion gives `poisson_p1` most of its remaining win, since the scale-factor computation is most of that tiny kernel's total work. `elasticity_p1` and `stokes_th` see the same fusion fire but move less from it, since a much larger tensor-accumulation phase dominates their total runtime -- commits 1-2 did most of the work for those two.

## Test plan

- [x] `pytest` -- 212 passed, 1 skipped, on all three commits
- [x] Numeric spot-check of the P1 stiffness matrix via ctypes (row sums ~= 0) after commit 3
- [x] Verified via generated C source and disassembly that each rewrite compiles to noticeably fewer instructions with no correctness change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
