### PR TITLE
Fix NuGet credentials so the Windows vcpkg binary cache actually works

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -47,7 +47,7 @@ jobs:
             -Source "${{ env.FEED_URL }}" `
             -StorePasswordInClearText `
             -Name GitHubPackages `
-            -UserName "${{ env.USERNAME }}" `
+            -UserName "${{ github.actor }}" `
             -Password "${{ secrets.GITHUB_TOKEN }}"
           .$(${{ env.VCPKG_EXE }} fetch nuget) `
             setapikey "${{ secrets.GITHUB_TOKEN }}" `


### PR DESCRIPTION
The "Add NuGet sources" step passed -UserName "${{ env.USERNAME }}", but USERNAME was never set in the workflow env, so it resolved to an empty string. nuget.exe then refused to add the source at all ("Both UserName and Password must be specified"), meaning no credentials were ever stored for the GitHub Packages feed.

As a result, every vcpkg buildcache push later in the job silently failed (falling back to an interactive credential prompt that errors out in CI), so the cache was never populated. Every Windows matrix job rebuilt OpenBLAS, LAPACK, and the gfortran/MinGW toolchain from source via vcpkg on every run, costing 13-16 minutes per Python version in the "Install FEniCS dependencies (Python, Windows)" step.