### PR TITLE
Retry basix wheel build on Windows CI to work around transient file-lock error

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -83,7 +83,14 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           pip install git+https://github.com/${{ env.ufl_repository }}.git@${{ env.ufl_ref }}
-          pip install -v git+https://github.com/${{ env.basix_repository }}.git@${{ env.basix_ref }} --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          $maxAttempts = 3
+          for ($i = 1; $i -le $maxAttempts; $i++) {
+            pip install -v git+https://github.com/${{ env.basix_repository }}.git@${{ env.basix_ref }} --config-settings=cmake.args=-DINSTALL_RUNTIME_DEPENDENCIES=ON --config-settings=cmake.args=-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($i -eq $maxAttempts) { exit $LASTEXITCODE }
+            Write-Host "basix build failed (attempt $i/$maxAttempts), likely a transient Windows file-lock error during wheel build cleanup. Retrying..."
+            Start-Sleep -Seconds 10
+          }
 
       - name: Install FFCx (Linux, with optional dependencies)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- `pip install` of `fenics-basix` on Windows CI runners intermittently fails with a `PermissionError` during `scikit-build-core`'s temp-build-directory cleanup, even though the wheel itself built successfully (a file is briefly held by another process, e.g. AV scanning).
- Retries the basix install up to 3 times (10s backoff) to ride out this flake.

Fixes the failure seen at https://github.com/FEniCS/ffcx/actions/runs/33213020815/job/98990381126?pr=858 (unrelated to that PR's actual code changes).

## Test plan
- [ ] Windows CI job passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)