### PR TITLE
Stack codegen performance fixes: quadrature-loop split, tensor contraction, CSE, coordinate unrolling, LICM fusion

### DIFF
--- a/.github/workflows/spack-config/gh-actions-env.yml
+++ b/.github/workflows/spack-config/gh-actions-env.yml
@@ -11,21 +11,15 @@ spack:
 
   packages:
     all:
-      # Pin to the generic microarchitecture the shared GitHub Actions
-      # build cache (added by spack/setup-spack) and our own
-      # local-buildcache are built for. Without this, concretization picks
-      # the runner's exact detected microarch, which does not match the
-      # cache's hashes, so every package (including LLVM, for numba)
-      # rebuilds from source instead of being pulled as a binary.
       require:
       - target=x86_64_v3
 
-      # Use netlib-lapack for blas/lapack: it is a much smaller/faster
-      # build than openblas, and CI only needs correctness, not
-      # performance.
-      providers:
-        blas: [netlib-lapack]
-        lapack: [netlib-lapack]
+    blas:
+      require:
+      - netlib-lapack
+    lapack:
+      require:
+      - netlib-lapack
 
     # Use the container's mesa instead of building one. mesa@25.0.5 (the
     # newest version the pinned packages_ref knows) does not compile

--- a/ffcx/codegeneration/C/formatter.py
+++ b/ffcx/codegeneration/C/formatter.py
@@ -249,9 +249,11 @@ class Formatter(FormatterInterface):
     @__call__.register
     def _(self, v: L.VariableDecl) -> str:
         """Format a variable declaration."""
-        val = self(v.value)
         symbol = self(v.symbol)
         typename = self._dtype_to_name(v.symbol.dtype)
+        if v.value is None:
+            return f"{typename} {symbol};\n"
+        val = self(v.value)
         return f"{typename} {symbol} = {val};\n"
 
     @__call__.register

--- a/ffcx/codegeneration/definitions.py
+++ b/ffcx/codegeneration/definitions.py
@@ -18,6 +18,16 @@ from ffcx.ir.representationutils import QuadratureRule
 logger = logging.getLogger("ffcx")
 
 
+# Cap on unrolling, so a curved high-order simplex doesn't blow up compile
+# time. Tensor-product geometry always keeps the loop path regardless.
+_MAX_UNROLLED_COORDINATE_DOFS = 16
+
+
+def _should_unroll_coordinate_dofs(num_dofs: int, has_tensor_factorisation: bool) -> bool:
+    """Return whether a coordinate-dof linear combination should be unrolled."""
+    return not has_tensor_factorisation and num_dofs <= _MAX_UNROLLED_COORDINATE_DOFS
+
+
 def create_quadrature_index(quadrature_rule, quadrature_index_symbol):
     """Create a multi index for the quadrature loop."""
     ranges = [0]
@@ -186,6 +196,7 @@ class FFCXBackendDefinitions:
 
         num_dofs = tabledata.values.shape[3]
         begin = tabledata.offset
+        assert begin is not None
 
         assert num_scalar_dofs == num_dofs
 
@@ -198,9 +209,7 @@ class FFCXBackendDefinitions:
         # Get access to element table
         ic_symbol = self.symbols.coefficient_dof_sum_index
         iq_symbol = self.symbols.quadrature_loop_index
-        ic = create_dof_index(tabledata, ic_symbol)
         iq = create_quadrature_index(quadrature_rule, iq_symbol)
-        FE, tables = self.access.table_access(tabledata, self.entity_type, mt.restriction, iq, ic)
 
         dof_access = L.Symbol("coordinate_dofs", dtype=L.DataType.REAL)
 
@@ -210,14 +219,41 @@ class FFCXBackendDefinitions:
         if mt.restriction == "-":
             offset = num_scalar_dofs * dim
 
-        code = []
-        declaration = [L.VariableDecl(access, 0.0)]
-        body = [L.AssignAdd(access, dof_access[ic.global_index * dim + begin + offset] * FE)]
-        code = [L.create_nested_for_loops([ic], body)]
+        if not _should_unroll_coordinate_dofs(num_dofs, tabledata.has_tensor_factorisation):
+            # Many coordinate dofs: keep the runtime loop instead of one
+            # literal term per dof.
+            ic = create_dof_index(tabledata, ic_symbol)
+            FE, tables = self.access.table_access(
+                tabledata, self.entity_type, mt.restriction, iq, ic
+            )
+            code = []
+            declaration = [L.VariableDecl(access, 0.0)]
+            body = [L.AssignAdd(access, dof_access[ic.global_index * dim + begin + offset] * FE)]
+            code = [L.create_nested_for_loops([ic], body)]
+            input = [dof_access, *tables]
+        else:
+            # Few dofs: emit a single literal-indexed sum instead of a
+            # runtime loop. This avoids GCC's vectoriser mis-vectorising a
+            # tiny fixed-trip-count reduction into an expensive
+            # permute-then-horizontal-sum sequence, and lets the table's
+            # exact 0.0/+-1.0 low-order values constant-fold away.
+            terms = []
+            coord_tables: list[L.Symbol] = []
+            for k in range(num_dofs):
+                ic_k = L.MultiIndex([L.LiteralInt(k)], [num_dofs])
+                FE_k, tables_k = self.access.table_access(
+                    tabledata, self.entity_type, mt.restriction, iq, ic_k
+                )
+                for t in tables_k:
+                    if t not in coord_tables:
+                        coord_tables.append(t)
+                terms.append(dof_access[k * dim + begin + offset] * FE_k)
+            declaration = [L.VariableDecl(access, L.Sum(terms))]
+            code = []
+            input = [dof_access, *coord_tables]
 
         name = type(mt.terminal).__name__
         output = [access]
-        input = [dof_access, *tables]
         annotations = [L.Annotation.fuse]
 
         # assert input and output are Symbol objects

--- a/ffcx/codegeneration/integral_generator.py
+++ b/ffcx/codegeneration/integral_generator.py
@@ -9,6 +9,8 @@
 
 import collections
 import logging
+import platform
+import sys
 from numbers import Integral
 from typing import Any
 
@@ -18,13 +20,68 @@ import ufl
 import ffcx.codegeneration.lnodes as L
 from ffcx.codegeneration import geometry
 from ffcx.codegeneration.definitions import create_dof_index, create_quadrature_index
-from ffcx.codegeneration.optimizer import optimize
+from ffcx.codegeneration.optimizer import (
+    expr_key,
+    optimize,
+    power_of_two_cse_statements,
+    prune_dead_scalars,
+    reciprocal_cse_statements,
+    scalar_declaration_names,
+)
 from ffcx.ir.elementtables import piecewise_ttypes
 from ffcx.ir.integral import BlockDataT, CommonExpressionIR, TensorPart
 from ffcx.ir.representation import IntegralIR
 from ffcx.ir.representationutils import QuadratureRule
 
 logger = logging.getLogger("ffcx")
