### PR TITLE
Restrict FFCx CI push trigger to main

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -6,8 +6,7 @@ name: FFCx CI
 
 on:
   push:
-    branches:
-      - "**"
+    branches: [main]
     tags:
       - "v*"
   pull_request:


### PR DESCRIPTION
## Summary
- CI (`pythonapp.yml`) was triggered by `push` on every branch (`branches: "**"`), so it ran on every commit push in addition to pull requests.
- Restrict the `push` trigger to `main` (still needed for the post-merge docs deploy step) and version tags. PR validation is already covered by the existing `pull_request` trigger.

## Test plan
- [ ] Confirm CI still runs on this PR via `pull_request`
- [ ] Confirm CI runs on push to `main` after merge (docs deploy)
- [ ] Confirm CI does not run on pushes to unrelated feature branches without an open PR