### PR TITLE
Use netlib BLAS in Spack-based CI workflow

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: "0 8 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/spack-config/gh-actions-env.yml
+++ b/.github/workflows/spack-config/gh-actions-env.yml
@@ -20,6 +20,13 @@ spack:
       require:
       - target=x86_64_v3
 
+      # Use netlib-lapack for blas/lapack: it is a much smaller/faster
+      # build than openblas, and CI only needs correctness, not
+      # performance.
+      providers:
+        blas: [netlib-lapack]
+        lapack: [netlib-lapack]
+
     # Use the container's mesa instead of building one. mesa@25.0.5 (the
     # newest version the pinned packages_ref knows) does not compile
     # against Ubuntu 26.04's glibc -- its bundled C11 threads polyfill


### PR DESCRIPTION
## Summary
- Pin the `blas`/`lapack` virtual package providers to `netlib-lapack` in the Spack environment used by the DOLFINx integration workflow, instead of the default `openblas`.
- netlib-lapack builds much faster than openblas and CI only needs correctness, not performance.

## Test plan
- [ ] DOLFINx integration workflow (`dolfinx.yml`) runs green with the new Spack environment config.