+
+
+_FW_CACHE_BUDGET_BYTES = 32768
+_FW_CACHE_BYTES_PER_SCALAR = 16
+_UNSUPPORTED_VECTOR_MATH_MIN_CONTRACTION_WORK = 256
+
+# GCC can lower these calls to glibc libmvec on supported x86-64 Linux
+# targets. Other hosts commonly keep scalar libm calls, in which case a
+# second loop and an fw cache are pure overhead.
+_VECTORIZABLE_MATH_FUNCTIONS = frozenset(
+    {
+        "acos",
+        "acosh",
+        "asin",
+        "asinh",
+        "atan",
+        "atanh",
+        "cos",
+        "cosh",
+        "erf",
+        "exp",
+        "ln",
+        "sin",
+        "sinh",
+        "tan",
+        "tanh",
+    }
+)
+
+
+def _fw_cache_tile_size(n_fw: int, num_points: int) -> int | None:
+    """Return a cache-tile length that stays within the fixed stack budget.
+
+    ``None`` means that even one cached value per intermediate would exceed
+    the budget, so the quadrature loop should remain fused.
+    """
+    assert n_fw > 0
+    assert num_points > 0
+
+    max_tile = _FW_CACHE_BUDGET_BYTES // (n_fw * _FW_CACHE_BYTES_PER_SCALAR)
+    if max_tile == 0:
+        return None
+
+    tile = min(max_tile, num_points)
+    # Round down to a SIMD-friendly width when it still fits the budget.
+    if tile >= 8:
+        tile = tile // 8 * 8
+    return tile
 
 
 def extract_dtype(v, vops: list[Any]):
@@ -46,6 +103,53 @@ def extract_dtype(v, vops: list[Any]):
     if is_real:
         return L.DataType.REAL
     return L.merge_dtypes(dtypes)
+
+
+def _contains_vectorizable_mathfunction(node) -> bool:
+    """Return whether *node* contains a math call targeted by libmvec."""
+    if isinstance(node, list):
+        return any(_contains_vectorizable_mathfunction(n) for n in node)
+    if isinstance(node, L.MathFunction):
+        return node.function in _VECTORIZABLE_MATH_FUNCTIONS or any(
+            _contains_vectorizable_mathfunction(arg) for arg in node.args
+        )
+    if isinstance(node, (L.StatementList, L.Section)):
+        return _contains_vectorizable_mathfunction(node.statements)
+    if isinstance(node, L.ForRange):
+        return _contains_vectorizable_mathfunction(node.body)
+    if isinstance(node, L.VariableDecl):
+        return node.value is not None and _contains_vectorizable_mathfunction(node.value)
+    if isinstance(node, (L.ArrayDecl, L.Comment)):
+        return False
+    if isinstance(node, L.Statement):
+        return _contains_vectorizable_mathfunction(node.expr)
+    if isinstance(node, L.NaryOp):
+        return any(_contains_vectorizable_mathfunction(a) for a in node.args)
+    if isinstance(node, L.BinOp):
+        return _contains_vectorizable_mathfunction(node.lhs) or _contains_vectorizable_mathfunction(
+            node.rhs
+        )
+    if isinstance(node, L.PrefixUnaryOp):
+        return _contains_vectorizable_mathfunction(node.arg)
+    return False
+
+
+def _supports_vector_math_loop_split() -> bool:
+    """Return whether the current JIT host has the required vector libm ABI."""
+    return sys.platform.startswith("linux") and platform.machine().lower() in {"amd64", "x86_64"}
+
+
+def _contraction_work(node) -> int:
+    """Estimate statically repeated scalar statements in a contraction tree."""
+    if isinstance(node, list):
+        return sum(_contraction_work(child) for child in node)
+    if isinstance(node, (L.Section, L.StatementList)):
+        return _contraction_work(node.statements)
+    if isinstance(node, L.ForRange):
+        if not isinstance(node.begin, L.LiteralInt) or not isinstance(node.end, L.LiteralInt):
+            return 0
+        return int(max(0, node.end.value - node.begin.value)) * _contraction_work(node.body)
+    return int(isinstance(node, L.Statement))
 
 
 class IntegralGenerator:
@@ -71,6 +175,12 @@ class IntegralGenerator:
 
         # Cache
         self.temp_symbols: dict[Any, L.Symbol] = {}
+
+        # Piecewise symbol name -> (lhs, rhs) of its defining two-factor
+        # product, if any. Lets generate_block_parts spot several block
+        # entries sharing one factor (e.g. several metric-tensor entries all
+        # scaled by |det J|) and fuse it with the quadrature weight once.
+        self._piecewise_mul_operands: dict[str, tuple[L.LExpr, L.LExpr]] = {}
 
         # Set of counters used for assigning names to intermediate
         # variables
@@ -179,6 +289,11 @@ class IntegralGenerator:
         # Collect parts before, during, and after quadrature loops
         parts += all_preparts
         parts += all_quadparts
+
+        # Drop every unread scalar declaration now the kernel body is whole.
+        # Done on the LNode tree, before formatting, so it respects scopes
+        # and is shared by all backends.
+        parts = prune_dead_scalars(parts, scalar_declaration_names(parts))
 
         return L.StatementList(parts)
 
@@ -294,7 +409,11 @@ class IntegralGenerator:
         for fw in intermediates_fw:
             assert isinstance(fw, L.VariableDecl)
             output += [fw.symbol]
-            declarations += [L.VariableDecl(fw.symbol, 0)]
+            # No initialiser: it's unconditionally assigned below, so one
+            # would be a dead store. Declared here rather than at that
+            # assignment because fw must stay visible to the "Tensor
+            # Computation" section that follows, outside this block's scope.
+            declarations += [L.VariableDecl(fw.symbol)]
             intermediates_0 += [L.Assign(fw.symbol, fw.value)]
         intermediates = [L.Section("Intermediates", intermediates_0, declarations, inputs, output)]
 
@@ -304,7 +423,123 @@ class IntegralGenerator:
         code = definitions + intermediates + tensor_comp
         code = optimize(code, quadrature_rule)
 
+        split = self._split_quadrature_loop(code, iq, intermediates_fw, quadrature_rule)
+        if split is not None:
+            return split
+
         return [L.create_nested_for_loops([iq], code)]
+
+    def _split_quadrature_loop(
+        self,
+        code: list[L.LNode],
+        iq: L.MultiIndex,
+        intermediates_fw: list[L.VariableDecl],
+        quadrature_rule: QuadratureRule,
+    ):
+        """Split the quadrature loop into evaluation and contraction loops.
+
+        The fused loop interleaves evaluation of the varying quantities
+        (which carries any math functions of the spatial coordinate) with
+        the tensor contraction, whose strided table reads stop the compiler
+        vectorising the loop -- leaving calls to `sin` and friends scalar.
+        Caching the `fw` values and contracting in a second loop leaves the
+        evaluation loop free of those reads, so it vectorises onto the SIMD
+        math library.
+
+        The `fw` cache is tiled, not sized to the full point count: a form
+        with many `fw` values and a large rule could otherwise put megabytes
+        on the stack. Tiling bounds stack use to a fixed budget and keeps
+        each tile resident in L1d across both passes.
+
+        Returns `None` if the split does not apply, in which case the
+        caller emits a single fused loop.
+        """
+        if quadrature_rule is None or not intermediates_fw:
+            return None
+
+        # Only single-index (non tensor-product) rules for now
+        if quadrature_rule.has_tensor_factors or iq.dim != 1:
+            return None
+
+        evaluation = [c for c in code if getattr(c, "name", None) != "Tensor Computation"]
+        contraction = [c for c in code if getattr(c, "name", None) == "Tensor Computation"]
+        if not contraction or not evaluation:
+            return None
+
+        # The split only pays for itself when there's a transcendental math
+        # call to vectorise -- most integrands (mass matrices, plain
+        # Poisson, etc.) have none, and for those it's a net loss.
+        if not _contains_vectorizable_mathfunction(evaluation):
+            return None
+        # On x86-64 Linux the evaluation loop can call libmvec. Elsewhere,
+        # only split when the contraction is expensive enough to amortise
+        # the fw cache without that benefit.
+        if not _supports_vector_math_loop_split() and (
+            _contraction_work(contraction) < _UNSUPPORTED_VECTOR_MATH_MIN_CONTRACTION_WORK
+        ):
+            return None
+
+        num_points = quadrature_rule.weights.size
+        index = iq.local_index(0)
+
+        # Budget the whole fw cache at 32 KiB, comfortably inside a typical
+        # L1d, using a conservative 16 bytes/scalar (covers complex128).
+        n_fw = len(intermediates_fw)
+        tile = _fw_cache_tile_size(n_fw, num_points)
+        if tile is None:
+            return None
+
+        caches = {
+            fw.symbol.name: L.Symbol(f"{fw.symbol.name}_q", fw.symbol.dtype)
+            for fw in intermediates_fw
+        }
+        declarations: list[L.LNode] = [L.ArrayDecl(cache, sizes=tile) for cache in caches.values()]
+
+        if tile >= num_points:
+            # Whole rule fits in one tile: no need for an outer tiling loop.
+            store = [
+                L.Assign(L.ArrayAccess(caches[fw.symbol.name], [index]), fw.symbol)
+                for fw in intermediates_fw
+            ]
+            load = [
+                L.VariableDecl(fw.symbol, L.ArrayAccess(caches[fw.symbol.name], [index]))
+                for fw in intermediates_fw
+            ]
+            return declarations + [
+                L.create_nested_for_loops([iq], evaluation + store),
+                L.create_nested_for_loops([iq], load + contraction),
+            ]
+
+        num_tiles = -(-num_points // tile)  # ceil division
+        tile_index = L.Symbol(f"{index.name}_tile", L.DataType.INT)
+        tile_base = L.Symbol(f"{index.name}_base", L.DataType.INT)
+        tile_end = L.Symbol(f"{index.name}_end", L.DataType.INT)
+        local_offset = L.Sub(index, tile_base)
+
+        tile_end_expr = L.Conditional(
+            L.LT(L.Add(tile_base, L.LiteralInt(tile)), L.LiteralInt(num_points)),
+            L.Add(tile_base, L.LiteralInt(tile)),
+            L.LiteralInt(num_points),
+        )
+        setup: list[L.LNode] = [
+            L.VariableDecl(tile_base, L.Mul(tile_index, L.LiteralInt(tile))),
+            L.VariableDecl(tile_end, tile_end_expr),
+        ]
+
+        store = [
+            L.Assign(L.ArrayAccess(caches[fw.symbol.name], [local_offset]), fw.symbol)
+            for fw in intermediates_fw
+        ]
+        load = [
+            L.VariableDecl(fw.symbol, L.ArrayAccess(caches[fw.symbol.name], [local_offset]))
+            for fw in intermediates_fw
+        ]
+
+        tile_body = setup + [
+            L.ForRange(index, tile_base, tile_end, evaluation + store),
+            L.ForRange(index, tile_base, tile_end, load + contraction),
+        ]
+        return declarations + [L.ForRange(tile_index, 0, num_tiles, tile_body)]
 
     def generate_piecewise_partition(self, quadrature_rule, domain: basix.CellType):
         """Generate a piecewise partition."""
@@ -365,6 +600,30 @@ class IntegralGenerator:
 
         # Optimize definitions
         definitions = optimize(definitions, quadrature_rule)
+
+        # Fold scalar chains that round-trip through exact powers of two
+        # (e.g. a symmetric gradient's 1/2 undoing an earlier *2) into a
+        # plain alias. Must run before reciprocal-CSE, which would otherwise
+        # hide the power-of-two divisors this looks for behind a symbol.
+        intermediates = power_of_two_cse_statements(intermediates)
+
+        # Collapse repeated divisions by the same divisor (e.g. an affine
+        # cell's pseudo-inverse Jacobian dividing every entry by the same
+        # determinant) into one reciprocal and a multiply each.
+        intermediates = reciprocal_cse_statements(intermediates, name_prefix=f"recip_{symbol.name}")
+
+        # Record each piecewise two-factor product so generate_block_parts
+        # can fuse a shared factor across block entries with the quadrature
+        # weight once (see _piecewise_mul_operands). Read after the CSE
+        # passes so a reciprocal-CSE-rewritten division counts too.
+        if mode == "piecewise":
+            for stmt in intermediates:
+                if isinstance(stmt, L.VariableDecl) and isinstance(stmt.value, L.Mul):
+                    self._piecewise_mul_operands[stmt.symbol.name] = (
+                        stmt.value.lhs,
+                        stmt.value.rhs,
+                    )
+
         return definitions, intermediates
 
     def generate_dofblock_partition(
@@ -473,6 +732,68 @@ class IntegralGenerator:
 
         A_shape = self.ir.expression.tensor_shape
 
+        # Detect block entries whose piecewise values share one common
+        # factor (e.g. several metric-tensor entries scaled by the same
+        # |det J|). Multiplying that factor into the quadrature weight once,
+        # rather than into every already-scaled entry, is cheaper whenever
+        # there are more sharing entries than quadrature points. This is a
+        # genuine re-association GCC can't perform itself without
+        # -ffast-math, since it changes rounding.
+        #
+        # Skip it when every argument table in this block is itself
+        # quadrature-point-independent (piecewise_ttypes) and there is more
+        # than one quadrature point: the per-entry values are then fully
+        # loop-invariant, and GCC/clang hoist the unfused multiply-by-weight
+        # out of the loop entirely -- an indirection this fusion adds (a
+        # shared factor computed fresh each iteration) can stop the compiler
+        # seeing that the whole loop is redundant, costing far more than the
+        # fusion saves (see PR #865's hyperelasticity_residual_p1 finding).
+        # With a single quadrature point there's no loop to hoist away, so
+        # the fusion's reduced op count is a clean win regardless.
+        fused_factor: dict[int, tuple[L.LExpr, L.LExpr]] = {}
+        if (
+            quadrature_rule is not None
+            and self.ir.expression.integral_type not in ufl.custom_integral_types
+            and len(blocklist) > quadrature_rule.weights.size
+            and (
+                quadrature_rule.weights.size == 1
+                or any(
+                    ttype not in piecewise_ttypes
+                    for blockdata in blocklist
+                    for ttype in blockdata.ttypes
+                )
+            )
+        ):
+            F = self.ir.expression.integrand[(domain, quadrature_rule)]["factorization"]
+            factor_indices = []
+            decomps: list[tuple[L.LExpr, L.LExpr]] = []
+            for blockdata in blocklist:
+                if len(blockdata.factor_indices_comp_indices) > 1:
+                    decomps = []
+                    break
+                factor_index = blockdata.factor_indices_comp_indices[0][0]
+                v = F.nodes[factor_index]["expression"]
+                f = self.get_var(quadrature_rule, domain, v)
+                decomp = (
+                    self._piecewise_mul_operands.get(f.name) if isinstance(f, L.Symbol) else None
+                )
+                if decomp is None:
+                    decomps = []
+                    break
+                factor_indices.append(factor_index)
+                decomps.append(decomp)
+
+            if decomps:
+                rhs_keys = {expr_key(d[1]) for d in decomps}
+                lhs_keys = {expr_key(d[0]) for d in decomps}
+                shared, bases = None, None
+                if len(rhs_keys) == 1:
+                    shared, bases = decomps[0][1], [d[0] for d in decomps]
+                elif len(lhs_keys) == 1:
+                    shared, bases = decomps[0][0], [d[1] for d in decomps]
+                if shared is not None and bases is not None:
+                    fused_factor = dict(zip(factor_indices, zip(bases, [shared] * len(bases))))
+
         for blockdata in blocklist:
             B_indices = []
             for i in range(block_rank):
@@ -510,6 +831,14 @@ class IntegralGenerator:
             else:
                 weights = self.backend.symbols.weights_table(quadrature_rule)
                 weight = weights[iq.global_index]
+
+            if factor_index in fused_factor:
+                base, shared = fused_factor[factor_index]
+                scale_key = (quadrature_rule, expr_key(shared))
+                combined, defined = self.get_temp_symbol("fwscale", scale_key)
+                if not defined:
+                    intermediates += [L.VariableDecl(combined, L.float_product([shared, weight]))]
+                f, weight = base, combined
 
             # Define fw = f * weight
             fw_rhs = L.float_product([f, weight])
@@ -573,9 +902,13 @@ class IntegralGenerator:
             for expression in keep[indices]:
                 body.append(L.AssignAdd(A[multi_index], expression))
 
-        # reverse B_indices
-        B_indices = B_indices[::-1]
-        body = [L.create_nested_for_loops(B_indices, body)]
+        # Nest with the last tensor index innermost when an entry sums more
+        # than one term (e.g. gradient-gradient) -- GCC's vectoriser wants
+        # this. A single-term entry (e.g. a plain mass matrix) prefers the
+        # opposite, row-innermost order instead.
+        multi_term = any(len(v) > 1 for v in keep.values())
+        nest_indices = B_indices if multi_term else B_indices[::-1]
+        body = [L.create_nested_for_loops(nest_indices, body)]
         input = [*vars, *tables]
         output = [A]
 

--- a/ffcx/codegeneration/lnodes.py
+++ b/ffcx/codegeneration/lnodes.py
@@ -1075,6 +1075,34 @@ def _math_function(op, *args):
     return MathFunction(name, args)
 
 
+# Small integer exponents a power is expanded into multiplications for,
+# rather than emitted as a pow() call -- see _power.
+_POWER_EXPAND_RANGE = range(-2, 5)
+
+
+def _power(op, base, exponent):
+    """Get a power expression, expanding small integer exponents.
+
+    ``pow(x, n)`` is a libm call GCC only folds into multiplications for
+    some exponents and dtypes, so for a literal integer exponent in a small
+    range this emits the multiplications directly: ``x*x``, ``x*x*x``,
+    ``1.0/x``, ``1.0/(x*x)``. It also avoids a stray ``pow()`` call
+    triggering the quadrature-loop SIMD split (see
+    ``integral_generator.py``) for a form whose only "math function" is a
+    small integer power, e.g. ``x**2`` from a squared norm. Any other
+    exponent falls back to a plain ``pow()`` call.
+    """
+    if isinstance(exponent, LiteralInt) and exponent.value in _POWER_EXPAND_RANGE:
+        n = exponent.value
+        if n == 0:
+            return LiteralFloat(1.0)
+        result = base
+        for _ in range(abs(n) - 1):
+            result = result * base
+        return result if n > 0 else LiteralFloat(1.0) / result
+    return _math_function(op, base, exponent)
+
+
 # Lookup table for handler to call when the ufl_to_lnodes method (below) is
 # called, depending on the first argument type.
 _ufl_call_lookup = {
@@ -1086,7 +1114,7 @@ _ufl_call_lookup = {
     ufl.algebra.Sum: lambda x, a, b: a + b,
     ufl.algebra.Division: lambda x, a, b: a / b,
     ufl.algebra.Abs: _math_function,
-    ufl.algebra.Power: _math_function,
+    ufl.algebra.Power: _power,
     ufl.algebra.Real: _math_function,
     ufl.algebra.Imag: _math_function,
     ufl.algebra.Conj: _math_function,

--- a/ffcx/codegeneration/numba/formatter.py
+++ b/ffcx/codegeneration/numba/formatter.py
@@ -118,7 +118,9 @@ class Formatter(FormatterInterface):
     def _(self, v: L.VariableDecl) -> str:
         """Format a variable declaration."""
         sym = self(v.symbol)
-        val = self(v.value)
+        # Python has no bare "declare without a value" statement, unlike C,
+        # so a value-less VariableDecl still needs one here.
+        val = self(v.value) if v.value is not None else "0"
         return f"{sym} = {val}\n"
 
     @__call__.register

--- a/ffcx/codegeneration/optimizer.py
+++ b/ffcx/codegeneration/optimizer.py
@@ -1,9 +1,24 @@
 """Optimizer."""
 
+import math
 from collections import defaultdict
 
 import ffcx.codegeneration.lnodes as L
 from ffcx.ir.representationutils import QuadratureRule
+
+
+def _pow2_exponent(node: L.LExpr) -> int | None:
+    """Return e such that node == 2**e, if node is an exact literal power of two."""
+    if isinstance(node, (L.LiteralFloat, L.LiteralInt)):
+        if isinstance(node.value, complex):
+            return None
+        value = float(node.value)
+        if value <= 0.0:
+            return None
+        mantissa, exponent = math.frexp(value)
+        if mantissa == 0.5:
+            return exponent - 1
+    return None
 
 
 def optimize(code: list[L.LNode], quadrature_rule: QuadratureRule) -> list[L.LNode]:
@@ -21,6 +36,8 @@ def optimize(code: list[L.LNode], quadrature_rule: QuadratureRule) -> list[L.LNo
     code = fuse_sections(code, "Jacobian")
     for i, section in enumerate(code):
         if isinstance(section, L.Section):
+            if section.name == "Jacobian":
+                section = reciprocal_cse(section)
             if L.Annotation.fuse in section.annotations:
                 section = fuse_loops(section)
             if L.Annotation.licm in section.annotations:
@@ -28,6 +45,303 @@ def optimize(code: list[L.LNode], quadrature_rule: QuadratureRule) -> list[L.LNo
             code[i] = section
 
     return code
+
+
+def reciprocal_cse_statements(
+    statements: list[L.LNode], name_prefix: str = "recip"
+) -> list[L.LNode]:
+    """Replace repeated divisions by the same divisor with one reciprocal and multiplies.
+
+    N divisions by the same value cost more than one reciprocal plus N
+    multiplications, since division is markedly more expensive than
+    multiplication on typical hardware. This is the same reassociation
+    `-ffast-math`/`-freciprocal-math` would apply automatically, done
+    unconditionally here: `a * (1.0 / b)` is not in general bit-identical to
+    `a / b` (two roundings instead of one) unless `b` is an exact power of
+    two, but the difference is at the ULP level, negligible next to
+    quadrature/discretisation error.
+
+    Args:
+        statements: A flat list of statements (no nested loops expected --
+            this targets piecewise/varying scalar partitions, not quadrature
+            loop bodies).
+        name_prefix: Prefix for the generated reciprocal symbols, kept distinct
+            per call site so two calls in the same kernel can't clash.
+
+    Returns:
+        A new statement list with repeated divisions rewritten.
+    """
+    # Keyed by the divisor's structural identity (`expr_key`), not the LExpr
+    # itself: a literal divisor is a `LiteralFloat`, which has no `__hash__`.
+    divisor_counts: dict[tuple, int] = defaultdict(int)
+    for stmt in statements:
+        if isinstance(stmt, L.VariableDecl) and isinstance(stmt.value, L.Div):
+            divisor_counts[expr_key(stmt.value.rhs)] += 1
+
+    recip_symbols: dict[tuple, L.Symbol] = {}
+    counter = 0
+    new_statements: list[L.LNode] = []
+    for stmt in statements:
+        if (
+            isinstance(stmt, L.VariableDecl)
+            and isinstance(stmt.value, L.Div)
+            and divisor_counts[expr_key(stmt.value.rhs)] >= 2
+        ):
+            divisor = stmt.value.rhs
+            divisor_key = expr_key(divisor)
+            if divisor_key not in recip_symbols:
+                recip_symbol = L.Symbol(f"{name_prefix}_{counter}", L.DataType.SCALAR)
+                counter += 1
+                recip_symbols[divisor_key] = recip_symbol
+                new_statements.append(
+                    L.VariableDecl(recip_symbol, L.Div(L.LiteralFloat(1.0), divisor))
+                )
+            recip_symbol = recip_symbols[divisor_key]
+            new_statements.append(L.VariableDecl(stmt.symbol, L.Mul(stmt.value.lhs, recip_symbol)))
+        else:
+            new_statements.append(stmt)
+
+    return new_statements
+
+
+def reciprocal_cse(section: L.Section) -> L.Section:
+    """Apply :func:`reciprocal_cse_statements` to a Section's statements in place."""
+    section.statements = reciprocal_cse_statements(section.statements)
+    return section
+
+
+def _referenced_symbol_names(expr: L.LExpr, out: set[str]) -> None:
+    """Collect the names of every Symbol referenced within an expression tree."""
+    if isinstance(expr, L.Symbol):
+        out.add(expr.name)
+    elif isinstance(expr, L.ArrayAccess):
+        out.add(expr.array.name)
+        for i in expr.indices:
+            _referenced_symbol_names(i, out)
+    elif isinstance(expr, L.Conditional):
+        _referenced_symbol_names(expr.condition, out)
+        _referenced_symbol_names(expr.true, out)
+        _referenced_symbol_names(expr.false, out)
+    elif isinstance(expr, L.BinOp):
+        _referenced_symbol_names(expr.lhs, out)
+        _referenced_symbol_names(expr.rhs, out)
+    elif isinstance(expr, L.PrefixUnaryOp):
+        _referenced_symbol_names(expr.arg, out)
+    elif isinstance(expr, (L.NaryOp, L.MathFunction)):
+        for a in expr.args:
+            _referenced_symbol_names(a, out)
+
+
+def power_of_two_cse_statements(
+    statements: list[L.LNode], speculative_out: set[str] | None = None
+) -> list[L.LNode]:
+    """Fold scalar chains that round-trip through exact powers of two.
+
+    UFL's expansion of e.g. a symmetric gradient introduces factors of 2 and
+    1/2 from different places (Voigt-style off-diagonal terms, a doubled
+    derivative later halved, etc.), so ordinary CSE doesn't recognise them
+    as equal -- even though multiplying/dividing by an exact power of two
+    never rounds in IEEE-754: ``(x + x) * 0.5`` is bit-identical to ``x``.
+    This walks a flat statement list tracking, for each declared scalar, the
+    (base symbol, power-of-two exponent) pair its value equals, and replaces
+    a statement whose value is already known under a different name with a
+    reference to that name.
+
+    Rerouting a statement back to `base` (or an earlier scaled symbol) can
+    leave the statement it depended on with no remaining reader -- dead
+    code, which GCC rejects under ``-Werror=unused-variable``. Whether
+    that's true can depend on code outside this statement list, so this
+    function doesn't decide it: symbols kept only speculatively are recorded
+    into `speculative_out` for the caller to check against the fully
+    assembled kernel body, via :func:`prune_dead_scalars`.
+
+    Args:
+        statements: A flat list of statements (piecewise/varying partition,
+            no nested loops).
+        speculative_out: If given, updated with the names of symbols kept
+            only speculatively by this call.
+
+    Returns:
+        A new statement list with round-trip duplicates folded to aliases.
+    """
+    if speculative_out is None:
+        speculative_out = set()
+    # symbol name -> (base symbol, exponent) with value == base * 2**exponent
+    canonical: dict[str, tuple[L.Symbol, int]] = {}
+    # (base symbol name, exponent) -> symbol already known to hold that value
+    seen: dict[tuple[str, int], L.Symbol] = {}
+
+    def resolve(node: L.LExpr) -> tuple[L.Symbol, int] | None:
+        """Look up a symbol's tracked (base, exponent), if any."""
+        if isinstance(node, L.Symbol) and node.name in canonical:
+            return canonical[node.name]
+        return None
+
+    new_statements: list[L.LNode] = []
+    for stmt in statements:
+        if not isinstance(stmt, L.VariableDecl):
+            new_statements.append(stmt)
+            continue
+
+        value = stmt.value
+        result: tuple[L.Symbol, int] | None = None
+
+        if isinstance(value, L.Add) and value.lhs == value.rhs:
+            operand = resolve(value.lhs)
+            if operand is not None:
+                base, exponent = operand
+                result = (base, exponent + 1)
+        elif isinstance(value, L.Mul):
+            for factor, other in ((value.lhs, value.rhs), (value.rhs, value.lhs)):
+                exponent_shift = _pow2_exponent(other)
+                operand = resolve(factor)
+                if exponent_shift is not None and operand is not None:
+                    base, exponent = operand
+                    result = (base, exponent + exponent_shift)
+                    break
+        elif isinstance(value, L.Div):
+            exponent_shift = _pow2_exponent(value.rhs)
+            operand = resolve(value.lhs)
+            if exponent_shift is not None and operand is not None:
+                base, exponent = operand
+                result = (base, exponent - exponent_shift)
+
+        if result is not None:
+            base, exponent = result
+            canonical[stmt.symbol.name] = (base, exponent)
+            key = (base.name, exponent)
+            if exponent == 0:
+                # Exactly equal to `base` itself: a pure alias.
+                new_statements.append(L.VariableDecl(stmt.symbol, base))
+                continue
+            elif key in seen:
+                # Exactly equal to some earlier scaled symbol: also an alias.
+                new_statements.append(L.VariableDecl(stmt.symbol, seen[key]))
+                continue
+            else:
+                seen[key] = stmt.symbol
+                speculative_out.add(stmt.symbol.name)
+        else:
+            # Opaque: this symbol is its own base, unrelated to anything earlier.
+            canonical[stmt.symbol.name] = (stmt.symbol, 0)
+            seen.setdefault((stmt.symbol.name, 0), stmt.symbol)
+
+        new_statements.append(stmt)
+
+    return new_statements
+
+
+def _collect_referenced_names(node, out: set[str]) -> None:
+    """Recursively collect every symbol name read anywhere in a code tree."""
+    if isinstance(node, list):
+        for n in node:
+            _collect_referenced_names(n, out)
+    elif isinstance(node, L.VariableDecl):
+        if node.value is not None:
+            _referenced_symbol_names(node.value, out)
+    elif isinstance(node, L.ArrayDecl):
+        pass
+    elif isinstance(node, L.Section):
+        for declaration in node.declarations:
+            if isinstance(declaration, L.VariableDecl) and declaration.value is not None:
+                _referenced_symbol_names(declaration.value, out)
+        _collect_referenced_names(node.statements, out)
+    elif isinstance(node, L.StatementList):
+        _collect_referenced_names(node.statements, out)
+    elif isinstance(node, L.ForRange):
+        _referenced_symbol_names(node.begin, out)
+        _referenced_symbol_names(node.end, out)
+        _collect_referenced_names(node.body, out)
+    elif isinstance(node, L.Comment):
+        pass
+    elif isinstance(node, L.Statement):
+        _referenced_symbol_names(node.expr, out)
+
+
+def _drop_unreferenced(node, dead: set[str]):
+    """Recursively rebuild a code tree, dropping VariableDecls named in `dead`."""
+    if isinstance(node, list):
+        return [
+            _drop_unreferenced(n, dead)
+            for n in node
+            if not (isinstance(n, L.VariableDecl) and n.symbol.name in dead)
+        ]
+    if isinstance(node, L.Section):
+        node.declarations = [
+            declaration
+            for declaration in node.declarations
+            if not (isinstance(declaration, L.VariableDecl) and declaration.symbol.name in dead)
+        ]
+        node.output = [symbol for symbol in node.output if symbol.name not in dead]
+        node.statements = _drop_unreferenced(node.statements, dead)
+    elif isinstance(node, L.StatementList):
+        node.statements = _drop_unreferenced(node.statements, dead)
+    elif isinstance(node, L.ForRange):
+        # Mutate the existing StatementList's statements in place rather
+        # than wrapping the result in a new one: `body` may itself be a
+        # single-element list holding one multi-statement StatementList,
+        # and re-wrapping that a second time is a shape `as_statement`
+        # cannot unwrap again.
+        node.body.statements = _drop_unreferenced(node.body.statements, dead)
+    return node
+
+
+def scalar_declaration_names(code: list[L.LNode]) -> set[str]:
+    """Return the names of every scalar declaration in a code tree.
+
+    Generated scalar declarations are pure computations, so an unread one can
+    be removed safely. Keeping this analysis on LNodes, rather than parsing
+    formatted C, preserves lexical structure and works for every backend.
+    """
+    names: set[str] = set()
+
+    def visit(node) -> None:
+        if isinstance(node, list):
+            for child in node:
+                visit(child)
+        elif isinstance(node, L.VariableDecl):
+            names.add(node.symbol.name)
+        elif isinstance(node, L.Section):
+            visit(node.declarations)
+            visit(node.statements)
+        elif isinstance(node, L.StatementList):
+            visit(node.statements)
+        elif isinstance(node, L.ForRange):
+            visit(node.body)
+
+    visit(code)
+    return names
+
+
+def prune_dead_scalars(code: list[L.LNode], candidates: set[str]) -> list[L.LNode]:
+    """Remove scalar declarations in `candidates` that end up with no reader.
+
+    :func:`power_of_two_cse_statements` can reroute a statement past an
+    earlier one it depended on, leaving that one dead -- code GCC rejects
+    under ``-Werror=unused-variable``. Call this once the whole kernel body
+    is assembled, so a declaration read only by code outside its own
+    partition (e.g. the tensor contraction) is still recognised as live.
+
+    Args:
+        code: The complete generated kernel body.
+        candidates: Names that are safe to drop if nothing reads them --
+            i.e. ones `power_of_two_cse_statements` itself introduced
+            speculatively, never anything the caller didn't flag as such.
+
+    Returns:
+        `code`, with any now-dead candidate declarations removed. `code`'s
+        Sections/ForRanges are mutated in place; the returned list is a new
+        top-level list.
+    """
+    candidates = set(candidates)
+    while True:
+        referenced: set[str] = set()
+        _collect_referenced_names(code, referenced)
+        dead = candidates - referenced
+        if not dead:
+            return code
+        code = _drop_unreferenced(code, dead)
+        candidates -= dead
 
 
 def fuse_sections(code: list[L.LNode], name: str) -> list[L.LNode]:
@@ -141,6 +455,34 @@ def check_dependency(statement: L.Statement, index: L.Symbol) -> bool:
     return False
 
 
+def expr_key(expr) -> tuple:
+    """Hashable identity of an expression, used to recognise equal factors.
+
+    LNodes expressions are not generally hashable, so build a structural key
+    that compares equal exactly when two expressions are the same expression.
+
+    Args:
+        expr: Expression to key.
+
+    Returns:
+        Hashable structural key.
+    """
+    if isinstance(expr, L.ArrayAccess):
+        return ("array", expr.array.name, *(expr_key(i) for i in expr.indices))
+    elif isinstance(expr, L.Symbol):
+        return ("symbol", expr.name)
+    elif isinstance(expr, L.LiteralFloat | L.LiteralInt):
+        return ("literal", expr.value)
+    elif isinstance(expr, L.PrefixUnaryOp):
+        # PrefixUnaryOp (Neg, Not) has no __repr__ override, so it would
+        # otherwise fall through to the identity-based default below.
+        return (type(expr).__name__, expr_key(expr.arg))
+    args = getattr(expr, "args", None)
+    if args is not None:
+        return (type(expr).__name__, *(expr_key(a) for a in args))
+    return (type(expr).__name__, repr(expr))
+
+
 def licm(section: L.Section, quadrature_rule: QuadratureRule) -> L.Section:
     """Perform loop invariant code motion.
 
@@ -178,32 +520,69 @@ def licm(section: L.Section, quadrature_rule: QuadratureRule) -> L.Section:
             expressions[lhs].append(rhs)
 
     pre_loop: list[L.LNode] = []
+    inner_body: list[L.LNode] = []
+    size = outer_loop.end.value - outer_loop.begin.value
+    # Every hoisted temp's assignment is collected here and emitted as one
+    # shared loop below, rather than one ForRange per temp -- many small
+    # loops back to back give the vectoriser nothing to work with.
+    hoist_loop_body: list[L.LNode] = []
+    # Structural key of an already-hoisted expression -> its temp symbol, so
+    # identical hoisted expressions (e.g. vector Poisson's diagonal blocks)
+    # are computed once instead of once per block entry.
+    seen_hoisted: dict[tuple, L.Symbol] = {}
     for lhs, rhs in expressions.items():
+        # Group terms by the factors that stay in the inner loop: terms
+        # sharing them differ only in what's hoisted, so one temporary can
+        # hold their sum and the entry needs a single update.
+        groups: dict[tuple, tuple[list, list]] = {}
+        terms: list[L.LExpr] = []
         for r in rhs:
             hoist_candidates = []
+            keep = []
             for arg in r.args:
-                dependency = check_dependency(arg, inner_loop.index)
-                if not dependency:
+                if check_dependency(arg, inner_loop.index):
+                    keep.append(arg)
+                else:
                     hoist_candidates.append(arg)
             if len(hoist_candidates) > 1:
-                # create new temp
+                key = tuple(expr_key(k) for k in keep)
+                groups.setdefault(key, (keep, []))[1].append(L.Product(hoist_candidates))
+            else:
+                # Nothing worth hoisting, keep the term unchanged
+                terms.append(r)
+
+        for keep, hoisted in groups.values():
+            rhs_hoisted = hoisted[0] if len(hoisted) == 1 else L.Sum(hoisted)
+            hoisted_key = expr_key(rhs_hoisted)
+            temp = seen_hoisted.get(hoisted_key)
+            if temp is None:
+                # Create new temp holding the sum of the hoisted terms
                 name = f"temp_{counter}"
                 counter += 1
                 temp = L.Symbol(name, L.DataType.SCALAR)
-                for h in hoist_candidates:
-                    r.args.remove(h)
-                # update expression with new temp
-                r.args.append(L.ArrayAccess(temp, [outer_loop.index]))
-                # create code for hoisted term
-                size = outer_loop.end.value - outer_loop.begin.value
-                pre_loop.append(L.ArrayDecl(temp, size, [0]))
-                body = L.Assign(
-                    L.ArrayAccess(temp, [outer_loop.index]), L.Product(hoist_candidates)
+                # No initialiser: every entry is written unconditionally by
+                # the loop just below (a plain Assign, not AssignAdd), so a
+                # zero-fill here would be a pure dead store.
+                pre_loop.append(L.ArrayDecl(temp, size))
+                hoist_loop_body.append(
+                    L.Assign(L.ArrayAccess(temp, [outer_loop.index]), rhs_hoisted)
                 )
-                pre_loop.append(
-                    L.ForRange(outer_loop.index, outer_loop.begin, outer_loop.end, [body])
-                )
+                seen_hoisted[hoisted_key] = temp
+            access = L.ArrayAccess(temp, [outer_loop.index])
+            terms.append(L.Product([*keep, access]))
 
-    section.statements = pre_loop + section.statements
+        # One read-modify-write of the entry instead of one per term
+        if terms:
+            inner_body.append(L.AssignAdd(lhs, terms[0] if len(terms) == 1 else L.Sum(terms)))
+
+    if hoist_loop_body:
+        pre_loop.append(
+            L.ForRange(outer_loop.index, outer_loop.begin, outer_loop.end, hoist_loop_body)
+        )
+
+    # Rebuild the loop nest around the regrouped body
+    new_inner = L.ForRange(inner_loop.index, inner_loop.begin, inner_loop.end, inner_body)
+    new_outer = L.ForRange(outer_loop.index, outer_loop.begin, outer_loop.end, [new_inner])
+    section.statements = pre_loop + [new_outer] + section.statements[1:]
 
     return section

--- a/test/test_codegen_heuristics.py
+++ b/test/test_codegen_heuristics.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2026 Garth N. Wells
+#
+# This file is part of FFCx. (https://www.fenicsproject.org)
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+"""Tests for code-generation size and storage heuristics."""
+
+import basix.ufl
+import pytest
+import ufl
+
+import ffcx.codegeneration.integral_generator as integral_generator
+import ffcx.codegeneration.jit
+import ffcx.codegeneration.lnodes as L
+from ffcx.codegeneration.definitions import _should_unroll_coordinate_dofs
+from ffcx.codegeneration.integral_generator import (
+    _UNSUPPORTED_VECTOR_MATH_MIN_CONTRACTION_WORK,
+    _contains_vectorizable_mathfunction,
+    _contraction_work,
+    _fw_cache_tile_size,
+    _supports_vector_math_loop_split,
+)
+from ffcx.codegeneration.optimizer import prune_dead_scalars, scalar_declaration_names
+
+
+def test_coordinate_dof_unrolling_is_limited_to_small_non_tensor_geometry():
+    """Curved simplex geometry must not be expanded into an unbounded sum."""
+    assert _should_unroll_coordinate_dofs(10, False)
+    assert not _should_unroll_coordinate_dofs(17, False)
+    assert not _should_unroll_coordinate_dofs(4, True)
+
+
+@pytest.mark.parametrize(
+    "n_fw, num_points, expected",
+    [
+        (1, 10000, 2048),
+        (256, 10000, 8),
+        (257, 10000, 7),
+        (2048, 10000, 1),
+        (2049, 10000, None),
+        (1000, 4, 2),
+    ],
+)
+def test_fw_cache_tiles_do_not_exceed_the_stack_budget(n_fw, num_points, expected):
+    """The cache must remain bounded even with many fw intermediates."""
+    tile = _fw_cache_tile_size(n_fw, num_points)
+    assert tile == expected
+    if tile is not None:
+        assert n_fw * tile * 16 <= 32768
+
+
+def test_split_only_targets_supported_vector_math_hosts(monkeypatch):
+    """The cache split is disabled where the compiler cannot use libmvec."""
+    sin = L.MathFunction("sin", [L.Symbol("x", L.DataType.SCALAR)])
+    power = L.MathFunction("power", [L.Symbol("x", L.DataType.SCALAR), L.LiteralInt(7)])
+    assert _contains_vectorizable_mathfunction(sin)
+    assert not _contains_vectorizable_mathfunction(power)
+
+    monkeypatch.setattr(integral_generator.sys, "platform", "darwin")
+    assert not _supports_vector_math_loop_split()
+    monkeypatch.setattr(integral_generator.sys, "platform", "linux")
+    monkeypatch.setattr(integral_generator.platform, "machine", lambda: "x86_64")
+    assert _supports_vector_math_loop_split()
+
+
+def test_contraction_work_distinguishes_small_and_large_contractions():
+    """Unsupported targets split only when enough contraction work remains."""
+    index = L.Symbol("i", L.DataType.INT)
+    output = L.Symbol("output", L.DataType.SCALAR)
+    small = L.ForRange(index, 0, 10, [L.Assign(output, 1.0) for _ in range(12)])
+    large = L.ForRange(index, 0, 10, [L.Assign(output, 1.0) for _ in range(26)])
+    assert _contraction_work(small) == 120
+    assert _contraction_work(large) == 260
+    assert _contraction_work(small) < _UNSUPPORTED_VECTOR_MATH_MIN_CONTRACTION_WORK
+    assert _contraction_work(large) >= _UNSUPPORTED_VECTOR_MATH_MIN_CONTRACTION_WORK
+
+
+def test_curved_simplex_geometry_uses_a_coordinate_dof_loop(compile_args):
+    """A high-order simplex must not become one enormous coordinate sum."""
+    coordinate_element = basix.ufl.element("Lagrange", "triangle", 5, shape=(2,))
+    domain = ufl.Mesh(coordinate_element)
+    element = basix.ufl.element("Lagrange", "triangle", 1)
+    space = ufl.FunctionSpace(domain, element)
+    test = ufl.TestFunction(space)
+    x = ufl.SpatialCoordinate(domain)
+    form = ufl.sin(x[0]) * test * ufl.dx(metadata={"quadrature_degree": 6})
+
+    _, _, (_, implementation) = ffcx.codegeneration.jit.compile_forms(
+        [form], options={"scalar_type": "float64"}, cffi_extra_compile_args=compile_args
+    )
+    assert "for (int ic = 0; ic < 21; ++ic)" in implementation
+
+
+def test_dead_scalar_pruning_respects_section_declarations():
+    """LNode liveness removes an unused declaration before C formatting."""
+    live = L.Symbol("live", L.DataType.SCALAR)
+    dead = L.Symbol("dead", L.DataType.SCALAR)
+    output = L.Symbol("output", L.DataType.SCALAR)
+    section = L.Section(
+        "test",
+        [L.Assign(output, live)],
+        [L.VariableDecl(live, 1.0), L.VariableDecl(dead, 2.0)],
+    )
+
+    pruned = prune_dead_scalars([section], scalar_declaration_names([section]))
+    assert [declaration.symbol.name for declaration in pruned[0].declarations] == ["live"]

--- a/test/test_lnodes.py
+++ b/test/test_lnodes.py
@@ -1,12 +1,69 @@
 import importlib
 
+import basix.ufl
 import numpy as np
 import pytest
+import ufl
 from cffi import FFI
 
+import ffcx.codegeneration.jit
 from ffcx.codegeneration import lnodes as L
 from ffcx.codegeneration.C import Formatter
 from ffcx.codegeneration.utils import dtype_to_c_type
+
+
+def _power_lnode(exponent):
+    """Translate ``base**exponent`` through ufl_to_lnodes, given a symbolic base.
+
+    Uses ufl.variable to stop UFL constant-folding the power away before it
+    reaches ufl_to_lnodes.
+    """
+    x = ufl.variable(ufl.constantvalue.FloatValue(3.0))
+    op = x**exponent
+    base = L.Symbol("x", L.DataType.SCALAR)
+    exponent_lnode = L.ufl_to_lnodes(op.ufl_operands[1])
+    return L.ufl_to_lnodes(op, base, exponent_lnode)
+
+
+@pytest.mark.parametrize(
+    "exponent,expected_type",
+    # Exponent 0 and 1 aren't tested: UFL itself constant-folds/simplifies
+    # x**0 and x**1 away before a Power node ever reaches ufl_to_lnodes.
+    [(2, L.Mul), (3, L.Mul), (-1, L.Div), (-2, L.Div)],
+)
+def test_power_expansion_small_integer_exponents(exponent, expected_type):
+    """Small integer powers expand to multiplications/a reciprocal, not pow()."""
+    result = _power_lnode(exponent)
+    assert isinstance(result, expected_type)
+    assert not isinstance(result, L.MathFunction)
+
+
+@pytest.mark.parametrize("exponent", [5, -5, 0.5])
+def test_power_expansion_falls_back_to_pow_outside_small_range(exponent):
+    """Exponents outside the small integer range still emit a pow() call."""
+    result = _power_lnode(exponent)
+    assert isinstance(result, L.MathFunction)
+    assert result.function == "power"
+
+
+def test_squared_coefficient_generates_no_pow_call(compile_args):
+    """A squared term in a form compiles without a pow() call in the generated code.
+
+    Also matters beyond the arithmetic: a stray pow() call can make the
+    vector-math split treat the kernel as containing a transcendental call,
+    despite there being no useful vectorised function to expose.
+    """
+    element = basix.ufl.element("Lagrange", "triangle", 2)
+    domain = ufl.Mesh(basix.ufl.element("Lagrange", "triangle", 1, shape=(2,)))
+    space = ufl.FunctionSpace(domain, element)
+    u = ufl.Coefficient(space)
+    v = ufl.TestFunction(space)
+    form = (u**2) * v * ufl.dx
+
+    _, _, (_, impl) = ffcx.codegeneration.jit.compile_forms(
+        [form], options={"scalar_type": "float64"}, cffi_extra_compile_args=compile_args
+    )
+    assert "pow(" not in impl
 
 
 @pytest.mark.parametrize("dtype", ("float32", "float64", "intc"))


### PR DESCRIPTION
Re-opens #865, which was reverted by #873 along with #858. Re-opened after https://github.com/FEniCS/dolfinx/pull/4457 fix.

Restores the original commit (2af4625b) unchanged, cherry-picked onto current `main`. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)